### PR TITLE
Harden v2.0.1 release tests under Windows load

### DIFF
--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -9,7 +9,6 @@
 
 import http from 'node:http';
 import { promises as fs } from 'node:fs';
-import path from 'node:path';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Caller } from '../src/main/agents.js';
 
@@ -76,6 +75,7 @@ const {
   workerRevivalClaimed
 } = await import('../src/main/agents.js');
 const { startMcpServer } = await import('../src/main/mcp/server.js');
+const { runningToolCalls } = await import('../src/main/mcp/call-context.js');
 const { flushDurable, initDurableStore, readDurable, writeDurableNow, writeDurableSoon } = await import('../src/main/durable.js');
 const { initSessionStore, resetSessionStoreForTests } = await import('../src/main/session/store.js');
 const { recordChatObservations, resetRecorderForTests } = await import('../src/main/session/recorder.js');
@@ -1471,6 +1471,14 @@ describe('through the MCP endpoint', () => {
 
   let evidenceSeq = 0;
 
+  const waitForRunningToolCall = async (timeoutMs = 5_000): Promise<void> => {
+    const deadline = Date.now() + timeoutMs;
+    while (runningToolCalls() === 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(runningToolCalls()).toBeGreaterThan(0);
+  };
+
   const callTool = async (name: string, args: unknown): Promise<string> => {
     const reply = await post({ jsonrpc: '2.0', id: nextId++, method: 'tools/call', params: { name, arguments: args } });
     return ((reply.result?.content ?? []) as Array<{ text?: string }>).map((part) => part.text ?? '').join('\n');
@@ -1503,7 +1511,7 @@ describe('through the MCP endpoint', () => {
     const seq = ++evidenceSeq;
     const requestId = `wfr_agents_${seq}`;
     const pending = replyWithRequestId(requestId, action, args);
-    await new Promise((resolve) => setTimeout(resolve, 60));
+    await waitForRunningToolCall();
     await recordChatObservations(conversationId, [
       { kind: 'turn_start', time: Date.now(), turnId: `t-${seq}` },
       {
@@ -1530,7 +1538,7 @@ describe('through the MCP endpoint', () => {
     const seq = ++evidenceSeq;
     const requestId = `wfr_agents_${seq}`;
     const pending = agentsWithRequestId(requestId, action, args);
-    await new Promise((resolve) => setTimeout(resolve, 60));
+    await waitForRunningToolCall();
     await recordChatObservations(conversationId, [
       { kind: 'turn_start', time: Date.now(), turnId: `t-${seq}` },
       {
@@ -1909,7 +1917,6 @@ describe('through the MCP endpoint', () => {
 
     const started = Date.now();
     const shell = `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
-    const heldMarker = path.join(dir, 'held-call-started.txt');
     const pending = post(
       {
         jsonrpc: '2.0',
@@ -1918,7 +1925,7 @@ describe('through the MCP endpoint', () => {
         params: {
           name: 'exec_command',
           arguments: {
-            cmd: "Set-Content -LiteralPath 'held-call-started.txt' -Value 'started' -NoNewline; Start-Sleep -Milliseconds 750; Write-Output 'held-call-done'",
+            cmd: "Start-Sleep -Milliseconds 750; Write-Output 'held-call-done'",
             workdir: dir,
             shell,
             yield_time_ms: 30_000
@@ -1927,16 +1934,8 @@ describe('through the MCP endpoint', () => {
       },
       { 'x-request-id': `${requestId}/relay` }
     );
-    const heldDeadline = Date.now() + 20_000;
-    while (Date.now() < heldDeadline) {
-      try {
-        await fs.access(heldMarker);
-        break;
-      } catch {
-        await new Promise((resolve) => setTimeout(resolve, 25));
-      }
-    }
-    await expect(fs.readFile(heldMarker, 'utf8')).resolves.toContain('started');
+    await waitForRunningToolCall();
+    expect(runningToolCalls('c-worker-1')).toBeGreaterThan(0);
 
     expect(noteWorkerRevived('worker-1', 'c-worker-1', revival.messageIds)).toBe(true);
     const offeredAt = snapshotSwarm()!.agents.find((entry) => entry.info.id === 'worker-1')!.queue[0]!.offeredAt!;

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -1511,7 +1511,6 @@ describe('through the MCP endpoint', () => {
     const seq = ++evidenceSeq;
     const requestId = `wfr_agents_${seq}`;
     const pending = replyWithRequestId(requestId, action, args);
-    await waitForRunningToolCall();
     await recordChatObservations(conversationId, [
       { kind: 'turn_start', time: Date.now(), turnId: `t-${seq}` },
       {
@@ -1538,7 +1537,6 @@ describe('through the MCP endpoint', () => {
     const seq = ++evidenceSeq;
     const requestId = `wfr_agents_${seq}`;
     const pending = agentsWithRequestId(requestId, action, args);
-    await waitForRunningToolCall();
     await recordChatObservations(conversationId, [
       { kind: 'turn_start', time: Date.now(), turnId: `t-${seq}` },
       {

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -2905,7 +2905,7 @@ describe('exec_command and write_stdin', () => {
 
     const first = await core('tools/call', {
       name: 'write_stdin',
-      arguments: { session_id: sessionId, chars: '\r', yield_time_ms: 1_000 }
+      arguments: { session_id: sessionId, chars: '\r', yield_time_ms: 5_000 }
     });
     expect(first.body.result?.isError).not.toBe(true);
     expect(textOf(first)).toContain('first=raw-no-newline');


### PR DESCRIPTION
Follow-up for the v2.0.1 release gate. Replaces the Windows marker-file race with the MCP call-context invariant, makes agent test identity evidence deterministic without forcing schema-rejected calls through dispatch, and gives the interactive stdin assertion a bounded 5s yield. Targeted Windows regression run passed 249/249 tests. Commits are GitHub Actions bot/noreply only.