### PR TITLE
Add first-class /plan mode with a hard read-only fence

### DIFF
--- a/src/main/mcp/surfaces.ts
+++ b/src/main/mcp/surfaces.ts
@@ -40,26 +40,63 @@ export interface SurfaceDefinition {
   id: SurfaceId;
   /** MCP server name. Stable; ChatGPT keys its cached metadata off it. */
   serverName: string;
-  /** Exactly what the user should type as the connector name in ChatGPT. */
+  /**
+   * Exactly what the user should type as the connector name in ChatGPT.
+   *
+   * Offered as copyable text rather than described, because the name is also the
+   * retrieval handle: `paths=["…"]` is matched against it, and a user who invents
+   * "my pc" gets a surface the model cannot address by name.
+   */
   connectorName: string;
-  /** Exactly what the user should paste as the connector description. */
+  /**
+   * Exactly what the user should paste as the connector description.
+   *
+   * This is the single most load-bearing string in the whole design. Before any
+   * discovery has happened the model holds the server name and this sentence and
+   * nothing else, and it decides from them alone whether to pull this surface's
+   * schemas at all. So it is written as vocabulary, not as prose: the words a person
+   * would actually use for the work live in here, because a query that misses is
+   * indistinguishable to the model from a capability that does not exist.
+   */
   description: string;
   /** Short line for the setup card, in the app's own voice. */
   cardSummary: string;
-  /** Whether the app is usable without it. */
+  /**
+   * Whether the app is usable without it. Core is required; Desktop is opt-in and
+   * most sessions never want it.
+   */
   required: boolean;
-  /** Every tool this surface can ever advertise, in listing order. */
+  /**
+   * Every tool this surface can ever advertise, in listing order.
+   *
+   * The authority for tests, for the setup UI's "what you get" list, and for the
+   * cross-surface leakage assertions. A tool that appears here and nowhere else is a
+   * bug in one direction; a tool registered on a server that does not name it here is
+   * a bug in the other.
+   */
   tools: readonly string[];
 }
 
 /**
  * Core — the coding loop.
  *
- * `session` and `agents` live here rather than on surfaces of their own. Core declares 8 possible
- * tool names below, but at most 7 schemas are live at once. `find` and the exec pair are mutually
- * exclusive — `find` exists only when command execution is off — so no runtime tools/list reaches
- * all 8 declarations. /plan deliberately does not add another schema: it is a session directive
- * enforced in front of these same tools.
+ * `session` and `agents` live here rather than on surfaces of their own, and that is a
+ * decision with a concrete reason rather than a tidiness preference:
+ *
+ *  - `session` is how a chat discovers and reads local recordings of past or concurrently
+ *    running work — including exact authored messages and the arguments/result of one call.
+ *    That is part of the coding loop rather than an extra connector.
+ *  - `agents` is one flat tool and is registered only while multi-agent mode is on.
+ *    Fresh installs enable it; an existing config that keeps it off still pays nothing for
+ *    it here. A dedicated connector for one conditional schema is pure setup overhead with
+ *    no discovery benefit.
+ *
+ * Core declares 8 possible tool names below, but at most 7 schemas are live at once. `find`
+ * and the exec pair are mutually exclusive — `find` exists only when command execution is
+ * off — so no runtime tools/list reaches all 8 declarations.
+ *
+ * /plan deliberately does not add a ninth declaration: it is a session directive enforced in
+ * front of these same handlers, preserving the existing no-query discovery budget.
  */
 const CORE: SurfaceDefinition = {
   id: 'core',
@@ -84,7 +121,8 @@ const CORE: SurfaceDefinition = {
  * separately and can switch off independently; its two schemas are the largest we publish, since
  * `computer` alone carries thirteen action variants; and the majority of coding sessions
  * never touch the desktop at all. Folding it into Core would put its weight into every
- * no-query discovery of the coding surface, for a capability most conversations do not want.
+ * no-query discovery of the coding surface, for a capability most conversations do not
+ * want.
  */
 const DESKTOP: SurfaceDefinition = {
   id: 'desktop',
@@ -112,12 +150,22 @@ export function surfaceDefinition(id: SurfaceId): SurfaceDefinition {
 
 /**
  * Whether a surface has anything to offer under these capabilities.
+ *
+ * Desktop with neither screen, control nor clipboard access would advertise an empty tool list,
+ * which is worse than not being offered: the user pays the whole setup cost for a
+ * connector that can do nothing, and ChatGPT shows them a working connection. The
+ * setup UI uses this to grey the card out and say why.
+ *
+ * Core remains the required surface even when its live tool list is temporarily empty. Keeping
+ * that identity stable is what lets permissions be enabled again without changing connectors.
  */
 export function surfaceIsUseful(
   id: SurfaceId,
   caps: Capabilities,
   platform: NodeJS.Platform = process.platform
 ): boolean {
+  // Clipboard counts: it is reached through `computer`, so granting only the clipboard
+  // still gives this surface something real to advertise.
   if (id === 'desktop') {
     return desktopAutomationSupported(platform) && (caps.screen || caps.control || caps.clipboardRead || caps.clipboardWrite);
   }

--- a/src/main/mcp/surfaces.ts
+++ b/src/main/mcp/surfaces.ts
@@ -40,60 +40,26 @@ export interface SurfaceDefinition {
   id: SurfaceId;
   /** MCP server name. Stable; ChatGPT keys its cached metadata off it. */
   serverName: string;
-  /**
-   * Exactly what the user should type as the connector name in ChatGPT.
-   *
-   * Offered as copyable text rather than described, because the name is also the
-   * retrieval handle: `paths=["…"]` is matched against it, and a user who invents
-   * "my pc" gets a surface the model cannot address by name.
-   */
+  /** Exactly what the user should type as the connector name in ChatGPT. */
   connectorName: string;
-  /**
-   * Exactly what the user should paste as the connector description.
-   *
-   * This is the single most load-bearing string in the whole design. Before any
-   * discovery has happened the model holds the server name and this sentence and
-   * nothing else, and it decides from them alone whether to pull this surface's
-   * schemas at all. So it is written as vocabulary, not as prose: the words a person
-   * would actually use for the work live in here, because a query that misses is
-   * indistinguishable to the model from a capability that does not exist.
-   */
+  /** Exactly what the user should paste as the connector description. */
   description: string;
   /** Short line for the setup card, in the app's own voice. */
   cardSummary: string;
-  /**
-   * Whether the app is usable without it. Core is required; Desktop is opt-in and
-   * most sessions never want it.
-   */
+  /** Whether the app is usable without it. */
   required: boolean;
-  /**
-   * Every tool this surface can ever advertise, in listing order.
-   *
-   * The authority for tests, for the setup UI's "what you get" list, and for the
-   * cross-surface leakage assertions. A tool that appears here and nowhere else is a
-   * bug in one direction; a tool registered on a server that does not name it here is
-   * a bug in the other.
-   */
+  /** Every tool this surface can ever advertise, in listing order. */
   tools: readonly string[];
 }
 
 /**
  * Core — the coding loop.
  *
- * `session` and `agents` live here rather than on surfaces of their own, and that is a
- * decision with a concrete reason rather than a tidiness preference:
- *
- *  - `session` is how a chat discovers and reads local recordings of past or concurrently
- *    running work — including exact authored messages and the arguments/result of one call.
- *    That is part of the coding loop rather than an extra connector.
- *  - `agents` is one flat tool and is registered only while multi-agent mode is on.
- *    Fresh installs enable it; an existing config that keeps it off still pays nothing for
- *    it here. A dedicated connector for one conditional schema is pure setup overhead with
- *    no discovery benefit.
- *
- * Core declares 8 possible tool names below, but at most 7 schemas are live at once. `find`
- * and the exec pair are mutually exclusive — `find` exists only when command execution is
- * off — so no runtime tools/list reaches all 8 declarations.
+ * `session` and `agents` live here rather than on surfaces of their own. Core declares 8 possible
+ * tool names below, but at most 7 schemas are live at once. `find` and the exec pair are mutually
+ * exclusive — `find` exists only when command execution is off — so no runtime tools/list reaches
+ * all 8 declarations. /plan deliberately does not add another schema: it is a session directive
+ * enforced in front of these same tools.
  */
 const CORE: SurfaceDefinition = {
   id: 'core',
@@ -104,7 +70,8 @@ const CORE: SurfaceDefinition = {
     'Use for: opening and reading files, searching a repository, applying patches, creating, renaming and deleting files, ' +
     'running builds, tests, linters, git, npm and shell commands, and continuing long-running or interactive terminal sessions. ' +
     'Also searches and reads local recordings of previous or concurrently running ChatGPT work, and — when the user has ' +
-    'enabled it — spawns and coordinates worker agents, subagents or a parallel swarm across several ChatGPT conversations.',
+    'enabled it — spawns and coordinates worker agents, subagents or a parallel swarm across several ChatGPT conversations. ' +
+    'Slash Plan Mode is built in: a user message beginning /plan starts a read-only planning phase; inspect and produce a decision-complete plan without editing, running shell commands, desktop input or workers. /plan run approves execution and /plan clear cancels the fence.',
   cardSummary: 'Files, patches and the terminal. Required — this is the coding connector.',
   required: true,
   tools: ['read', 'view_image', 'find', 'apply_patch', 'exec_command', 'write_stdin', 'session', 'agents']
@@ -117,8 +84,7 @@ const CORE: SurfaceDefinition = {
  * separately and can switch off independently; its two schemas are the largest we publish, since
  * `computer` alone carries thirteen action variants; and the majority of coding sessions
  * never touch the desktop at all. Folding it into Core would put its weight into every
- * no-query discovery of the coding surface, for a capability most conversations do not
- * want.
+ * no-query discovery of the coding surface, for a capability most conversations do not want.
  */
 const DESKTOP: SurfaceDefinition = {
   id: 'desktop',
@@ -128,7 +94,8 @@ const DESKTOP: SurfaceDefinition = {
     'See and control this Windows desktop, including its clipboard. ' +
     'Use for: taking a screenshot, reading what is on screen, listing and finding windows, inspecting buttons, fields and other UI controls, ' +
     'clicking, typing, pressing keys, scrolling and dragging in any Windows application, ' +
-    'and reading the clipboard or copying and pasting text between programs.',
+    'and reading the clipboard or copying and pasting text between programs. ' +
+    'When the current recorded session is in /plan mode, observe remains available but computer input/control is hard-blocked until the user sends /plan run.',
   cardSummary:
     'Screenshots, windows, mouse/keyboard control and the clipboard. Optional — connect it only if you want desktop automation.',
   required: false,
@@ -145,22 +112,12 @@ export function surfaceDefinition(id: SurfaceId): SurfaceDefinition {
 
 /**
  * Whether a surface has anything to offer under these capabilities.
- *
- * Desktop with neither screen, control nor clipboard access would advertise an empty tool list,
- * which is worse than not being offered: the user pays the whole setup cost for a
- * connector that can do nothing, and ChatGPT shows them a working connection. The
- * setup UI uses this to grey the card out and say why.
- *
- * Core remains the required surface even when its live tool list is temporarily empty. Keeping
- * that identity stable is what lets permissions be enabled again without changing connectors.
  */
 export function surfaceIsUseful(
   id: SurfaceId,
   caps: Capabilities,
   platform: NodeJS.Platform = process.platform
 ): boolean {
-  // Clipboard counts: it is reached through `computer`, so granting only the clipboard
-  // still gives this surface something real to advertise.
   if (id === 'desktop') {
     return desktopAutomationSupported(platform) && (caps.screen || caps.control || caps.clipboardRead || caps.clipboardWrite);
   }

--- a/src/main/mcp/tools.ts
+++ b/src/main/mcp/tools.ts
@@ -14,6 +14,7 @@
  */
 
 import { McpServer } from '@modelcontextprotocol/server';
+import { withPlanGuard } from '../plan.js';
 import { createRegistrar, type ToolContext } from './kernel.js';
 import { registerCoreTools } from './tools-core.js';
 import { registerDesktopTools } from './tools-desktop.js';
@@ -31,8 +32,9 @@ export function buildServer(ctx: ToolContext, surface: SurfaceId): McpServer {
   );
 
   const registrar = createRegistrar(server, ctx, surface);
-  if (surface === 'core') registerCoreTools(registrar);
-  else registerDesktopTools(registrar);
+  const guardedRegistrar = withPlanGuard(registrar);
+  if (surface === 'core') registerCoreTools(guardedRegistrar);
+  else registerDesktopTools(guardedRegistrar);
 
   // Cheap self-check on a property the tests assert and the design depends on: a surface
   // may register fewer tools than it declares — permissions decide that — but it may never

--- a/src/main/plan.ts
+++ b/src/main/plan.ts
@@ -1,0 +1,240 @@
+/**
+ * First-class /plan semantics without adding another MCP schema.
+ *
+ * The command itself lives in the user's ChatGPT message. The app derives the newest /plan
+ * directive from the durable session history and the MCP dispatcher enforces the resulting mode
+ * before any model-facing tool handler runs. This keeps the Core surface at its deliberate seven
+ * live schemas while making Plan Mode an app-owned permission boundary rather than a prompt that
+ * the model may ignore.
+ *
+ *   /plan <objective>  -> planning: reads/inspection only
+ *   /plan              -> planning: ask/produce a plan for the current task
+ *   /plan run          -> approved: lift the mutation fence and execute the agreed plan
+ *   /plan clear        -> off: cancel the plan fence
+ *
+ * Plan state is keyed by the local session, not by one ChatGPT conversation. Compact & Resume
+ * rebinds a session to a replacement conversation, so the same plan follows that rebind without
+ * a second migration mechanism. The latest directive sequence is persisted separately so an app
+ * restart cannot rediscover an old /plan start after a later /plan run or /plan clear fell out of
+ * a bounded recent-history read.
+ */
+
+import type { SessionEvent } from '../shared/session.js';
+import { readDurable, writeDurableNow } from './durable.js';
+import { logWarn } from './logger.js';
+import { currentCall } from './mcp/call-context.js';
+import { IDENTITY_EVIDENCE_MS, type SurfaceRegistrar, type ToolResult } from './mcp/kernel.js';
+import { awaitFreshCallOrigin } from './session/recorder.js';
+import { findSessionByConversation, readEvents, readRecentEvents } from './session/store.js';
+
+export type PlanPhase = 'off' | 'planning' | 'approved';
+
+export interface PlanDirective {
+  phase: PlanPhase;
+  objective: string;
+}
+
+interface StoredPlanState extends PlanDirective {
+  /** Session-local sequence of the user message that most recently changed Plan Mode. */
+  directiveSeq: number;
+  updatedAt: number;
+}
+
+interface PlanSnapshot {
+  version: 1;
+  savedAt: number;
+  sessions: Array<{ sessionId: string; state: StoredPlanState }>;
+}
+
+export const PLAN_STATE_FILE = 'plan-mode';
+const MAX_OBJECTIVE_CHARS = 4_000;
+const RECENT_USER_DIRECTIVES = 64;
+const MAX_STORED_SESSIONS = 512;
+
+/**
+ * These tools cannot mutate the approved filesystem/terminal/desktop. Everything else is
+ * denied while planning. In particular exec_command is intentionally not special-cased: even a
+ * command that looks like a search can contain shell redirection, command substitution or an rg
+ * --pre hook. The existing read tool still supports folder listings and globs during planning.
+ */
+const PLAN_READ_ONLY_TOOLS = new Set(['read', 'view_image', 'find', 'session', 'observe']);
+
+const stateBySession = new Map<string, StoredPlanState>();
+let loaded: Promise<void> | null = null;
+
+function toolError(text: string): ToolResult {
+  return { content: [{ type: 'text', text }], isError: true };
+}
+
+function cleanObjective(value: string): string {
+  return value.replace(/\u0000/g, '').trim().slice(0, MAX_OBJECTIVE_CHARS);
+}
+
+/** Pure slash parser. Only a message beginning with /plan owns Plan Mode. */
+export function parsePlanDirective(message: string): PlanDirective | null {
+  const text = String(message ?? '').trim();
+  if (!/^\/plan(?:\s|$)/i.test(text)) return null;
+  const tail = cleanObjective(text.slice('/plan'.length));
+  const command = tail.toLowerCase();
+  if (command === 'run' || command === 'execute' || command === 'approve') {
+    return { phase: 'approved', objective: '' };
+  }
+  if (command === 'clear' || command === 'off' || command === 'cancel') {
+    return { phase: 'off', objective: '' };
+  }
+  return { phase: 'planning', objective: tail };
+}
+
+/** Pure permission policy, exported for focused tests. */
+export function planAllowsTool(phase: PlanPhase, tool: string): boolean {
+  return phase !== 'planning' || PLAN_READ_ONLY_TOOLS.has(tool);
+}
+
+function validStoredState(value: unknown): value is StoredPlanState {
+  if (!value || typeof value !== 'object') return false;
+  const raw = value as Partial<StoredPlanState>;
+  return (
+    (raw.phase === 'off' || raw.phase === 'planning' || raw.phase === 'approved') &&
+    typeof raw.objective === 'string' &&
+    raw.objective.length <= MAX_OBJECTIVE_CHARS &&
+    typeof raw.directiveSeq === 'number' &&
+    Number.isSafeInteger(raw.directiveSeq) &&
+    raw.directiveSeq >= 0 &&
+    typeof raw.updatedAt === 'number' &&
+    Number.isFinite(raw.updatedAt)
+  );
+}
+
+async function ensureLoaded(): Promise<void> {
+  if (loaded) return loaded;
+  loaded = (async () => {
+    const snapshot = await readDurable<PlanSnapshot>(PLAN_STATE_FILE);
+    if (!snapshot || snapshot.version !== 1 || !Array.isArray(snapshot.sessions)) return;
+    for (const row of snapshot.sessions) {
+      if (!row || typeof row.sessionId !== 'string' || !/^[0-9a-z-]{8,64}$/i.test(row.sessionId)) continue;
+      if (!validStoredState(row.state)) continue;
+      stateBySession.set(row.sessionId, {
+        ...row.state,
+        objective: cleanObjective(row.state.objective)
+      });
+    }
+  })();
+  return loaded;
+}
+
+function snapshot(): PlanSnapshot {
+  const sessions = [...stateBySession.entries()]
+    .sort((a, b) => b[1].updatedAt - a[1].updatedAt)
+    .slice(0, MAX_STORED_SESSIONS)
+    .map(([sessionId, state]) => ({ sessionId, state }));
+  return { version: 1, savedAt: Date.now(), sessions };
+}
+
+async function saveState(): Promise<void> {
+  const keep = [...stateBySession.entries()]
+    .sort((a, b) => b[1].updatedAt - a[1].updatedAt)
+    .slice(0, MAX_STORED_SESSIONS);
+  stateBySession.clear();
+  for (const [sessionId, state] of keep) stateBySession.set(sessionId, state);
+  await writeDurableNow(PLAN_STATE_FILE, snapshot());
+}
+
+function newestDirective(events: readonly SessionEvent[], afterSeq = -1): { seq: number; directive: PlanDirective } | null {
+  for (let at = events.length - 1; at >= 0; at--) {
+    const event = events[at];
+    if (!event || event.seq <= afterSeq || event.kind !== 'user_message') continue;
+    const directive = parsePlanDirective(event.message.text);
+    if (directive) return { seq: event.seq, directive };
+  }
+  return null;
+}
+
+async function refreshSessionPlan(sessionId: string): Promise<StoredPlanState | null> {
+  await ensureLoaded();
+  const stored = stateBySession.get(sessionId) ?? null;
+  const events = stored
+    ? await readRecentEvents(sessionId, RECENT_USER_DIRECTIVES, { kinds: ['user_message'] })
+    : await readEvents(sessionId, { kinds: ['user_message'] });
+  const found = newestDirective(events, stored?.directiveSeq ?? -1);
+  if (!found) return stored;
+
+  const next: StoredPlanState = {
+    phase: found.directive.phase,
+    objective: found.directive.phase === 'planning' ? found.directive.objective : stored?.objective ?? '',
+    directiveSeq: found.seq,
+    updatedAt: Date.now()
+  };
+  if (found.directive.phase === 'off') next.objective = '';
+  stateBySession.set(sessionId, next);
+  try {
+    await saveState();
+  } catch (error) {
+    logWarn(`plan: could not persist directive for ${sessionId}: ${(error as Error).message}`);
+  }
+  return next;
+}
+
+async function callerConversation(tool: string): Promise<string | null> {
+  const call = currentCall();
+  if (!call) return null;
+  if (call.caller.conversationId) return call.caller.conversationId;
+  if (!call.caller.requestId) return null;
+  const conversationId = await awaitFreshCallOrigin(tool, call.startedAt, IDENTITY_EVIDENCE_MS, {
+    requestId: call.caller.requestId
+  });
+  if (conversationId) call.caller.conversationId = conversationId;
+  return conversationId;
+}
+
+async function sessionStateForConversation(conversationId: string): Promise<StoredPlanState | null> {
+  const summary = await findSessionByConversation(conversationId, { requireUnique: true });
+  if (!summary) return null;
+  return refreshSessionPlan(summary.id);
+}
+
+function blockedMessage(state: StoredPlanState, tool: string): string {
+  const objective = state.objective ? `\nPlan objective: ${state.objective}` : '';
+  return (
+    `PLAN_MODE_READ_ONLY: ${tool} is blocked because this ChatGPT session is in /plan mode.${objective}\n` +
+    'Inspect with read/view_image/find/session/observe only. Produce a decision-complete implementation plan and stop for the user to review it. ' +
+    'Do not edit files, run shell commands, type/click on the desktop, write the clipboard, or spawn workers. ' +
+    'The user can send /plan run to approve execution or /plan clear to cancel Plan Mode.'
+  );
+}
+
+async function guardPlanTool(tool: string): Promise<ToolResult | null> {
+  await ensureLoaded();
+  if (PLAN_READ_ONLY_TOOLS.has(tool)) return null;
+
+  const conversationId = await callerConversation(tool);
+  if (!conversationId) {
+    const anyPlanning = [...stateBySession.values()].some((state) => state.phase === 'planning');
+    return anyPlanning
+      ? toolError(
+          'PLAN_CALLER_IDENTITY_REQUIRED: a /plan session is active and this mutating call could not be attributed to a ChatGPT conversation. No action was run. Restore the browser-extension identity path and retry.'
+        )
+      : null;
+  }
+
+  const state = await sessionStateForConversation(conversationId);
+  if (!state || planAllowsTool(state.phase, tool)) return null;
+  return toolError(blockedMessage(state, tool));
+}
+
+/** Wraps a surface registrar without changing its schemas or discovery budget. */
+export function withPlanGuard(reg: SurfaceRegistrar): SurfaceRegistrar {
+  return {
+    ...reg,
+    register: ((name: string, config: unknown, handler: (args: unknown) => Promise<ToolResult>) => {
+      reg.register(name, config as never, (async (args: unknown) => {
+        const blocked = await guardPlanTool(name);
+        return blocked ?? handler(args);
+      }) as never);
+    }) as SurfaceRegistrar['register']
+  };
+}
+
+export function resetPlanStateForTests(): void {
+  stateBySession.clear();
+  loaded = null;
+}

--- a/test/plan.test.ts
+++ b/test/plan.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { parsePlanDirective, planAllowsTool } from '../src/main/plan.js';
+
+describe('/plan command semantics', () => {
+  it('recognizes plan start, approval and cancellation only at the start of a user message', () => {
+    expect(parsePlanDirective('/plan refactor the recorder')).toEqual({
+      phase: 'planning',
+      objective: 'refactor the recorder'
+    });
+    expect(parsePlanDirective('/plan')).toEqual({ phase: 'planning', objective: '' });
+    expect(parsePlanDirective('/plan run')).toEqual({ phase: 'approved', objective: '' });
+    expect(parsePlanDirective('/plan clear')).toEqual({ phase: 'off', objective: '' });
+    expect(parsePlanDirective('please mention /plan run in the docs')).toBeNull();
+  });
+
+  it('hard-blocks every mutating surface while planning', () => {
+    for (const tool of ['apply_patch', 'exec_command', 'write_stdin', 'agents', 'computer']) {
+      expect(planAllowsTool('planning', tool), tool).toBe(false);
+    }
+  });
+
+  it('keeps inspection tools available while planning', () => {
+    for (const tool of ['read', 'view_image', 'find', 'session', 'observe']) {
+      expect(planAllowsTool('planning', tool), tool).toBe(true);
+    }
+  });
+
+  it('lifts the fence after /plan run or /plan clear', () => {
+    for (const phase of ['approved', 'off'] as const) {
+      expect(planAllowsTool(phase, 'apply_patch')).toBe(true);
+      expect(planAllowsTool(phase, 'exec_command')).toBe(true);
+      expect(planAllowsTool(phase, 'computer')).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a first-class `/plan` workflow without adding another MCP schema or increasing the existing Core discovery budget.

- `/plan <objective>` enters a session-scoped planning phase.
- `/plan` enters planning for the current task.
- `/plan run` approves execution and lifts the mutation fence.
- `/plan clear` cancels Plan Mode.
- While planning, `read`, `view_image`, `find`, `session`, and `observe` remain available.
- `apply_patch`, `exec_command`, `write_stdin`, `agents`, and `computer` are hard-blocked by the app before their handlers execute.
- State is keyed by the durable local session, so Compact & Resume naturally carries Plan Mode to the replacement ChatGPT conversation.
- The latest directive sequence is persisted so an old `/plan` cannot re-activate after a later `/plan run` or `/plan clear` falls out of a bounded history window.
- Mutation calls fail closed when a Plan session is active but caller identity cannot be proven.

## Why no new `plan` MCP tool?

Core deliberately caps its worst-case no-query discovery at seven live schemas. Adding a ninth declared tool would increase that budget on every relevant conversation. This implementation keeps the existing surface unchanged and treats `/plan` as a session directive enforced in front of the current handlers.

## Safety model

Plan Mode is a runtime permission boundary, not merely a prompt. Even if the model ignores the planning instruction and attempts an edit, command, worker spawn, or desktop input, the connector refuses it.

`exec_command` is intentionally blocked wholesale during planning rather than trying to classify apparently read-only shell commands: shell redirection, command substitution, hooks, aliases, and program-specific options make a general shell allowlist unsafe.

## Tests

Adds focused tests for slash parsing and the read-vs-mutate permission policy. The branch also preserves the existing Core/Desktop tool declarations and discovery shape.

## Current limitation

The slash directive is derived from the app's recorded authored-user history, so Plan Mode requires session recording to be enabled. Fresh installs currently enable recording by default. A future browser-side directive path could remove that dependency without changing the enforcement layer introduced here.