### PR TITLE
Fix v2.0.1 CI release gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "verify": "npm run verify:privacy && npm run typecheck && npm run test",
-    "verify:ci": "npm run verify:privacy && npm run typecheck && vitest run --exclude test/mcp-shutdown.test.ts && vitest run test/mcp-shutdown.test.ts",
+    "verify:ci": "npm run rg && npm run verify:privacy && npm run typecheck && vitest run --exclude test/mcp-shutdown.test.ts && vitest run test/mcp-shutdown.test.ts",
     "verify:privacy": "node scripts/verify-public-history.mjs",
     "hooks:install": "node scripts/install-git-hooks.mjs",
     "icon": "node scripts/make-icon.mjs",

--- a/scripts/verify-public-history.mjs
+++ b/scripts/verify-public-history.mjs
@@ -82,8 +82,13 @@ function checkHistory() {
   const commits = String(runGit(['rev-list', '--all']).stdout)
     .split(/\r?\n/)
     .filter(Boolean);
+  // pull_request jobs default to a GitHub-generated merge object that can never enter
+  // public history. Its identity belongs to GitHub's test ref, not to the proposed tree.
+  const syntheticPullRequestCommit =
+    process.env.GITHUB_EVENT_NAME === 'pull_request' ? process.env.GITHUB_SHA?.trim() : '';
 
   for (const commit of commits) {
+    if (syntheticPullRequestCommit && commit === syntheticPullRequestCommit) continue;
     const record = String(
       runGit(['show', '-s', '--format=%an%x00%ae%x00%cn%x00%ce%x00%B', commit]).stdout,
     );

--- a/src/main/session/store.ts
+++ b/src/main/session/store.ts
@@ -64,6 +64,8 @@ const MAX_LINE_BYTES = 512 * 1024;
 const MAX_LISTED_SESSIONS = 200;
 /** Bound for legacy/model-facing full-list scans. Identity and retention use the uncapped cached catalog. */
 const MAX_SCANNED_SESSIONS = 5_000;
+/** Keep the uncapped authoritative scan fast without opening thousands of files at once. */
+const ATTACHMENT_CATALOG_READ_CONCURRENCY = 32;
 
 let root = '';
 /**
@@ -1444,12 +1446,16 @@ async function ensureAttachmentCatalog(): Promise<AttachmentCatalog> {
         else throw error;
       }
       const catalog = newAttachmentCatalog();
-      for (const name of names) {
-        if (!/^[0-9a-z-]{8,64}$/i.test(name)) continue;
-        const live = open.get(name);
-        const snapshot = live ? null : await readDurableSnapshot(name).catch(() => null);
-        const summary = live?.summary ?? snapshot?.summary ?? null;
-        if (summary) indexSummary(catalog, summary);
+      const candidates = names.filter((name) => /^[0-9a-z-]{8,64}$/i.test(name));
+      for (let offset = 0; offset < candidates.length; offset += ATTACHMENT_CATALOG_READ_CONCURRENCY) {
+        const summaries = await Promise.all(
+          candidates.slice(offset, offset + ATTACHMENT_CATALOG_READ_CONCURRENCY).map(async (name) => {
+            const live = open.get(name);
+            const snapshot = live ? null : await readDurableSnapshot(name).catch(() => null);
+            return live?.summary ?? snapshot?.summary ?? null;
+          })
+        );
+        for (const summary of summaries) if (summary) indexSummary(catalog, summary);
       }
       catalog.orderedIds = [...catalog.summaries.values()]
         .sort(compareSummariesNewestFirst)

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -1919,7 +1919,7 @@ describe('through the MCP endpoint', () => {
             cmd: "Start-Sleep -Milliseconds 350; Write-Output 'held-call-done'",
             workdir: dir,
             shell,
-            yield_time_ms: 1_000
+            yield_time_ms: 10_000
           }
         }
       },

--- a/test/mcp-inflight.test.ts
+++ b/test/mcp-inflight.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, expect, it, vi } from 'vitest';
 import { defaultConfig, initConfigPath, saveConfig } from '../src/main/config.js';
+import { validateNewRoot } from '../src/main/sandbox.js';
 import { initDurableStore, resetDurableForTests } from '../src/main/durable.js';
 import {
   inFlightToolCalls,
@@ -62,10 +63,12 @@ async function serve(): Promise<McpEndpoint> {
   initSessionStore(dir);
   initDurableStore(dir);
   const cfg = defaultConfig();
-  await saveConfig({ ...cfg, roots: [{ name: 'probe', path: dir }], readOnly: false });
+  const rootPath = await validateNewRoot(dir, []);
+  const roots = [{ name: 'probe', path: rootPath }];
+  await saveConfig({ ...cfg, roots, readOnly: false });
   await fs.writeFile(path.join(dir, 'note.txt'), 'hello\n', 'utf8');
   return startMcpServer(() => ({
-    roots: [{ name: 'probe', path: dir }],
+    roots,
     caps: cfg.capabilities,
     readOnly: false,
     sessionTools: false,


### PR DESCRIPTION
Superseded after rewriting the repair branch to a single privacy-safe GitHub Actions bot commit. The branch no longer contains the temporary bootstrap/plugin commit history; a fresh PR is used to trigger normal CI on the clean head.