### PR TITLE
Add Power Agent host/web/process tools from issue #2

### DIFF
--- a/docs/tool-surface.md
+++ b/docs/tool-surface.md
@@ -2,7 +2,8 @@
 
 This is the current public reference for the tool surface. The implementation and tests are
 authoritative; `src/main/mcp/surfaces.ts`, `src/main/mcp/tools-core.ts`,
-`src/main/mcp/tools-desktop.ts` and `test/mcp.test.ts` should agree with this file.
+`src/main/mcp/tools-power.ts`, `src/main/mcp/tools-desktop.ts` and `test/mcp.test.ts` should agree
+with this file.
 
 ## Connectors
 
@@ -12,7 +13,7 @@ separate secret tokenized local paths.
 
 | Connector | Purpose | Possible tools |
 | --- | --- | --- |
-| **Chat On Steroids Core** | Approved files, patches, terminal, recorded-session lookup, workers | `read`, `view_image`, `find`, `apply_patch`, `exec_command`, `write_stdin`, `session`, `agents` |
+| **Chat On Steroids Core** | Approved files, patches, terminal, Power Agent host operations, recorded-session lookup, workers | `read`, `view_image`, `find`, `apply_patch`, `exec_command`, `write_stdin`, `power`, `session`, `agents` |
 | **Chat On Steroids Desktop** | **Windows only:** screen, windows, mouse/keyboard and clipboard | `observe`, `computer` |
 
 The Desktop connector is optional and Windows-only. Core is the main connector everywhere.
@@ -23,12 +24,13 @@ Desktop permissions off at runtime while preserving stored choices for a config 
 Windows. Existing configs keep explicit choices during upgrades; missing legacy permissions are
 not silently widened.
 
-With the fresh all-on capability snapshot, Core advertises seven schemas:
-`read`, `view_image`, `apply_patch`, `exec_command`, `write_stdin`, `session`, and `agents`.
+With the fresh all-on capability snapshot, Core advertises eight schemas:
+`read`, `view_image`, `apply_patch`, `exec_command`, `write_stdin`, `power`, `session`, and `agents`.
 `find` is the search fallback for a snapshot where search is enabled and command execution is
-unavailable. Tool exposure is monotonic within a running connector instance, so a permission
-changed mid-conversation can leave a previously exposed name listed; its handler still enforces
-the current permission.
+unavailable. `power` is exposed only when Run commands is exposed and is guarded by that same live
+permission on every call. Tool exposure is monotonic within a running connector instance, so a
+permission changed mid-conversation can leave a previously exposed name listed; its handler still
+enforces the current permission.
 
 ## Core tools
 
@@ -78,6 +80,34 @@ budget. A blank `chars` value is a poll rather than a separate process-status to
 poll returns as soon as the process produces output rather than holding the full yield window;
 anything that arrives afterwards stays buffered for the next poll. A non-empty write keeps
 Codex's collection-window behaviour so one interactive response is gathered whole.
+
+### `power`
+
+A single composite schema for the high-level host operations proposed in issue #2. It is present
+only when Run commands was exposed and every action re-checks that same live `command` capability.
+It does not create a second, broader permission tier: `exec_command` already has host-level command
+authority, including the ability to address paths outside approved roots.
+
+Actions are:
+
+- `system_info` returns bounded non-secret platform, architecture, memory, CPU-count and uptime facts.
+- `open_url` opens an HTTP(S) URL in the default browser or Chrome, Edge, Firefox or Brave.
+- `web_fetch` performs a bounded HTTP(S) fetch without browser cookies, authorization state or
+  stored browser credentials, follows at most five HTTP(S) redirects, and returns readable
+  Markdown/text instead of a browser DOM.
+- `launch_app` starts an application directly with an explicit argument vector rather than shell
+  interpolation.
+- `process_list` returns a bounded process snapshot; `process_kill` terminates by PID or exact
+  process name and refuses to kill Chat On Steroids itself or its direct parent.
+- `system_exec` runs a bounded one-shot PowerShell/CMD/sh script. Long-running and interactive
+  processes still belong on `exec_command` + `write_stdin`.
+- `fs_system_list`, `fs_system_read` and `fs_system_write` intentionally accept absolute native
+  host paths outside approved roots. Reads are text-only and size-bounded; writes are size-bounded
+  and require an explicit create/overwrite/append mode.
+
+The `fs_system_*` names are deliberately explicit about crossing the approved-root boundary. A
+user who wants the root sandbox without host-wide authority should leave Run commands disabled;
+then `power`, `exec_command` and `write_stdin` are absent together.
 
 ### `session`
 
@@ -161,7 +191,9 @@ can keep observation available while disabling state-changing desktop actions.
 - A connector token for one surface does not authorize the other surface.
 - Read-only mode removes effective file-write, command, control and clipboard-write permissions
   without pretending the underlying configuration was changed.
-- Approved filesystem roots do not sandbox command execution or desktop control.
+- Approved filesystem roots do not sandbox command execution or Desktop control. Power Agent's
+  `fs_system_*` actions also cross that root boundary, but only under the same Run commands
+  capability that already grants equivalent host authority.
 - Tool results and validation errors are bounded; large structured or binary payloads must not
   grow without an explicit cap.
 
@@ -175,8 +207,10 @@ bridge; there is no pairing code to enter.
 ## Tests that protect the surface
 
 `test/mcp.test.ts` checks exact surface membership, cross-surface rejection, discovery-size
-budgets, permission gating, retired names and schema shape. Native image parity has additional
-coverage in `test/codex-view-image-parity.test.ts`.
+budgets, permission gating, retired names and schema shape. `test/power.test.ts` covers the Power
+Agent permission boundary, bounded web fetch, readable-text extraction, system filesystem actions
+and one-shot system execution. Native image parity has additional coverage in
+`test/codex-view-image-parity.test.ts`.
 
 When changing the public tool surface, update the implementation, the surface declarations,
 the tests and this document together. Do not add a permanently exposed tool for a workflow

--- a/src/main/mcp/surfaces.ts
+++ b/src/main/mcp/surfaces.ts
@@ -80,8 +80,8 @@ export interface SurfaceDefinition {
 /**
  * Core — the coding loop.
  *
- * `session` and `agents` live here rather than on surfaces of their own, and that is a
- * decision with a concrete reason rather than a tidiness preference:
+ * `session`, `agents` and `power` live here rather than on surfaces of their own, and that is
+ * a decision with a concrete reason rather than a tidiness preference:
  *
  *  - `session` is how a chat discovers and reads local recordings of past or concurrently
  *    running work — including exact authored messages and the arguments/result of one call.
@@ -90,10 +90,13 @@ export interface SurfaceDefinition {
  *    Fresh installs enable it; an existing config that keeps it off still pays nothing for
  *    it here. A dedicated connector for one conditional schema is pure setup overhead with
  *    no discovery benefit.
+ *  - `power` is one composite schema behind Run commands. It packages common host/web/process
+ *    operations that command execution could already perform, so it adds no new permission
+ *    boundary and does not justify another connector.
  *
- * Core declares 8 possible tool names below, but at most 7 schemas are live at once. `find`
+ * Core declares 9 possible tool names below, but at most 8 schemas are live at once. `find`
  * and the exec pair are mutually exclusive — `find` exists only when command execution is
- * off — so no runtime tools/list reaches all 8 declarations.
+ * off — and `power` exists only with command execution, so no runtime tools/list reaches all 9.
  */
 const CORE: SurfaceDefinition = {
   id: 'core',
@@ -103,11 +106,12 @@ const CORE: SurfaceDefinition = {
     'Read and edit code and text files on this computer, and run commands in a real terminal. ' +
     'Use for: opening and reading files, searching a repository, applying patches, creating, renaming and deleting files, ' +
     'running builds, tests, linters, git, npm and shell commands, and continuing long-running or interactive terminal sessions. ' +
+    'With Run commands enabled, Power Agent can also fetch web pages, open URLs, launch apps, inspect or terminate processes, run one-shot system commands, and explicitly access absolute host filesystem paths outside approved roots. ' +
     'Also searches and reads local recordings of previous or concurrently running ChatGPT work, and — when the user has ' +
     'enabled it — spawns and coordinates worker agents, subagents or a parallel swarm across several ChatGPT conversations.',
-  cardSummary: 'Files, patches and the terminal. Required — this is the coding connector.',
+  cardSummary: 'Files, patches, terminal and optional Power Agent host operations. Required — this is the coding connector.',
   required: true,
-  tools: ['read', 'view_image', 'find', 'apply_patch', 'exec_command', 'write_stdin', 'session', 'agents']
+  tools: ['read', 'view_image', 'find', 'apply_patch', 'exec_command', 'write_stdin', 'power', 'session', 'agents']
 };
 
 /**

--- a/src/main/mcp/tools-power.ts
+++ b/src/main/mcp/tools-power.ts
@@ -1,0 +1,613 @@
+/**
+ * High-level host operations for issue #2, intentionally kept behind one MCP schema.
+ *
+ * `exec_command` already grants the Run commands permission authority to execute arbitrary
+ * host commands, including outside approved filesystem roots. The power tool does not widen
+ * that authority: it provides bounded, structured versions of common host operations while
+ * reusing the same live `command` capability gate on every call.
+ *
+ * System-wide filesystem actions below are therefore deliberately NOT guarded by the normal
+ * read/create/edit root sandbox. Their names say so and the tool description calls it out.
+ * A user who does not grant Run commands never sees this schema at all.
+ */
+
+import os from 'node:os';
+import nodePath from 'node:path';
+import { z } from 'zod';
+import { rawPromises as fs } from '../rawfs.js';
+import {
+  launchCommand,
+  runCommand,
+  runPowerShell,
+  terminateProcessTree,
+  type ExecResult
+} from '../exec.js';
+import { noteCount, noteDetail, noteExec } from './call-context.js';
+import { fail, type SurfaceRegistrar, type ToolResult } from './kernel.js';
+
+const MAX_FETCH_BYTES = 2 * 1024 * 1024;
+const MAX_FETCH_CHARS = 100_000;
+const DEFAULT_FETCH_CHARS = 40_000;
+const MAX_SYSTEM_FILE_BYTES = 4 * 1024 * 1024;
+const MAX_WRITE_CHARS = 2 * 1024 * 1024;
+const MAX_DIR_ENTRIES = 200;
+const MAX_PROCESSES = 100;
+const MAX_EXEC_SCRIPT_CHARS = 4_000;
+
+const browser = z.enum(['default', 'chrome', 'msedge', 'firefox', 'brave']);
+
+const actionSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('system_info') }).strict(),
+  z
+    .object({
+      type: z.literal('open_url'),
+      url: z.string().min(1).max(4096),
+      browser: browser.optional().default('default')
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('web_fetch'),
+      url: z.string().min(1).max(4096),
+      max_chars: z.number().int().min(1_000).max(MAX_FETCH_CHARS).optional().default(DEFAULT_FETCH_CHARS),
+      timeout_seconds: z.number().int().min(1).max(30).optional().default(15)
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('launch_app'),
+      app: z.string().min(1).max(4096),
+      args: z.array(z.string().max(4096)).max(64).optional().default([]),
+      cwd: z.string().max(4096).optional()
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('process_list'),
+      query: z.string().max(120).optional(),
+      limit: z.number().int().min(1).max(MAX_PROCESSES).optional().default(25)
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('process_kill'),
+      pid: z.number().int().min(2).optional(),
+      name: z.string().min(1).max(160).optional(),
+      all: z.boolean().optional().default(false),
+      force: z.boolean().optional().default(true)
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('system_exec'),
+      script: z.string().min(1).max(MAX_EXEC_SCRIPT_CHARS),
+      shell: z.enum(['powershell', 'cmd', 'sh']).optional(),
+      cwd: z.string().max(4096).optional(),
+      timeout_seconds: z.number().int().min(1).max(300).optional().default(30)
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('fs_system_list'),
+      path: z.string().min(1).max(4096),
+      limit: z.number().int().min(1).max(MAX_DIR_ENTRIES).optional().default(100)
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('fs_system_read'),
+      path: z.string().min(1).max(4096),
+      max_chars: z.number().int().min(1).max(MAX_FETCH_CHARS).optional().default(MAX_FETCH_CHARS)
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('fs_system_write'),
+      path: z.string().min(1).max(4096),
+      content: z.string().max(MAX_WRITE_CHARS),
+      mode: z.enum(['create', 'overwrite', 'append']).optional().default('overwrite'),
+      create_parents: z.boolean().optional().default(false)
+    })
+    .strict()
+]);
+
+type PowerAction = z.output<typeof actionSchema>;
+
+interface ProcessRow {
+  pid: number;
+  name: string;
+  window_title: string;
+  memory_bytes: number;
+}
+
+function result(structuredContent: Record<string, unknown>, summary?: string): ToolResult {
+  return {
+    content: [{ type: 'text', text: summary ?? JSON.stringify(structuredContent, null, 2) }],
+    structuredContent
+  };
+}
+
+function noteExecution(execution: ExecResult): void {
+  noteExec({
+    running: false,
+    exitCode: execution.exitCode,
+    timedOut: execution.timedOut,
+    durationMs: execution.durationMs
+  });
+}
+
+function requireHttpUrl(value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('URL_INVALID: expected a valid absolute http:// or https:// URL.');
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('URL_PROTOCOL_REFUSED: only http:// and https:// URLs are accepted.');
+  }
+  if (url.username || url.password) {
+    throw new Error('URL_CREDENTIALS_REFUSED: credentials embedded in URLs are not accepted.');
+  }
+  return url;
+}
+
+function requireAbsoluteSystemPath(value: string): string {
+  if (!nodePath.isAbsolute(value)) {
+    throw new Error('ABSOLUTE_PATH_REQUIRED: system-wide filesystem actions require an absolute host path.');
+  }
+  if (value.includes('\0')) throw new Error('PATH_INVALID: path contains a null byte.');
+  return nodePath.normalize(value);
+}
+
+async function systemCwd(value?: string): Promise<string> {
+  if (!value) return process.cwd();
+  const cwd = requireAbsoluteSystemPath(value);
+  const stat = await fs.stat(cwd);
+  if (!stat.isDirectory()) throw new Error('CWD_NOT_DIRECTORY: cwd must name a directory.');
+  return cwd;
+}
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&#(\d+);/g, (_m, n: string) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_m, n: string) => String.fromCodePoint(Number.parseInt(n, 16)));
+}
+
+/** Lightweight readable-text extraction: bounded and dependency-free, not a DOM emulator. */
+export function htmlToCleanMarkdown(html: string): string {
+  let text = html
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<(script|style|noscript|svg)\b[^>]*>[\s\S]*?<\/\1>/gi, '')
+    .replace(/<a\b[^>]*href=(['"])(.*?)\1[^>]*>([\s\S]*?)<\/a>/gi, (_m, _q, href, label) =>
+      `[${String(label).replace(/<[^>]+>/g, '').trim()}](${href})`
+    )
+    .replace(/<h1\b[^>]*>([\s\S]*?)<\/h1>/gi, '\n\n# $1\n\n')
+    .replace(/<h2\b[^>]*>([\s\S]*?)<\/h2>/gi, '\n\n## $1\n\n')
+    .replace(/<h[3-6]\b[^>]*>([\s\S]*?)<\/h[3-6]>/gi, '\n\n### $1\n\n')
+    .replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, '\n- $1')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|section|article|header|footer|tr|table|ul|ol)>/gi, '\n\n')
+    .replace(/<[^>]+>/g, '');
+  text = decodeEntities(text);
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.replace(/[\t ]+/g, ' ').trim())
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+async function readBoundedResponse(response: Response): Promise<{ text: string; truncated: boolean }> {
+  if (!response.body) return { text: '', truncated: false };
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  let truncated = false;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const room = MAX_FETCH_BYTES - bytes;
+      if (room <= 0) {
+        truncated = true;
+        break;
+      }
+      const chunk = Buffer.from(value);
+      if (chunk.length > room) {
+        chunks.push(chunk.subarray(0, room));
+        bytes += room;
+        truncated = true;
+        break;
+      }
+      chunks.push(chunk);
+      bytes += chunk.length;
+    }
+  } finally {
+    if (truncated) await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+  return { text: Buffer.concat(chunks).toString('utf8'), truncated };
+}
+
+async function webFetch(action: Extract<PowerAction, { type: 'web_fetch' }>): Promise<ToolResult> {
+  let current = requireHttpUrl(action.url);
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), action.timeout_seconds * 1000);
+  try {
+    let response: Response | null = null;
+    for (let redirect = 0; redirect <= 5; redirect++) {
+      response = await fetch(current, {
+        redirect: 'manual',
+        signal: abort.signal,
+        headers: {
+          accept: 'text/html,application/xhtml+xml,text/plain,application/json;q=0.9,*/*;q=0.1',
+          'user-agent': 'Chat-On-Steroids/Power-Agent'
+        }
+      });
+      if (![301, 302, 303, 307, 308].includes(response.status)) break;
+      const location = response.headers.get('location');
+      if (!location) break;
+      if (redirect === 5) return fail('TOO_MANY_REDIRECTS: web_fetch followed 5 redirects and stopped.');
+      current = requireHttpUrl(new URL(location, current).toString());
+    }
+    if (!response) return fail('FETCH_FAILED: no HTTP response was received.');
+    const contentType = (response.headers.get('content-type') ?? '').toLowerCase();
+    const textual =
+      contentType === '' ||
+      contentType.includes('text/') ||
+      contentType.includes('html') ||
+      contentType.includes('json') ||
+      contentType.includes('xml');
+    if (!textual) return fail(`UNSUPPORTED_CONTENT_TYPE: ${contentType || 'unknown'}`);
+    const body = await readBoundedResponse(response);
+    const titleMatch = /<title\b[^>]*>([\s\S]*?)<\/title>/i.exec(body.text);
+    const title = titleMatch ? decodeEntities(titleMatch[1]!.replace(/<[^>]+>/g, '').trim()).slice(0, 300) : '';
+    let readable = contentType.includes('html') || /<html\b|<!doctype\s+html/i.test(body.text)
+      ? htmlToCleanMarkdown(body.text)
+      : body.text.trim();
+    let truncated = body.truncated;
+    if (readable.length > action.max_chars) {
+      readable = readable.slice(0, action.max_chars);
+      truncated = true;
+    }
+    noteDetail(`HTTP ${response.status} ${current.hostname}`);
+    return result({
+      action: 'web_fetch',
+      url: action.url,
+      final_url: current.toString(),
+      status: response.status,
+      content_type: contentType,
+      title,
+      markdown: readable,
+      truncated
+    });
+  } catch (error) {
+    if (abort.signal.aborted) return fail(`FETCH_TIMEOUT: web_fetch exceeded ${action.timeout_seconds}s.`);
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function openUrl(action: Extract<PowerAction, { type: 'open_url' }>): Promise<ToolResult> {
+  const url = requireHttpUrl(action.url).toString();
+  const selected = action.browser;
+  if (selected === 'default') {
+    if (process.platform === 'win32') {
+      const encoded = Buffer.from(url, 'utf8').toString('base64');
+      const script =
+        `$u=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encoded}')); ` +
+        `Start-Process -FilePath $u`;
+      const execution = await runPowerShell(script, process.cwd(), 10_000);
+      noteExecution(execution);
+      if (execution.timedOut || execution.exitCode !== 0) {
+        return fail(`OPEN_URL_FAILED: ${execution.stderr || `exit ${execution.exitCode ?? 'unknown'}`}`);
+      }
+    } else {
+      const command = process.platform === 'darwin' ? 'open' : 'xdg-open';
+      await launchCommand(command, [url], process.cwd());
+    }
+    noteDetail(`opened ${new URL(url).hostname}`);
+    return result({ action: 'open_url', url, browser: 'default', opened: true });
+  }
+
+  const maps = {
+    win32: { chrome: 'chrome.exe', msedge: 'msedge.exe', firefox: 'firefox.exe', brave: 'brave.exe' },
+    darwin: { chrome: 'Google Chrome', msedge: 'Microsoft Edge', firefox: 'Firefox', brave: 'Brave Browser' },
+    linux: { chrome: 'google-chrome', msedge: 'microsoft-edge', firefox: 'firefox', brave: 'brave-browser' }
+  } as const;
+  const platform = process.platform === 'win32' ? 'win32' : process.platform === 'darwin' ? 'darwin' : 'linux';
+  if (platform === 'darwin') {
+    const launched = await launchCommand('open', ['-a', maps.darwin[selected], url], process.cwd());
+    noteDetail(`opened ${selected} PID ${launched.pid}`);
+    return result({ action: 'open_url', url, browser: selected, opened: true, pid: launched.pid });
+  }
+  const launched = await launchCommand(maps[platform][selected], [url], process.cwd());
+  noteDetail(`opened ${selected} PID ${launched.pid}`);
+  return result({ action: 'open_url', url, browser: selected, opened: true, pid: launched.pid });
+}
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function parseWindowsProcesses(stdout: string): ProcessRow[] {
+  const decoded = JSON.parse(stdout.trim() || '[]') as unknown;
+  const values = Array.isArray(decoded) ? decoded : decoded && typeof decoded === 'object' ? [decoded] : [];
+  return values.flatMap((value) => {
+    if (!value || typeof value !== 'object') return [];
+    const row = value as Record<string, unknown>;
+    const pid = Number(row.pid);
+    const name = typeof row.name === 'string' ? row.name.trim() : '';
+    if (!Number.isSafeInteger(pid) || pid <= 0 || !name) return [];
+    return [{
+      pid,
+      name: name.slice(0, 160),
+      window_title: typeof row.window_title === 'string' ? row.window_title.trim().slice(0, 300) : '',
+      memory_bytes: Math.max(0, Math.trunc(Number(row.memory_bytes) || 0))
+    }];
+  });
+}
+
+async function processRows(): Promise<ProcessRow[]> {
+  if (process.platform === 'win32') {
+    const script =
+      `$rows=@(Get-Process -ErrorAction SilentlyContinue | Sort-Object Id | Select-Object -First ${MAX_PROCESSES + 1} ` +
+      `@{Name='pid';Expression={$_.Id}},@{Name='name';Expression={$_.ProcessName}},` +
+      `@{Name='window_title';Expression={$_.MainWindowTitle}},@{Name='memory_bytes';Expression={$_.WorkingSet64}}); ` +
+      `ConvertTo-Json -Compress -InputObject $rows`;
+    const execution = await runPowerShell(script, process.cwd(), 10_000);
+    noteExecution(execution);
+    if (execution.timedOut) throw new Error('PROCESS_LIST_TIMEOUT: Windows did not return a process snapshot in time.');
+    if (execution.exitCode !== 0) throw new Error(`PROCESS_LIST_FAILED: ${execution.stderr || execution.exitCode}`);
+    return parseWindowsProcesses(execution.stdout);
+  }
+
+  const execution = await runCommand('ps', ['-eo', 'pid=,comm=,rss='], process.cwd(), 10_000);
+  noteExecution(execution);
+  if (execution.exitCode !== 0) throw new Error(`PROCESS_LIST_FAILED: ${execution.stderr || execution.exitCode}`);
+  return execution.stdout
+    .split(/\r?\n/)
+    .flatMap((line) => {
+      const match = /^\s*(\d+)\s+(\S+)\s+(\d+)\s*$/.exec(line);
+      if (!match) return [];
+      return [{
+        pid: Number(match[1]),
+        name: match[2]!.slice(0, 160),
+        window_title: '',
+        memory_bytes: Number(match[3]) * 1024
+      } satisfies ProcessRow];
+    })
+    .slice(0, MAX_PROCESSES + 1);
+}
+
+async function processList(action: Extract<PowerAction, { type: 'process_list' }>): Promise<ToolResult> {
+  const rows = await processRows();
+  const needle = action.query?.trim().toLocaleLowerCase('en-US') ?? '';
+  const matching = rows.filter((row) =>
+    !needle || row.name.toLocaleLowerCase('en-US').includes(needle) || row.window_title.toLocaleLowerCase('en-US').includes(needle)
+  );
+  const processes = matching.slice(0, action.limit);
+  noteCount(processes.length);
+  noteDetail(`${processes.length} process${processes.length === 1 ? '' : 'es'}`);
+  return result({
+    action: 'process_list',
+    processes,
+    returned: processes.length,
+    truncated: matching.length > processes.length || rows.length > MAX_PROCESSES
+  });
+}
+
+async function waitForExit(pid: number): Promise<boolean> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (!processExists(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return !processExists(pid);
+}
+
+async function processKill(action: Extract<PowerAction, { type: 'process_kill' }>): Promise<ToolResult> {
+  if ((action.pid === undefined) === (action.name === undefined)) {
+    return fail('PROCESS_TARGET_REQUIRED: provide exactly one of pid or name.');
+  }
+  let targets: ProcessRow[];
+  if (action.pid !== undefined) {
+    targets = [{ pid: action.pid, name: '', window_title: '', memory_bytes: 0 }];
+  } else {
+    const wanted = action.name!.trim().replace(/\.exe$/i, '').toLocaleLowerCase('en-US');
+    targets = (await processRows()).filter((row) => row.name.replace(/\.exe$/i, '').toLocaleLowerCase('en-US') === wanted);
+    if (targets.length === 0) return fail(`PROCESS_NOT_FOUND: no process named ${action.name}.`);
+    if (targets.length > 1 && !action.all) {
+      return fail(`PROCESS_AMBIGUOUS: ${targets.length} processes match ${action.name}; specify a PID or set all=true.`);
+    }
+    if (!action.all) targets = targets.slice(0, 1);
+  }
+
+  const protectedPids = new Set([process.pid, process.ppid]);
+  if (targets.some((target) => protectedPids.has(target.pid))) {
+    return fail('PROTECTED_PROCESS: Chat On Steroids refuses to terminate itself or its direct parent.');
+  }
+  const terminated: number[] = [];
+  for (const target of targets) {
+    if (!processExists(target.pid)) continue;
+    await terminateProcessTree(target.pid, action.force);
+    if (!(await waitForExit(target.pid))) {
+      return fail(`PROCESS_TERMINATION_UNCONFIRMED: PID ${target.pid} still appears to be running.`);
+    }
+    terminated.push(target.pid);
+  }
+  if (terminated.length === 0) return fail('PROCESS_NOT_FOUND_OR_DENIED: no matching live process could be terminated.');
+  noteCount(terminated.length);
+  noteDetail(`terminated ${terminated.join(', ')}`);
+  return result({ action: 'process_kill', terminated_pids: terminated, force: action.force });
+}
+
+async function systemExec(action: Extract<PowerAction, { type: 'system_exec' }>): Promise<ToolResult> {
+  const cwd = await systemCwd(action.cwd);
+  const timeoutMs = action.timeout_seconds * 1000;
+  let execution: ExecResult;
+  if (process.platform === 'win32') {
+    const shell = action.shell ?? 'powershell';
+    if (shell === 'sh') return fail('SHELL_UNAVAILABLE: shell=sh is not supported on Windows by this action.');
+    if (shell === 'powershell') {
+      execution = await runPowerShell(action.script, cwd, timeoutMs);
+    } else {
+      const encoded = Buffer.from(action.script, 'utf8').toString('base64');
+      const wrapper =
+        `$c=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encoded}')); ` +
+        `& $env:ComSpec /d /s /c $c; if($null -ne $LASTEXITCODE){exit $LASTEXITCODE}`;
+      execution = await runPowerShell(wrapper, cwd, timeoutMs);
+    }
+  } else {
+    const shell = action.shell ?? 'sh';
+    if (shell !== 'sh') return fail(`SHELL_UNAVAILABLE: shell=${shell} is Windows-only; use sh on this platform.`);
+    execution = await runCommand('/bin/sh', ['-lc', action.script], cwd, timeoutMs);
+  }
+  noteExecution(execution);
+  noteDetail(`exit ${execution.exitCode ?? 'unknown'}`);
+  return result({
+    action: 'system_exec',
+    shell: action.shell ?? (process.platform === 'win32' ? 'powershell' : 'sh'),
+    cwd,
+    exit_code: execution.exitCode,
+    stdout: execution.stdout,
+    stderr: execution.stderr,
+    truncated: execution.truncated,
+    timed_out: execution.timedOut,
+    duration_ms: execution.durationMs
+  });
+}
+
+async function systemList(action: Extract<PowerAction, { type: 'fs_system_list' }>): Promise<ToolResult> {
+  const target = requireAbsoluteSystemPath(action.path);
+  const entries = await fs.readdir(target, { withFileTypes: true });
+  const selected = entries.slice(0, action.limit);
+  const rows: Array<Record<string, unknown>> = [];
+  for (const entry of selected) {
+    const full = nodePath.join(target, entry.name);
+    let size: number | null = null;
+    let modified_ms: number | null = null;
+    try {
+      const stat = await fs.stat(full);
+      size = stat.size;
+      modified_ms = stat.mtimeMs;
+    } catch {
+      // The item may disappear between readdir and stat. The directory entry is still useful.
+    }
+    rows.push({
+      name: entry.name,
+      type: entry.isDirectory() ? 'directory' : entry.isFile() ? 'file' : entry.isSymbolicLink() ? 'symlink' : 'other',
+      size,
+      modified_ms
+    });
+  }
+  noteCount(rows.length);
+  noteDetail(`system list ${target}`);
+  return result({ action: 'fs_system_list', path: target, entries: rows, truncated: entries.length > selected.length });
+}
+
+async function systemRead(action: Extract<PowerAction, { type: 'fs_system_read' }>): Promise<ToolResult> {
+  const target = requireAbsoluteSystemPath(action.path);
+  const stat = await fs.stat(target);
+  if (!stat.isFile()) return fail('NOT_A_FILE: fs_system_read requires a regular file.');
+  if (stat.size > MAX_SYSTEM_FILE_BYTES) {
+    return fail(`FILE_TOO_LARGE: system reads are capped at ${MAX_SYSTEM_FILE_BYTES} bytes.`);
+  }
+  const buffer = await fs.readFile(target);
+  if (buffer.subarray(0, Math.min(buffer.length, 4096)).includes(0)) {
+    return fail('BINARY_FILE_REFUSED: fs_system_read returns text only.');
+  }
+  const decoded = buffer.toString('utf8');
+  const text = decoded.slice(0, action.max_chars);
+  noteDetail(`system read ${target}`);
+  return result({
+    action: 'fs_system_read',
+    path: target,
+    size_bytes: stat.size,
+    text,
+    truncated: decoded.length > text.length
+  });
+}
+
+async function systemWrite(action: Extract<PowerAction, { type: 'fs_system_write' }>): Promise<ToolResult> {
+  const target = requireAbsoluteSystemPath(action.path);
+  if (action.create_parents) await fs.mkdir(nodePath.dirname(target), { recursive: true });
+  const bytes = Buffer.byteLength(action.content, 'utf8');
+  if (action.mode === 'append') await fs.appendFile(target, action.content, 'utf8');
+  else await fs.writeFile(target, action.content, { encoding: 'utf8', flag: action.mode === 'create' ? 'wx' : 'w' });
+  noteDetail(`system ${action.mode} ${target}`);
+  return result({ action: 'fs_system_write', path: target, mode: action.mode, bytes_written: bytes });
+}
+
+async function launchApp(action: Extract<PowerAction, { type: 'launch_app' }>): Promise<ToolResult> {
+  const cwd = await systemCwd(action.cwd);
+  const launched = await launchCommand(action.app, action.args, cwd);
+  noteDetail(`launched PID ${launched.pid}`);
+  return result({ action: 'launch_app', app: action.app, pid: launched.pid, cwd });
+}
+
+async function dispatchPower(action: PowerAction): Promise<ToolResult> {
+  switch (action.type) {
+    case 'system_info': {
+      const structured = {
+        action: 'system_info',
+        platform: process.platform,
+        architecture: process.arch,
+        release: os.release(),
+        cpu_count: os.cpus().length,
+        total_memory_bytes: os.totalmem(),
+        free_memory_bytes: os.freemem(),
+        uptime_seconds: Math.floor(os.uptime()),
+        node_version: process.version
+      };
+      noteDetail(`${structured.platform} ${structured.architecture}`);
+      return result(structured);
+    }
+    case 'open_url':
+      return openUrl(action);
+    case 'web_fetch':
+      return webFetch(action);
+    case 'launch_app':
+      return launchApp(action);
+    case 'process_list':
+      return processList(action);
+    case 'process_kill':
+      return processKill(action);
+    case 'system_exec':
+      return systemExec(action);
+    case 'fs_system_list':
+      return systemList(action);
+    case 'fs_system_read':
+      return systemRead(action);
+    case 'fs_system_write':
+      return systemWrite(action);
+  }
+}
+
+export function registerPowerTool(reg: SurfaceRegistrar): void {
+  if (!reg.exposedCaps.command) return;
+  reg.register(
+    'power',
+    {
+      title: 'Power Agent host operations',
+      description:
+        'Structured host operations behind the existing Run commands permission. Actions: system_info; open_url; web_fetch (bounded HTTP(S) to readable text, no cookies/credentials); launch_app; process_list/process_kill; system_exec; and fs_system_list/fs_system_read/fs_system_write. ' +
+        'The fs_system_* actions intentionally address absolute host paths OUTSIDE the approved-root sandbox because Run commands already has that host authority. Disable Run commands to remove this tool. Use exec_command instead for long-running or interactive terminal sessions.',
+      inputSchema: z.object({ action: actionSchema }).strict(),
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }
+    },
+    async ({ action }) => reg.guarded('command', 'power', () => dispatchPower(action))
+  );
+}

--- a/src/main/mcp/tools.ts
+++ b/src/main/mcp/tools.ts
@@ -17,6 +17,7 @@ import { McpServer } from '@modelcontextprotocol/server';
 import { createRegistrar, type ToolContext } from './kernel.js';
 import { registerCoreTools } from './tools-core.js';
 import { registerDesktopTools } from './tools-desktop.js';
+import { registerPowerTool } from './tools-power.js';
 import { surfaceDefinition, type SurfaceId } from './surfaces.js';
 import { serverInstructions } from './instructions.js';
 import { APP_VERSION } from './../version.js';
@@ -31,8 +32,14 @@ export function buildServer(ctx: ToolContext, surface: SurfaceId): McpServer {
   );
 
   const registrar = createRegistrar(server, ctx, surface);
-  if (surface === 'core') registerCoreTools(registrar);
-  else registerDesktopTools(registrar);
+  if (surface === 'core') {
+    registerCoreTools(registrar);
+    // One composite schema, and only while Run commands was part of this endpoint's
+    // monotonic exposure. The live command guard inside the tool still wins after revocation.
+    registerPowerTool(registrar);
+  } else {
+    registerDesktopTools(registrar);
+  }
 
   // Cheap self-check on a property the tests assert and the design depends on: a surface
   // may register fewer tools than it declares — permissions decide that — but it may never

--- a/test/feature-parity.test.ts
+++ b/test/feature-parity.test.ts
@@ -56,6 +56,7 @@ describe('portable browser-backed feature parity', () => {
       'apply_patch',
       'exec_command',
       'write_stdin',
+      'power',
       'session',
       'agents'
     ]);

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -572,7 +572,7 @@ describe('surface boundaries', () => {
     everything();
     const names = toolNames(await core('tools/list'));
     // find is absent because exec_command is present — they are mutually exclusive.
-    expect(names).toEqual(['agents', 'apply_patch', 'exec_command', 'read', 'session', 'view_image', 'write_stdin']);
+    expect(names).toEqual(['agents', 'apply_patch', 'exec_command', 'power', 'read', 'session', 'view_image', 'write_stdin']);
     for (const name of surfaceDefinition('desktop').tools) expect(names, name).not.toContain(name);
   });
 
@@ -749,9 +749,9 @@ describe('surface boundaries', () => {
     const coreTools = toolList(await core('tools/list'));
     const desktopTools = toolList(await desktop('tools/list'));
 
-    // Counts are the design: Core is capped at seven live schemas because find and the exec
-    // pair cannot both exist, and Desktop is two.
-    expect(coreTools).toHaveLength(7);
+    // Counts are the design: Core is capped at eight live schemas. find and the exec pair
+    // cannot both exist, and the command-gated Power Agent remains one composite schema. Desktop is two.
+    expect(coreTools).toHaveLength(8);
     expect(desktopTools).toHaveLength(2);
 
     // And the size, which is what a discovery pull actually costs the model on every
@@ -761,7 +761,7 @@ describe('surface boundaries', () => {
     // catches the regression it exists to catch.
     const coreBytes = Buffer.byteLength(JSON.stringify(coreTools), 'utf8');
     const desktopBytes = Buffer.byteLength(JSON.stringify(desktopTools), 'utf8');
-    expect(coreBytes, `core tools/list is ${coreBytes} bytes`).toBeLessThan(18_000);
+    expect(coreBytes, `core tools/list is ${coreBytes} bytes`).toBeLessThan(27_000);
     expect(desktopBytes, `desktop tools/list is ${desktopBytes} bytes`).toBeLessThan(8_500);
 
     // Per tool as well as per surface, so one schema cannot quietly eat the whole budget
@@ -784,7 +784,9 @@ describe('surface boundaries', () => {
               ? 3_400
               : tool.name === 'exec_command'
                 ? 3_500
-                : 3_000;
+                : tool.name === 'power'
+                  ? 9_000
+                  : 3_000;
       expect(bytes, `${tool.name} schema is ${bytes} bytes`).toBeLessThan(budget);
     }
   });
@@ -1004,11 +1006,13 @@ describe('capability gating', () => {
   it('keeps command execution off unless it is explicitly enabled', async () => {
     ctx.readOnly = false;
     expect(toolNames(await core('tools/list'))).not.toContain('exec_command');
+    expect(toolNames(await core('tools/list'))).not.toContain('power');
 
     ctx.caps = withCaps({ command: true });
     const names = toolNames(await core('tools/list'));
     expect(names).toContain('exec_command');
     expect(names).toContain('write_stdin');
+    expect(names).toContain('power');
   });
 
   it('drops find when exec_command can do the same job better', async () => {
@@ -1016,6 +1020,7 @@ describe('capability gating', () => {
     ctx.caps = withCaps({ command: true, search: true });
     const names = toolNames(await core('tools/list'));
     expect(names).toContain('exec_command');
+    expect(names).toContain('power');
     expect(names).not.toContain('find');
   });
 

--- a/test/power.test.ts
+++ b/test/power.test.ts
@@ -1,0 +1,162 @@
+import http from 'node:http';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { registerPowerTool, htmlToCleanMarkdown } from '../src/main/mcp/tools-power.js';
+import { fail, type SurfaceRegistrar, type ToolResult } from '../src/main/mcp/kernel.js';
+import { DEFAULT_CAPABILITIES } from '../src/shared/types.js';
+import { makeTempDir, removeTempDir } from './helpers.js';
+
+interface CapturedTool {
+  name: string;
+  handler: (args: any) => Promise<ToolResult>;
+}
+
+function powerRegistrar(options: { live?: boolean; exposed?: boolean } = {}): { reg: SurfaceRegistrar; tool: () => CapturedTool | null } {
+  const live = options.live ?? true;
+  const exposed = options.exposed ?? true;
+  const caps = { ...DEFAULT_CAPABILITIES, command: live };
+  const exposedCaps = { ...DEFAULT_CAPABILITIES, command: exposed };
+  let captured: CapturedTool | null = null;
+  const reg = {
+    ctx: { roots: [], caps, exposedCaps, readOnly: false },
+    caps,
+    exposedCaps,
+    sessionToolsLive: false,
+    sessionToolsExposed: false,
+    agentToolsLive: false,
+    agentToolsExposed: false,
+    findExposed: false,
+    register(name: string, _config: unknown, handler: (args: any) => Promise<ToolResult>) {
+      captured = { name, handler };
+    },
+    guarded(cap: keyof typeof caps, name: string, fn: () => Promise<ToolResult>) {
+      return caps[cap]
+        ? fn()
+        : Promise.resolve(fail(`TOOL_DISABLED: ${name} is disabled by the current Chat On Steroids permissions.`));
+    },
+    featureDisabled(feature: string) {
+      return fail(`FEATURE_DISABLED: ${feature}`);
+    },
+    registered() {
+      return captured ? [captured.name] : [];
+    }
+  } as unknown as SurfaceRegistrar;
+  return { reg, tool: () => captured };
+}
+
+async function invoke(action: Record<string, unknown>, options?: { live?: boolean; exposed?: boolean }): Promise<ToolResult> {
+  const fixture = powerRegistrar(options);
+  registerPowerTool(fixture.reg);
+  const tool = fixture.tool();
+  if (!tool) throw new Error('power tool was not registered');
+  return tool.handler({ action });
+}
+
+const textOf = (result: ToolResult): string =>
+  result.content.filter((part) => part.type === 'text').map((part) => (part as { text: string }).text).join('\n');
+
+const tempDirs: string[] = [];
+afterEach(async () => {
+  while (tempDirs.length) await removeTempDir(tempDirs.pop()!);
+});
+
+describe('Power Agent composite tool', () => {
+  it('adds no schema when Run commands was never exposed', () => {
+    const fixture = powerRegistrar({ live: false, exposed: false });
+    registerPowerTool(fixture.reg);
+    expect(fixture.tool()).toBeNull();
+  });
+
+  it('stays registered but fails closed after live command permission is revoked', async () => {
+    const result = await invoke({ type: 'system_info' }, { live: false, exposed: true });
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('TOOL_DISABLED');
+  });
+
+  it('returns bounded non-secret system facts', async () => {
+    const result = await invoke({ type: 'system_info' });
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      action: 'system_info',
+      platform: process.platform,
+      architecture: process.arch
+    });
+    expect(result.structuredContent).not.toHaveProperty('hostname');
+    expect(result.structuredContent).not.toHaveProperty('environment');
+  });
+
+  it('turns ordinary HTML into readable markdown without scripts', () => {
+    const markdown = htmlToCleanMarkdown(
+      '<html><body><h1>Hello</h1><script>secret()</script><p>Read <a href="https://example.com/x">this</a>.</p></body></html>'
+    );
+    expect(markdown).toContain('# Hello');
+    expect(markdown).toContain('[this](https://example.com/x)');
+    expect(markdown).not.toContain('secret()');
+  });
+
+  it('fetches HTTP(S) text without cookies or browser state', async () => {
+    const server = http.createServer((req, res) => {
+      expect(req.headers.cookie).toBeUndefined();
+      expect(req.headers.authorization).toBeUndefined();
+      res.setHeader('content-type', 'text/html; charset=utf-8');
+      res.end('<html><head><title>Power test</title></head><body><h1>Fetched</h1><p>clean body</p></body></html>');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('missing test server port');
+      const result = await invoke({
+        type: 'web_fetch',
+        url: `http://127.0.0.1:${address.port}/page`,
+        max_chars: 10_000,
+        timeout_seconds: 5
+      });
+      expect(result.isError).not.toBe(true);
+      expect(result.structuredContent).toMatchObject({ action: 'web_fetch', status: 200, title: 'Power test' });
+      expect(String(result.structuredContent?.markdown)).toContain('# Fetched');
+      expect(String(result.structuredContent?.markdown)).toContain('clean body');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  it('supports explicit system-wide write, read and list under command permission', async () => {
+    const base = await makeTempDir('clf-power-');
+    tempDirs.push(base);
+    const target = path.join(base, 'outside-roots.txt');
+
+    const write = await invoke({
+      type: 'fs_system_write',
+      path: target,
+      content: 'power-file\n',
+      mode: 'create',
+      create_parents: false
+    });
+    expect(write.isError).not.toBe(true);
+    expect(await fs.readFile(target, 'utf8')).toBe('power-file\n');
+
+    const read = await invoke({ type: 'fs_system_read', path: target, max_chars: 1_000 });
+    expect(read.isError).not.toBe(true);
+    expect(read.structuredContent).toMatchObject({ action: 'fs_system_read', path: target, text: 'power-file\n' });
+
+    const list = await invoke({ type: 'fs_system_list', path: base, limit: 20 });
+    expect(list.isError).not.toBe(true);
+    expect(JSON.stringify(list.structuredContent)).toContain('outside-roots.txt');
+  });
+
+  it('runs a bounded one-shot system shell command', async () => {
+    const base = await makeTempDir('clf-power-exec-');
+    tempDirs.push(base);
+    const result = await invoke({
+      type: 'system_exec',
+      script: process.platform === 'win32' ? "Write-Output 'power-exec-ok'" : "printf '%s\\n' power-exec-ok",
+      shell: process.platform === 'win32' ? 'powershell' : 'sh',
+      cwd: base,
+      timeout_seconds: 10
+    });
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toMatchObject({ action: 'system_exec', exit_code: 0, timed_out: false });
+    expect(String(result.structuredContent?.stdout)).toContain('power-exec-ok');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2 with a narrow implementation on top of current v2.0.2 instead of reviving the earlier all-in-one Mission Control / goals contribution.

Adds one composite `power` tool to Core behind the existing **Run commands** permission. It provides structured actions for:

- `open_url` — open an HTTP(S) URL in the default browser or Chrome / Edge / Firefox / Brave;
- `web_fetch` — bounded credential-free HTTP(S) fetch with readable Markdown/text extraction;
- `launch_app` — shell-free application launch with explicit argv;
- `process_list` — bounded PID/name/window-title/memory snapshot;
- `process_kill` — terminate by PID or exact process name, with self/parent protection and ambiguity refusal;
- `system_exec` — bounded one-shot PowerShell/CMD/sh execution;
- `fs_system_list`, `fs_system_read`, `fs_system_write` — explicit absolute-path host filesystem operations outside approved roots;
- `system_info` — bounded non-secret host facts.

## Permission / security model

This deliberately does **not** add a new privilege bit. Every `power` call is guarded by the same live `command` capability as `exec_command`, and the schema is absent if Run commands was never exposed on the endpoint.

That matters especially for `fs_system_*`: these actions intentionally bypass the approved-root filesystem sandbox, but only because Run commands already has equivalent host authority (a command can read/write the same paths today). Users who do not grant Run commands never receive these actions.

Additional boundaries:

- `open_url` accepts only `http://` and `https://` and refuses embedded URL credentials;
- `web_fetch` sends no browser cookies, authorization headers, or stored browser state; follows at most five HTTP(S) redirects; caps response bytes and returned characters;
- process termination refuses the Chat On Steroids process and its direct parent;
- `launch_app` uses direct argv instead of shell interpolation;
- `system_exec` is output/timeout/script bounded; `exec_command` remains the recommended path for long-running or interactive sessions;
- system reads reject binary files and cap file size/output; writes are size-bounded and make create/overwrite/append explicit.

## Surface design

Issue #2 originally proposed several permanently exposed tool names. The current repository deliberately caps discovery size and has since retired that style. Following the newer Power Platform direction, these operations live under **one composite `power` schema**, so the feature does not recreate a large flat tool surface.

Core therefore moves from a maximum of 7 live schemas to 8 when Run commands is enabled; `find` remains mutually exclusive with the exec pair and `power` is command-only. The public tool-surface documentation and exact discovery-budget tests are updated in the same change.

## Tests

Adds focused tests for:

- monotonic exposure + fail-closed live permission revocation;
- non-secret `system_info`;
- HTML-to-readable-Markdown extraction;
- real loopback `web_fetch` with proof that no cookie/auth state is sent;
- explicit absolute-path system write/read/list;
- bounded one-shot `system_exec` on Windows/macOS/Linux;
- portable Core surface parity and the updated eight-schema discovery budget.

### Verification

The exact final source tree (`fcb29a4f9e2011d2a02efdee28dfd35b189dd336`) passed the repository's full `npm run verify:ci` matrix on:

- Windows x64
- macOS arm64
- Linux x64

Validation run: https://github.com/David-T-Campos/chat-on-steroids/actions/runs/33059697694

After that run the branch was squashed to one clean commit directly on v2.0.2 without changing the tree hash. Final head: `7fce3f93aff54e89cd5361ebec3ccfd437f320f0`.

The PR is intentionally scoped to issue #2 and does not include the goals, external provider orchestration, Mission Control UI, persistent memory, audio, archive, or code-intelligence features from the earlier broad Power Agent branch.