### PR TITLE
feat: add Claude-style /loop mode

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -24,7 +24,7 @@ const PORTS = [8765, 8766, 8767, 8768, 8769];
 const HELLO_TIMEOUT_MS = 1200;
 const REQUEST_TIMEOUT_MS = 10_000;
 /** Bumped only when the request/response shape changes; the app compares it. */
-const BRIDGE_PROTOCOL = 8;
+const BRIDGE_PROTOCOL = 9;
 
 /**
  * Journal caps. The byte figure is what actually matters — chrome.storage.session has a
@@ -1947,6 +1947,40 @@ const HANDLERS = {
     });
     return ownsDocument(source) ? result : { ok: false, error: 'stale_document' };
   },
+  /** Claim one due /loop prompt only for the document that owns this exact chat. */
+  async loop_due(message, _sender, source) {
+    await load();
+    if (!ownsDocument(source)) return { ok: false, error: 'stale_document' };
+    const conversationId = cleanConversationId(message.conversationId);
+    if (!conversationId) return { ok: false, status: 400, error: 'bad_conversation_id' };
+    await noteTabConversation(source, conversationId);
+    if (!ownsDocument(source)) return { ok: false, error: 'stale_document' };
+    if (!(await deliverConversationJournal(conversationId))) {
+      return { ok: false, status: 503, error: 'transcript_not_delivered', retryable: true };
+    }
+    const result = await call('/loop/due', {
+      method: 'POST',
+      body: JSON.stringify({ conversationId, clientId: String(source.tab) })
+    });
+    return ownsDocument(source) ? result : { ok: false, error: 'stale_document' };
+  },
+  async loop_ack(message, _sender, source) {
+    await load();
+    if (!ownsDocument(source)) return { ok: false, error: 'stale_document' };
+    const conversationId = cleanConversationId(message.conversationId);
+    if (!conversationId) return { ok: false, status: 400, error: 'bad_conversation_id' };
+    return call('/loop/ack', {
+      method: 'POST',
+      body: JSON.stringify({ conversationId, token: String(message.token || ''), sent: message.sent === true })
+    });
+  },
+  async loop_escape(message, _sender, source) {
+    await load();
+    if (!ownsDocument(source)) return { ok: false, error: 'stale_document' };
+    const conversationId = cleanConversationId(message.conversationId);
+    if (!conversationId) return { ok: false, status: 400, error: 'bad_conversation_id' };
+    return call('/loop/escape', { method: 'POST', body: JSON.stringify({ conversationId }) });
+  },
   /**
    * The goal loop: this page saw its turn genuinely finish and wants the next user message.
    *
@@ -2201,6 +2235,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     'closed',
     'compact',
     'auto_compact_claim',
+    'loop_due',
+    'loop_ack',
+    'loop_escape',
     'goal_draft',
     'goal_focus',
     'goal_ack',

--- a/extension/content.js
+++ b/extension/content.js
@@ -628,6 +628,7 @@
   let goalError = '';
   /** Guards the settle watch and the send, so one finished turn produces one message. */
   let goalBusy = false;
+  let loopBusy = false;
   /** When this tab started trying to type a ready draft, so a held composer eventually gives up. */
   let goalTypingSince = 0;
   /** Terminal Goal card the user dismissed. Keyed to its chat + finished turn across repaints. */
@@ -7492,6 +7493,48 @@
   }
 
   /**
+   * Deliver one app-owned scheduled /loop iteration through the same conservative composer
+   * boundary as Goal: never type over the user, never race a live turn, and remember the
+   * irreversible send before the fallible ACK hop.
+   */
+  async function maybeSendLoopDue() {
+    if (!conversationId || loopBusy || goalBusy || goalDraft || compactCapture || nativeBusy || (job && job.busy)) return;
+    if (generating || CLF_DOM.generating()) return;
+    const forId = conversationId;
+    const forEpoch = epoch;
+    loopBusy = true;
+    try {
+      const reply = await ask({ type: 'loop_due', conversationId: forId });
+      if (!alive || conversationId !== forId || epoch !== forEpoch) return;
+      const delivery = reply && reply.ok === true && reply.data ? reply.data.delivery : null;
+      if (!delivery || !delivery.token || !delivery.prompt) return;
+      const token = String(delivery.token);
+      if (goalWasSpent(forId, token)) {
+        await ask({ type: 'loop_ack', conversationId: forId, token, sent: true }).catch(() => undefined);
+        return;
+      }
+      if (generating || CLF_DOM.generating() || goalBusy || goalDraft || compactCapture || nativeBusy || (job && job.busy)) {
+        await ask({ type: 'loop_ack', conversationId: forId, token, sent: false }).catch(() => undefined);
+        return;
+      }
+      if (!CLF_DOM.insertPrompt(String(delivery.prompt))) {
+        await ask({ type: 'loop_ack', conversationId: forId, token, sent: false }).catch(() => undefined);
+        return;
+      }
+      await sleep(200);
+      const sent = await CLF_DOM.send();
+      if (!sent) {
+        await ask({ type: 'loop_ack', conversationId: forId, token, sent: false }).catch(() => undefined);
+        return;
+      }
+      rememberGoalSpent(forId, token);
+      await ask({ type: 'loop_ack', conversationId: forId, token, sent: true }).catch(() => undefined);
+    } finally {
+      loopBusy = false;
+    }
+  }
+
+  /**
    * Types a ready draft into the composer and sends it, once.
    *
    * Called from the activity pull, because that is where the draft arrives. Every exit
@@ -8291,6 +8334,10 @@
     // pagehide also happens on reload, so closing here corrupts live turn identity.
   };
   listen(window, 'pagehide', notePageHide);
+  listen(window, 'keydown', (event) => {
+    if (TEST_MODE || event.key !== 'Escape' || !conversationId || generating || CLF_DOM.generating()) return;
+    void ask({ type: 'loop_escape', conversationId }).catch(() => undefined);
+  }, true);
 
   function every(ms, fn) {
     const timer = setInterval(() => {
@@ -8537,6 +8584,7 @@
     };
     listen(document, 'visibilitychange', visibilityChanged);
   }
+  every(2000, () => { void maybeSendLoopDue(); });
   every(STATUS_MS, checkStatus);
 
   // Only now, with every binding above initialised, does this recorder answer for itself.

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -37,6 +37,7 @@ import {
   setGoalObjectiveNow,
   startGoalDraft
 } from './goal.js';
+import { ackLoopDelivery, cancelDynamicWakeups, claimDueLoop } from './loop.js';
 import { logInfo, logWarn } from './logger.js';
 import {
   closeConversation,
@@ -1665,6 +1666,54 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
       },
       origin
     );
+  }
+
+  /** Claim at most one due /loop iteration for this exact conversation. */
+  if (route === '/loop/due' && req.method === 'POST') {
+    let body: Record<string, unknown>;
+    try {
+      body = (await readBody(req)) as Record<string, unknown>;
+    } catch (err) {
+      if ((err as Error).message === 'body_too_large') return tooLarge(res, origin);
+      return json(res, 400, { error: 'bad_request' }, origin);
+    }
+    const id = conversationId(body['conversationId']);
+    const clientId = typeof body['clientId'] === 'string' ? body['clientId'].slice(0, 100) : '';
+    if (!id) return json(res, 400, { error: 'bad_conversation_id' }, origin);
+    const delivery = await claimDueLoop(id, clientId);
+    return json(res, 200, { delivery }, origin);
+  }
+
+  /** A loop prompt crossed (or failed to cross) the browser's irreversible send boundary. */
+  if (route === '/loop/ack' && req.method === 'POST') {
+    let body: Record<string, unknown>;
+    try {
+      body = (await readBody(req)) as Record<string, unknown>;
+    } catch (err) {
+      if ((err as Error).message === 'body_too_large') return tooLarge(res, origin);
+      return json(res, 400, { error: 'bad_request' }, origin);
+    }
+    const id = conversationId(body['conversationId']);
+    const token = typeof body['token'] === 'string' ? body['token'].slice(0, 100) : '';
+    const sent = body['sent'] === true;
+    if (!id || !token) return json(res, 400, { error: 'bad_loop_ack' }, origin);
+    const accepted = await ackLoopDelivery(id, token, sent);
+    return accepted ? json(res, 200, { accepted: true }, origin) : json(res, 404, { error: 'no_such_loop_delivery' }, origin);
+  }
+
+  /** Esc while a self-paced loop is waiting clears pending dynamic wakeups, not fixed loops. */
+  if (route === '/loop/escape' && req.method === 'POST') {
+    let body: Record<string, unknown>;
+    try {
+      body = (await readBody(req)) as Record<string, unknown>;
+    } catch (err) {
+      if ((err as Error).message === 'body_too_large') return tooLarge(res, origin);
+      return json(res, 400, { error: 'bad_request' }, origin);
+    }
+    const id = conversationId(body['conversationId']);
+    if (!id) return json(res, 400, { error: 'bad_conversation_id' }, origin);
+    const cancelled = await cancelDynamicWakeups(id);
+    return json(res, 200, { cancelled }, origin);
   }
 
   /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,6 +38,7 @@ import { flushDurable, initDurableStore, readDurable, writeDurableNow, writeDura
 import { restoreRequestCorrelations } from './session/correlation.js';
 import { stopComputerHelper } from './computer/index.js';
 import { GOAL_OBJECTIVES_STATE, restoreGoalObjectives, type GoalObjectivesSnapshot } from './goal.js';
+import { LOOPS_STATE, restoreLoops, type LoopSnapshot } from './loop.js';
 import {
   CONTINUATIONS_STATE,
   restoreContinuations,
@@ -233,6 +234,9 @@ void app.whenReady().then(async () => {
   const savedGoalObjectives = await readDurable<GoalObjectivesSnapshot>(GOAL_OBJECTIVES_STATE);
   if (windowActivation.isDisabled()) return;
   restoreGoalObjectives(savedGoalObjectives);
+  const savedLoops = await readDurable<LoopSnapshot>(LOOPS_STATE);
+  if (windowActivation.isDisabled()) return;
+  restoreLoops(savedLoops);
   // Request ownership must exist before either side of the bridge can race in. A request id
   // that was proved yesterday remains the same workflow today even if its ChatGPT tab closed.
   await restoreRequestCorrelations();

--- a/src/main/loop.ts
+++ b/src/main/loop.ts
@@ -1,0 +1,559 @@
+import { randomBytes } from 'node:crypto';
+import { writeDurableNow, writeDurableSoon } from './durable.js';
+import { logWarn } from './logger.js';
+import { currentCall } from './mcp/call-context.js';
+import { IDENTITY_EVIDENCE_MS } from './mcp/kernel.js';
+import { awaitFreshCallOrigin } from './session/recorder.js';
+import { findSessionByConversation, readRecentEvents } from './session/store.js';
+
+/** Durable state for the clean-room Claude Code compatible /loop implementation. */
+export const LOOPS_STATE = 'loops';
+
+const MAX_TASKS_PER_SESSION = 50;
+const MAX_PROMPT_CHARS = 12_000;
+const MAX_REASON_CHARS = 500;
+const LOOP_LIFETIME_MS = 7 * 24 * 60 * 60_000;
+const MIN_FIXED_INTERVAL_MS = 60_000;
+const MIN_DYNAMIC_DELAY_SECONDS = 60;
+const MAX_DYNAMIC_DELAY_SECONDS = 60 * 60;
+const DYNAMIC_FALLBACK_MS = 20 * 60_000;
+const DELIVERY_LEASE_MS = 2 * 60_000;
+const RECENT_USER_MESSAGES = 48;
+
+export type LoopMode = 'fixed' | 'dynamic';
+export type LoopWakeKind = 'scheduled' | 'fallback';
+
+export interface ParsedLoopInput {
+  mode: LoopMode;
+  prompt: string;
+  intervalMs: number | null;
+  requestedInterval: string | null;
+  bare: boolean;
+}
+
+interface LoopLease {
+  token: string;
+  clientId: string;
+  expiresAt: number;
+  kind: LoopWakeKind;
+  final?: boolean;
+}
+
+export interface LoopTask {
+  id: string;
+  sessionId: string;
+  sourceSeq: number;
+  mode: LoopMode;
+  prompt: string;
+  requestedInterval: string | null;
+  intervalMs: number | null;
+  createdAt: number;
+  expiresAt: number;
+  nextWakeAt: number | null;
+  nextWakeKind: LoopWakeKind | null;
+  stopAt: number | null;
+  lastReason: string;
+  runCount: number;
+  lastRunAt: number | null;
+  lease: LoopLease | null;
+}
+
+export interface LoopSnapshot {
+  version: 1;
+  savedAt: number;
+  tasks: LoopTask[];
+}
+
+export interface LoopDelivery {
+  token: string;
+  conversationId: string;
+  loopId: string;
+  mode: LoopMode;
+  prompt: string;
+}
+
+const tasksBySession = new Map<string, Map<string, LoopTask>>();
+
+const UNIT_MS: Record<string, number> = {
+  s: 1_000,
+  sec: 1_000,
+  secs: 1_000,
+  second: 1_000,
+  seconds: 1_000,
+  m: 60_000,
+  min: 60_000,
+  mins: 60_000,
+  minute: 60_000,
+  minutes: 60_000,
+  h: 60 * 60_000,
+  hr: 60 * 60_000,
+  hrs: 60 * 60_000,
+  hour: 60 * 60_000,
+  hours: 60 * 60_000,
+  d: 24 * 60 * 60_000,
+  day: 24 * 60 * 60_000,
+  days: 24 * 60 * 60_000
+};
+
+function cleanText(value: string, max = MAX_PROMPT_CHARS): string {
+  return String(value ?? '').replace(/\u0000/g, '').trim().slice(0, max);
+}
+
+function normaliseFixedInterval(ms: number): number {
+  // Claude Code's fixed scheduler is cron-backed and therefore has one-minute granularity.
+  // Keep that user-visible contract even though this app uses a local interval anchor instead
+  // of exposing another cron schema.
+  return Math.max(MIN_FIXED_INTERVAL_MS, Math.ceil(ms / 60_000) * 60_000);
+}
+
+function parseInterval(amountText: string, unitText: string): number | null {
+  const amount = Number.parseInt(amountText, 10);
+  const unit = unitText.toLowerCase();
+  if (!Number.isSafeInteger(amount) || amount <= 0 || !UNIT_MS[unit]) return null;
+  const raw = amount * UNIT_MS[unit];
+  if (!Number.isSafeInteger(raw) || raw <= 0) return null;
+  return normaliseFixedInterval(raw);
+}
+
+/**
+ * Parse the public /loop grammar used by current Claude Code.
+ *
+ * Priority is intentional: a leading compact token wins, then a trailing time-valued
+ * "every" clause, otherwise the prompt is dynamic/self-paced. A bare /loop, or a fixed
+ * interval with no prompt, uses the modern autonomous-maintenance task.
+ */
+export function parseLoopInput(rawInput: string): ParsedLoopInput {
+  let input = cleanText(rawInput);
+  input = input.replace(/^\/(?:loop|proactive)(?=\s|$)/i, '').trim();
+  if (!input) {
+    return { mode: 'dynamic', prompt: autonomousLoopPrompt(), intervalMs: null, requestedInterval: null, bare: true };
+  }
+
+  const leading = input.match(/^(\d+)([smhd])(?:\s+|$)([\s\S]*)$/i);
+  if (leading) {
+    const intervalMs = parseInterval(leading[1]!, leading[2]!);
+    const suppliedPrompt = cleanText(leading[3] ?? '');
+    if (!intervalMs) throw new Error('LOOP_BAD_INTERVAL: use a positive interval such as 5m, 2h, or 1d');
+    const bare = !suppliedPrompt;
+    return {
+      mode: 'fixed',
+      prompt: bare ? autonomousLoopPrompt() : suppliedPrompt,
+      intervalMs,
+      requestedInterval: `${leading[1]}${leading[2]!.toLowerCase()}`,
+      bare
+    };
+  }
+
+  const bareEvery = input.match(/^every\s+(\d+)\s*(seconds?|secs?|sec|s|minutes?|mins?|min|m|hours?|hrs?|hr|h|days?|d)\s*$/i);
+  if (bareEvery) {
+    const intervalMs = parseInterval(bareEvery[1]!, bareEvery[2]!);
+    if (!intervalMs) throw new Error('LOOP_BAD_INTERVAL: use a positive interval such as 5m, 2h, or 1d');
+    return {
+      mode: 'fixed',
+      prompt: autonomousLoopPrompt(),
+      intervalMs,
+      requestedInterval: `every ${bareEvery[1]} ${bareEvery[2]!.toLowerCase()}`,
+      bare: true
+    };
+  }
+
+  const trailing = input.match(/^(.*?)(?:\s+)every\s+(\d+)\s*(seconds?|secs?|sec|s|minutes?|mins?|min|m|hours?|hrs?|hr|h|days?|d)\s*$/i);
+  if (trailing) {
+    const prompt = cleanText(trailing[1] ?? '');
+    const intervalMs = parseInterval(trailing[2]!, trailing[3]!);
+    if (!prompt) throw new Error('LOOP_USAGE: /loop [interval] <prompt>');
+    if (!intervalMs) throw new Error('LOOP_BAD_INTERVAL: use a positive interval such as 5m, 2h, or 1d');
+    return {
+      mode: 'fixed',
+      prompt,
+      intervalMs,
+      requestedInterval: `${trailing[2]} ${trailing[3]!.toLowerCase()}`,
+      bare: false
+    };
+  }
+
+  return { mode: 'dynamic', prompt: input, intervalMs: null, requestedInterval: null, bare: false };
+}
+
+function autonomousLoopPrompt(): string {
+  return (
+    'Autonomous maintenance loop. First, if an approved project root contains .claude/loop.md, read it and treat its current contents as the task for this iteration. If no project-level file is available, use ~/.claude/loop.md when it is accessible through an approved root; project-level instructions win. Re-read the selected file on each iteration so edits take effect. ' +
+    'Otherwise continue unfinished work already established in this conversation; if that is complete, tend the current branch or pull request by addressing concrete CI failures, review comments, or merge conflicts. ' +
+    'Only when there is no such work should you perform small, reversible cleanup or maintenance. Do not invent a new project or expand scope merely to stay busy.'
+  );
+}
+
+function sessionTasks(sessionId: string, create = false): Map<string, LoopTask> | null {
+  let tasks = tasksBySession.get(sessionId) ?? null;
+  if (!tasks && create) {
+    tasks = new Map();
+    tasksBySession.set(sessionId, tasks);
+  }
+  return tasks;
+}
+
+function snapshot(): LoopSnapshot {
+  const tasks: LoopTask[] = [];
+  for (const bucket of tasksBySession.values()) {
+    for (const task of bucket.values()) tasks.push({ ...task, lease: null });
+  }
+  return { version: 1, savedAt: Date.now(), tasks };
+}
+
+function persistSoon(): void {
+  writeDurableSoon(LOOPS_STATE, snapshot());
+}
+
+async function persistNow(): Promise<void> {
+  await writeDurableNow(LOOPS_STATE, snapshot());
+}
+
+function validTask(value: unknown): value is LoopTask {
+  if (!value || typeof value !== 'object') return false;
+  const raw = value as Partial<LoopTask>;
+  return (
+    typeof raw.id === 'string' && /^[0-9a-f]{8}$/i.test(raw.id) &&
+    typeof raw.sessionId === 'string' && raw.sessionId.length >= 8 && raw.sessionId.length <= 64 &&
+    Number.isSafeInteger(raw.sourceSeq) && (raw.sourceSeq ?? -1) >= 0 &&
+    (raw.mode === 'fixed' || raw.mode === 'dynamic') &&
+    typeof raw.prompt === 'string' && raw.prompt.length <= MAX_PROMPT_CHARS &&
+    typeof raw.createdAt === 'number' && Number.isFinite(raw.createdAt) &&
+    typeof raw.expiresAt === 'number' && Number.isFinite(raw.expiresAt) &&
+    (raw.intervalMs === null || (typeof raw.intervalMs === 'number' && Number.isFinite(raw.intervalMs) && raw.intervalMs >= MIN_FIXED_INTERVAL_MS)) &&
+    (raw.nextWakeAt === null || (typeof raw.nextWakeAt === 'number' && Number.isFinite(raw.nextWakeAt))) &&
+    (raw.nextWakeKind === null || raw.nextWakeKind === 'scheduled' || raw.nextWakeKind === 'fallback') &&
+    (raw.stopAt === null || (typeof raw.stopAt === 'number' && Number.isFinite(raw.stopAt))) &&
+    typeof raw.runCount === 'number' && Number.isSafeInteger(raw.runCount) && raw.runCount >= 0
+  );
+}
+
+export function restoreLoops(saved: LoopSnapshot | null, now = Date.now()): void {
+  tasksBySession.clear();
+  if (!saved || saved.version !== 1 || !Array.isArray(saved.tasks)) return;
+  for (const candidate of saved.tasks) {
+    const expiredWithoutFinalFixedFire = candidate.expiresAt <= now && (candidate.mode !== 'fixed' || candidate.nextWakeAt === null);
+    if (!validTask(candidate) || expiredWithoutFinalFixedFire || (candidate.stopAt !== null && candidate.stopAt <= now)) continue;
+    const task: LoopTask = {
+      ...candidate,
+      prompt: cleanText(candidate.prompt),
+      requestedInterval: typeof candidate.requestedInterval === 'string' ? cleanText(candidate.requestedInterval, 80) : null,
+      lastReason: typeof candidate.lastReason === 'string' ? cleanText(candidate.lastReason, MAX_REASON_CHARS) : '',
+      lastRunAt: typeof candidate.lastRunAt === 'number' && Number.isFinite(candidate.lastRunAt) ? candidate.lastRunAt : null,
+      lease: null
+    };
+    sessionTasks(task.sessionId, true)!.set(task.id, task);
+  }
+}
+
+export function snapshotLoops(): LoopSnapshot {
+  return snapshot();
+}
+
+async function currentConversation(tool = 'session'): Promise<string> {
+  const call = currentCall();
+  if (!call) throw new Error('LOOP_CALLER_REQUIRED: loop control must come from a ChatGPT MCP call');
+  if (call.caller.conversationId) return call.caller.conversationId;
+  if (!call.caller.requestId) throw new Error('LOOP_CALLER_REQUIRED: this call has no request identity');
+  const conversationId = await awaitFreshCallOrigin(tool, call.startedAt, IDENTITY_EVIDENCE_MS, {
+    requestId: call.caller.requestId
+  });
+  if (!conversationId) throw new Error('LOOP_CALLER_REQUIRED: could not prove which ChatGPT conversation owns this loop call');
+  call.caller.conversationId = conversationId;
+  return conversationId;
+}
+
+async function currentSession(tool = 'session'): Promise<{ conversationId: string; sessionId: string }> {
+  const conversationId = await currentConversation(tool);
+  const summary = await findSessionByConversation(conversationId, { requireUnique: true });
+  if (!summary) throw new Error('LOOP_SESSION_REQUIRED: this conversation has no unique recorded local session');
+  return { conversationId, sessionId: summary.id };
+}
+
+async function latestLoopDirective(sessionId: string): Promise<{ seq: number; text: string } | null> {
+  const events = await readRecentEvents(sessionId, RECENT_USER_MESSAGES, { kinds: ['user_message'] });
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (!event || event.kind !== 'user_message') continue;
+    const text = event.message.text.trim();
+    if (/^\/(?:loop|proactive)(?:\s|$)/i.test(text)) return { seq: event.seq, text };
+  }
+  return null;
+}
+
+function newLoopId(existing: Map<string, LoopTask>): string {
+  for (;;) {
+    const id = randomBytes(4).toString('hex');
+    if (!existing.has(id)) return id;
+  }
+}
+
+function humanInterval(ms: number): string {
+  if (ms % (24 * 60 * 60_000) === 0) return `every ${ms / (24 * 60 * 60_000)} day(s)`;
+  if (ms % (60 * 60_000) === 0) return `every ${ms / (60 * 60_000)} hour(s)`;
+  return `every ${ms / 60_000} minute(s)`;
+}
+
+export async function startLoopFromCurrentCall(input = ''): Promise<string> {
+  const { sessionId } = await currentSession();
+  const directive = await latestLoopDirective(sessionId);
+  if (!directive) throw new Error('LOOP_DIRECTIVE_REQUIRED: start a loop from a user message beginning /loop or /proactive');
+
+  const bucket = sessionTasks(sessionId, true)!;
+  for (const task of bucket.values()) {
+    if (task.sourceSeq === directive.seq) return loopStartedText(task, true);
+  }
+  if (bucket.size >= MAX_TASKS_PER_SESSION) throw new Error(`LOOP_LIMIT: this session already has ${MAX_TASKS_PER_SESSION} loop tasks`);
+
+  // The recorder is authoritative. The optional model field is accepted only as a diagnostic
+  // cross-check; it never gets to replace or broaden what the user actually typed.
+  const supplied = cleanText(input);
+  const recordedTail = directive.text.replace(/^\/(?:loop|proactive)(?=\s|$)/i, '').trim();
+  if (supplied && supplied !== directive.text && supplied !== recordedTail) {
+    throw new Error('LOOP_INPUT_MISMATCH: loop_start input does not match the latest recorded /loop user message');
+  }
+
+  const parsed = parseLoopInput(directive.text);
+  const now = Date.now();
+  const task: LoopTask = {
+    id: newLoopId(bucket),
+    sessionId,
+    sourceSeq: directive.seq,
+    mode: parsed.mode,
+    prompt: parsed.prompt,
+    requestedInterval: parsed.requestedInterval,
+    intervalMs: parsed.intervalMs,
+    createdAt: now,
+    expiresAt: now + LOOP_LIFETIME_MS,
+    nextWakeAt: parsed.mode === 'fixed' ? now + parsed.intervalMs! : now + DYNAMIC_FALLBACK_MS,
+    nextWakeKind: parsed.mode === 'fixed' ? 'scheduled' : 'fallback',
+    stopAt: null,
+    lastReason: '',
+    runCount: 0,
+    lastRunAt: null,
+    lease: null
+  };
+  bucket.set(task.id, task);
+  await persistNow();
+  return loopStartedText(task, false);
+}
+
+function loopStartedText(task: LoopTask, existing: boolean): string {
+  const prefix = existing ? 'Loop already scheduled for this exact /loop turn.' : 'Loop scheduled.';
+  if (task.mode === 'fixed') {
+    return (
+      `${prefix}\nloop_id: ${task.id}\nmode: fixed\ncadence: ${humanInterval(task.intervalMs!)}\nauto_expires: 7 days\n` +
+      `task: ${task.prompt}\n\nExecute the task once now. Do not wait for the first scheduled fire and do not create a second loop for this same user turn.`
+    );
+  }
+  return (
+    `${prefix}\nloop_id: ${task.id}\nmode: dynamic/self-paced\nauto_expires: 7 days\ntask: ${task.prompt}\n\n` +
+    `Execute the task once now. At the end of this iteration, call session action=loop_wakeup with loop_id=${task.id}, delay_seconds between 60 and 3600, and a short reason for the chosen delay. ` +
+    `If no further iteration is useful, call session action=loop_stop instead. The runtime keeps one ~20 minute fallback heartbeat if an iteration forgets to do either.`
+  );
+}
+
+function ownTask(bucket: Map<string, LoopTask> | null, loopId: string): LoopTask {
+  const id = cleanText(loopId, 20).toLowerCase();
+  const task = bucket?.get(id) ?? null;
+  if (!task) throw new Error(`LOOP_NOT_FOUND: no active loop ${id || '(missing id)'} belongs to this session`);
+  return task;
+}
+
+export async function wakeLoopFromCurrentCall(loopId: string, delaySeconds: number, reason = ''): Promise<string> {
+  const { sessionId } = await currentSession();
+  const task = ownTask(sessionTasks(sessionId), loopId);
+  if (task.mode !== 'dynamic') throw new Error('LOOP_FIXED_CADENCE: fixed loops are paced by their interval; use loop_cancel to end one');
+  if (!Number.isInteger(delaySeconds) || delaySeconds < MIN_DYNAMIC_DELAY_SECONDS || delaySeconds > MAX_DYNAMIC_DELAY_SECONDS) {
+    throw new Error('LOOP_BAD_DELAY: dynamic wakeups must be 60 to 3600 seconds in the future');
+  }
+  const now = Date.now();
+  task.nextWakeAt = now + delaySeconds * 1000;
+  task.nextWakeKind = 'scheduled';
+  task.stopAt = null;
+  task.lastReason = cleanText(reason, MAX_REASON_CHARS);
+  task.lease = null;
+  await persistNow();
+  return `Loop ${task.id} will wake in ${delaySeconds} seconds.${task.lastReason ? ` Reason: ${task.lastReason}` : ''}`;
+}
+
+export async function stopLoopFromCurrentCall(loopId: string): Promise<string> {
+  const { sessionId } = await currentSession();
+  const bucket = sessionTasks(sessionId);
+  const task = ownTask(bucket, loopId);
+  bucket!.delete(task.id);
+  if (bucket!.size === 0) tasksBySession.delete(sessionId);
+  await persistNow();
+  return `Loop ${task.id} stopped.`;
+}
+
+export async function cancelLoopFromCurrentCall(loopId: string): Promise<string> {
+  return stopLoopFromCurrentCall(loopId);
+}
+
+export async function listLoopsForCurrentCall(now = Date.now()): Promise<string> {
+  const { sessionId } = await currentSession();
+  cleanupSession(sessionId, now);
+  const bucket = sessionTasks(sessionId);
+  if (!bucket || bucket.size === 0) return 'No active loop tasks in this session.';
+  return [...bucket.values()]
+    .sort((a, b) => a.createdAt - b.createdAt)
+    .map((task) => {
+      const next = task.nextWakeAt === null ? 'none' : new Date(task.nextWakeAt).toISOString();
+      return `${task.id}  ${task.mode}  next=${next}  runs=${task.runCount}  task=${task.prompt.slice(0, 180)}`;
+    })
+    .join('\n');
+}
+
+function cleanupSession(sessionId: string, now: number): void {
+  const bucket = sessionTasks(sessionId);
+  if (!bucket) return;
+  let changed = false;
+  for (const [id, task] of bucket) {
+    const expiredWithoutFinalFixedFire = task.expiresAt <= now && (task.mode !== 'fixed' || task.nextWakeAt === null);
+    if (expiredWithoutFinalFixedFire || (task.stopAt !== null && task.stopAt <= now)) {
+      bucket.delete(id);
+      changed = true;
+      continue;
+    }
+    if (task.lease && task.lease.expiresAt <= now) {
+      task.lease = null;
+      changed = true;
+    }
+  }
+  if (bucket.size === 0) tasksBySession.delete(sessionId);
+  if (changed) persistSoon();
+}
+
+function dueTask(sessionId: string, now: number): LoopTask | null {
+  cleanupSession(sessionId, now);
+  const bucket = sessionTasks(sessionId);
+  if (!bucket) return null;
+  let due: LoopTask | null = null;
+  for (const task of bucket.values()) {
+    if (task.lease || task.nextWakeAt === null || task.nextWakeAt > now) continue;
+    if (!due || task.nextWakeAt < due.nextWakeAt!) due = task;
+  }
+  return due;
+}
+
+function iterationPrompt(task: LoopTask, kind: LoopWakeKind): string {
+  const head = `[Chat On Steroids /loop iteration ${task.id}]`;
+  if (task.mode === 'fixed') {
+    return `${head}\nRe-run the scheduled task now. This is an existing loop iteration; do not create another loop.\n\nTask:\n${task.prompt}`;
+  }
+  const fallback = kind === 'fallback' ? ' This wake is the runtime fallback because the previous iteration did not explicitly schedule its next wake.' : '';
+  return (
+    `${head}\nRun the self-paced task again.${fallback}\n\nTask:\n${task.prompt}\n\n` +
+    `Before this iteration ends, call session action=loop_wakeup with loop_id=${task.id}, delay_seconds from 60 to 3600 and a short reason, or call session action=loop_stop if the loop should end. ` +
+    'Choose the delay from the observed state; do not spin rapidly just to poll.'
+  );
+}
+
+export async function claimDueLoop(conversationId: string, clientId: string, now = Date.now()): Promise<LoopDelivery | null> {
+  const summary = await findSessionByConversation(conversationId, { requireUnique: true });
+  if (!summary) return null;
+  const task = dueTask(summary.id, now);
+  if (!task) return null;
+  const kind = task.nextWakeKind ?? 'scheduled';
+  const token = randomBytes(16).toString('hex');
+  task.lease = {
+    token,
+    clientId: cleanText(clientId, 100),
+    expiresAt: now + DELIVERY_LEASE_MS,
+    kind,
+    final: task.mode === 'fixed' && task.expiresAt <= now
+  };
+  persistSoon();
+  return {
+    token,
+    conversationId,
+    loopId: task.id,
+    mode: task.mode,
+    prompt: iterationPrompt(task, kind)
+  };
+}
+
+function nextFixedWake(task: LoopTask, now: number): number {
+  const interval = task.intervalMs!;
+  const elapsed = Math.max(0, now - task.createdAt);
+  return task.createdAt + (Math.floor(elapsed / interval) + 1) * interval;
+}
+
+export async function ackLoopDelivery(conversationId: string, token: string, sent: boolean, now = Date.now()): Promise<boolean> {
+  const summary = await findSessionByConversation(conversationId, { requireUnique: true });
+  if (!summary) return false;
+  const bucket = sessionTasks(summary.id);
+  if (!bucket) return false;
+  for (const task of bucket.values()) {
+    if (!task.lease || task.lease.token !== token) continue;
+    const kind = task.lease.kind;
+    const final = task.lease.final === true;
+    task.lease = null;
+    if (!sent) {
+      await persistNow();
+      return true;
+    }
+    task.runCount += 1;
+    task.lastRunAt = now;
+    if (task.mode === 'fixed') {
+      if (final) {
+        bucket.delete(task.id);
+        if (bucket.size === 0) tasksBySession.delete(summary.id);
+        await persistNow();
+        return true;
+      }
+      // Advance directly to the first future anchor. Missed periods collapse into this one fire;
+      // there is deliberately no catch-up burst.
+      task.nextWakeAt = nextFixedWake(task, now);
+      task.nextWakeKind = 'scheduled';
+    } else if (kind === 'fallback') {
+      // The fallback gets exactly one chance to remind the model to self-pace. If that iteration
+      // still does not call loop_wakeup/loop_stop, retire it after the same quiet window rather
+      // than creating a permanent 20-minute accidental poller.
+      task.nextWakeAt = null;
+      task.nextWakeKind = null;
+      task.stopAt = now + DYNAMIC_FALLBACK_MS;
+    } else {
+      task.nextWakeAt = now + DYNAMIC_FALLBACK_MS;
+      task.nextWakeKind = 'fallback';
+      task.stopAt = null;
+    }
+    await persistNow();
+    return true;
+  }
+  return false;
+}
+
+/** Escape while a dynamic /loop is waiting clears its pending wake; fixed cron-style loops remain. */
+export async function cancelDynamicWakeups(conversationId: string): Promise<number> {
+  const summary = await findSessionByConversation(conversationId, { requireUnique: true });
+  if (!summary) return 0;
+  const bucket = sessionTasks(summary.id);
+  if (!bucket) return 0;
+  let removed = 0;
+  for (const [id, task] of bucket) {
+    if (task.mode !== 'dynamic') continue;
+    bucket.delete(id);
+    removed += 1;
+  }
+  if (bucket.size === 0) tasksBySession.delete(summary.id);
+  if (removed > 0) await persistNow();
+  return removed;
+}
+
+export function resetLoopsForTests(): void {
+  tasksBySession.clear();
+}
+
+/** Test-only deterministic insertion that exercises due/no-catch-up behavior without MCP identity. */
+export function putLoopForTests(task: LoopTask): void {
+  sessionTasks(task.sessionId, true)!.set(task.id, { ...task, lease: task.lease ? { ...task.lease } : null });
+}
+
+export function loopForTests(sessionId: string, id: string): LoopTask | null {
+  return sessionTasks(sessionId)?.get(id) ?? null;
+}
+
+export function warnLoopPersistence(error: unknown): void {
+  logWarn(`loop: could not persist scheduler state: ${(error as Error).message}`);
+}

--- a/src/main/mcp/session-tool.ts
+++ b/src/main/mcp/session-tool.ts
@@ -14,6 +14,13 @@ import { createHash } from 'node:crypto';
 import { z } from 'zod';
 import type { SessionEvent, SessionSummary, StoredText } from '../../shared/session.js';
 import { getSession, listAllSessions, readEvents } from '../session/store.js';
+import {
+  cancelLoopFromCurrentCall,
+  listLoopsForCurrentCall,
+  startLoopFromCurrentCall,
+  stopLoopFromCurrentCall,
+  wakeLoopFromCurrentCall
+} from '../loop.js';
 import { noteCount, noteDetail } from './call-context.js';
 import { expandStored, fail, guard, ok, type SurfaceRegistrar, type ToolResult } from './kernel.js';
 
@@ -147,7 +154,11 @@ const cursorSchema = z.discriminatedUnion('kind', [
 
 const inputSchema = z
   .object({
-    action: z.enum(['search', 'read']).describe('search discovers recordings; read inspects one explicit recording.'),
+    action: z
+      .enum(['search', 'read', 'loop_start', 'loop_wakeup', 'loop_stop', 'loop_list', 'loop_cancel'])
+      .describe(
+        'search/read inspect recordings. loop_start begins the latest recorded /loop or /proactive user request; loop_wakeup self-paces a dynamic loop; loop_stop/loop_cancel end one; loop_list shows this calling session’s active loops.'
+      ),
     query: z.string().max(500).optional().describe('search only. Omit to list the 30 newest recordings.'),
     session_id: z.string().min(8).max(64).optional().describe('read only. Exact id returned by search.'),
     include: z
@@ -168,37 +179,74 @@ const inputSchema = z
       .min(1)
       .max(CURSOR_MAX_CHARS)
       .optional()
-      .describe('Opaque continuation, older-history, search-result or update checkpoint returned by this tool.')
+      .describe('search/read only. Opaque checkpoint returned by this tool.'),
+    input: z
+      .string()
+      .max(12_000)
+      .optional()
+      .describe('loop_start only. Optional echo of the /loop arguments. The recorded user message remains authoritative.'),
+    loop_id: z
+      .string()
+      .regex(/^[0-9a-f]{8}$/i)
+      .optional()
+      .describe('loop_wakeup/loop_stop/loop_cancel only. The 8-character id returned by loop_start or loop_list.'),
+    delay_seconds: z
+      .number()
+      .int()
+      .min(60)
+      .max(3600)
+      .optional()
+      .describe('loop_wakeup only. Self-paced next wake, 60–3600 seconds from now.'),
+    reason: z
+      .string()
+      .max(500)
+      .optional()
+      .describe('loop_wakeup only. Short reason the selected delay fits the current state.')
   })
   .superRefine((input, ctx) => {
-    if (input.action === 'search') {
-      for (const field of ['session_id', 'include', 'tool_call'] as const) {
-        if (input[field] !== undefined) {
-          ctx.addIssue({ code: 'custom', path: [field], message: `${field} is only valid with action=read` });
+    const reject = (fields: string[], allowed: Set<string>) => {
+      for (const field of fields) {
+        if (!allowed.has(field) && (input as Record<string, unknown>)[field] !== undefined) {
+          ctx.addIssue({ code: 'custom', path: [field], message: `${field} is not valid with action=${input.action}` });
         }
       }
+    };
+    const fields = ['query', 'session_id', 'include', 'tool_call', 'cursor', 'input', 'loop_id', 'delay_seconds', 'reason'];
+
+    if (input.action === 'search') {
+      reject(fields, new Set(['query', 'cursor']));
       if (input.cursor && input.query !== undefined) {
         ctx.addIssue({ code: 'custom', path: ['query'], message: 'A search continuation cursor already contains its query' });
       }
       return;
     }
-
-    if (!input.session_id) {
-      ctx.addIssue({ code: 'custom', path: ['session_id'], message: 'session_id is required with action=read' });
+    if (input.action === 'read') {
+      reject(fields, new Set(['session_id', 'include', 'tool_call', 'cursor']));
+      if (!input.session_id) ctx.addIssue({ code: 'custom', path: ['session_id'], message: 'session_id is required with action=read' });
+      if (input.cursor && (input.include !== undefined || input.tool_call !== undefined)) {
+        ctx.addIssue({ code: 'custom', path: ['cursor'], message: 'A read cursor already contains its filters and mode; do not combine it with include or tool_call' });
+      }
+      if (input.tool_call && input.include !== undefined) {
+        ctx.addIssue({ code: 'custom', path: ['include'], message: 'include cannot be combined with tool_call' });
+      }
+      return;
     }
-    if (input.query !== undefined) {
-      ctx.addIssue({ code: 'custom', path: ['query'], message: 'query is only valid with action=search' });
+    if (input.action === 'loop_start') {
+      reject(fields, new Set(['input']));
+      return;
     }
-    if (input.cursor && (input.include !== undefined || input.tool_call !== undefined)) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['cursor'],
-        message: 'A read cursor already contains its filters and mode; do not combine it with include or tool_call'
-      });
+    if (input.action === 'loop_list') {
+      reject(fields, new Set());
+      return;
     }
-    if (input.tool_call && input.include !== undefined) {
-      ctx.addIssue({ code: 'custom', path: ['include'], message: 'include cannot be combined with tool_call' });
+    if (input.action === 'loop_wakeup') {
+      reject(fields, new Set(['loop_id', 'delay_seconds', 'reason']));
+      if (!input.loop_id) ctx.addIssue({ code: 'custom', path: ['loop_id'], message: 'loop_id is required with action=loop_wakeup' });
+      if (input.delay_seconds === undefined) ctx.addIssue({ code: 'custom', path: ['delay_seconds'], message: 'delay_seconds is required with action=loop_wakeup' });
+      return;
     }
+    reject(fields, new Set(['loop_id']));
+    if (!input.loop_id) ctx.addIssue({ code: 'custom', path: ['loop_id'], message: `loop_id is required with action=${input.action}` });
   })
   .strict();
 
@@ -206,20 +254,31 @@ export function registerSessionTool(reg: SurfaceRegistrar): void {
   reg.register(
     'session',
     {
-      title: 'Recorded sessions',
+      title: 'Session control and recordings',
       description:
-        'Search and read this app’s local recordings, including other and concurrently running chats. ' +
-        'action=search lists the 30 newest sessions when query is omitted, or finds recordings containing a term. ' +
-        'action=read requires session_id and returns exact user/assistant text plus compact tool headlines. ' +
-        'Save update_cursor and pass it later to receive only activity not already read; pass a short T… reference as tool_call to inspect exact arguments and result.',
+        'Search/read local recordings and control this calling session’s /loop tasks. ' +
+        'For a user message beginning /loop or /proactive: call action=loop_start first, then immediately execute the returned task once. ' +
+        'Intervals make fixed loops; prompt-only loops self-pace; interval-only loops run maintenance. ' +
+        'At the end of each dynamic iteration call loop_wakeup with the returned loop_id and a 60–3600 second delay chosen from current state, or loop_stop when no further run is useful. ' +
+        'Bare /loop runs maintenance; prefer project .claude/loop.md, then ~/.claude/loop.md. Fixed loops and dynamic fallback wakes are delivered only after the current ChatGPT turn is idle; missed fixed periods collapse to one fire; loops auto-expire after seven days. ' +
+        'search lists/fetches recordings; read returns exact user/assistant text and compact tool headlines, with update_cursor for incremental reads.',
       inputSchema,
-      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false }
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
     },
     async (input) =>
       guard('session', async () => {
         if (!reg.sessionToolsLive) return reg.featureDisabled('Session recording', 'Record sessions');
-        if (input.action === 'search') return searchSessions(input.query, input.cursor);
-        return readSession(input.session_id!, input.include, input.tool_call, input.cursor);
+        try {
+          if (input.action === 'search') return searchSessions(input.query, input.cursor);
+          if (input.action === 'read') return readSession(input.session_id!, input.include, input.tool_call, input.cursor);
+          if (input.action === 'loop_start') return ok(await startLoopFromCurrentCall(input.input));
+          if (input.action === 'loop_wakeup') return ok(await wakeLoopFromCurrentCall(input.loop_id!, input.delay_seconds!, input.reason));
+          if (input.action === 'loop_stop') return ok(await stopLoopFromCurrentCall(input.loop_id!));
+          if (input.action === 'loop_cancel') return ok(await cancelLoopFromCurrentCall(input.loop_id!));
+          return ok(await listLoopsForCurrentCall());
+        } catch (error) {
+          return fail(error instanceof Error ? error.message : String(error));
+        }
       })
   );
 }

--- a/src/main/mcp/surfaces.ts
+++ b/src/main/mcp/surfaces.ts
@@ -104,7 +104,8 @@ const CORE: SurfaceDefinition = {
     'Use for: opening and reading files, searching a repository, applying patches, creating, renaming and deleting files, ' +
     'running builds, tests, linters, git, npm and shell commands, and continuing long-running or interactive terminal sessions. ' +
     'Also searches and reads local recordings of previous or concurrently running ChatGPT work, and — when the user has ' +
-    'enabled it — spawns and coordinates worker agents, subagents or a parallel swarm across several ChatGPT conversations.',
+    'enabled it — spawns and coordinates worker agents, subagents or a parallel swarm across several ChatGPT conversations. ' +
+    'Slash /loop (alias /proactive) is built into session control: call session action=loop_start for the latest /loop message, execute the task immediately, and use loop_wakeup/loop_stop to self-pace dynamic loops.',
   cardSummary: 'Files, patches and the terminal. Required — this is the coding connector.',
   required: true,
   tools: ['read', 'view_image', 'find', 'apply_patch', 'exec_command', 'write_stdin', 'session', 'agents']

--- a/src/main/version.ts
+++ b/src/main/version.ts
@@ -47,5 +47,7 @@ export function extensionDownloadUrl(version = APP_VERSION): string {
  *     `disconnected`, protected routes distinguish that revocation from a stale token, and
  *     /pair accepts `reconnect: true` only for an explicit browser-side reconnect. An older
  *     extension would otherwise silently undo the user's app-side Disconnect on its next 401.
+ * 9 — session-scoped /loop delivery adds /loop/due, /loop/ack and /loop/escape plus the
+ *     matching extension messages. Older peers cannot safely provide the scheduler handshake.
  */
-export const BRIDGE_PROTOCOL = 8;
+export const BRIDGE_PROTOCOL = 9;

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -38,8 +38,8 @@ describe('extension release metadata', () => {
     expect(lock.version).toBe(APP_VERSION);
     expect(lock.packages?.['']?.version).toBe(APP_VERSION);
     expect(manifest.version).toBe(APP_VERSION);
-    expect(BRIDGE_PROTOCOL).toBe(8);
-    expect(backgroundSource).toContain('const BRIDGE_PROTOCOL = 8;');
+    expect(BRIDGE_PROTOCOL).toBe(9);
+    expect(backgroundSource).toContain('const BRIDGE_PROTOCOL = 9;');
   });
 
   /**

--- a/test/loop.test.ts
+++ b/test/loop.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  loopForTests,
+  parseLoopInput,
+  resetLoopsForTests,
+  restoreLoops,
+  snapshotLoops,
+  type LoopTask
+} from '../src/main/loop.js';
+
+function task(overrides: Partial<LoopTask> = {}): LoopTask {
+  const now = 10_000_000;
+  return {
+    id: 'a1b2c3d4',
+    sessionId: 'session-1234',
+    sourceSeq: 7,
+    mode: 'fixed',
+    prompt: 'check the deploy',
+    requestedInterval: '5m',
+    intervalMs: 5 * 60_000,
+    createdAt: now,
+    expiresAt: now + 7 * 24 * 60 * 60_000,
+    nextWakeAt: now + 5 * 60_000,
+    nextWakeKind: 'scheduled',
+    stopAt: null,
+    lastReason: '',
+    runCount: 0,
+    lastRunAt: null,
+    lease: null,
+    ...overrides
+  };
+}
+
+describe('/loop parsing', () => {
+  it('gives a leading compact interval priority', () => {
+    expect(parseLoopInput('/loop 5m /babysit-prs')).toMatchObject({
+      mode: 'fixed',
+      prompt: '/babysit-prs',
+      intervalMs: 300_000,
+      requestedInterval: '5m',
+      bare: false
+    });
+  });
+
+  it('extracts only a time-valued trailing every clause', () => {
+    expect(parseLoopInput('/loop check the deploy every 20 minutes')).toMatchObject({
+      mode: 'fixed',
+      prompt: 'check the deploy',
+      intervalMs: 1_200_000
+    });
+    expect(parseLoopInput('/loop check every PR')).toMatchObject({
+      mode: 'dynamic',
+      prompt: 'check every PR'
+    });
+  });
+
+  it('uses dynamic self-pacing when no interval is present', () => {
+    expect(parseLoopInput('/proactive check the deploy')).toEqual({
+      mode: 'dynamic',
+      prompt: 'check the deploy',
+      intervalMs: null,
+      requestedInterval: null,
+      bare: false
+    });
+  });
+
+  it('supports modern bare autonomous maintenance mode', () => {
+    const parsed = parseLoopInput('/loop');
+    expect(parsed.mode).toBe('dynamic');
+    expect(parsed.bare).toBe(true);
+    expect(parsed.prompt).toContain('.claude/loop.md');
+    expect(parsed.prompt).toContain('~/.claude/loop.md');
+    expect(parsed.prompt).toContain('unfinished work');
+  });
+
+  it('keeps the fixed scheduler at cron-compatible one-minute granularity', () => {
+    expect(parseLoopInput('/loop 30s ping').intervalMs).toBe(60_000);
+    expect(parseLoopInput('/loop 90s ping').intervalMs).toBe(120_000);
+  });
+
+  it('uses autonomous maintenance when only a fixed interval is supplied', () => {
+    const parsed = parseLoopInput('/loop 15m');
+    expect(parsed.mode).toBe('fixed');
+    expect(parsed.intervalMs).toBe(900_000);
+    expect(parsed.requestedInterval).toBe('15m');
+    expect(parsed.bare).toBe(true);
+    expect(parsed.prompt).toContain('.claude/loop.md');
+    expect(parsed.prompt).toContain('~/.claude/loop.md');
+    expect(parsed.prompt).toContain('unfinished work');
+
+    const natural = parseLoopInput('/loop every 15 minutes');
+    expect(natural.mode).toBe('fixed');
+    expect(natural.intervalMs).toBe(900_000);
+    expect(natural.bare).toBe(true);
+    expect(natural.prompt).toContain('unfinished work');
+  });
+});
+
+describe('/loop durable state', () => {
+  it('restores live tasks without restoring a stale delivery lease', () => {
+    resetLoopsForTests();
+    const saved = task({ lease: { token: 'x', clientId: 'tab', expiresAt: 20_000_000, kind: 'scheduled' } });
+    restoreLoops({ version: 1, savedAt: 10_000_000, tasks: [saved] }, 10_000_001);
+    expect(loopForTests(saved.sessionId, saved.id)?.lease).toBeNull();
+    expect(snapshotLoops().tasks).toHaveLength(1);
+  });
+
+  it('drops expired dynamic tasks but preserves an aged fixed task for its final due fire', () => {
+    resetLoopsForTests();
+    const expiredDynamic = task({ id: '11112222', mode: 'dynamic', intervalMs: null, expiresAt: 9_999_999 });
+    const expiredFixed = task({ id: '33334444', expiresAt: 9_999_999, nextWakeAt: 9_900_000 });
+    restoreLoops({ version: 1, savedAt: 10_000_000, tasks: [expiredDynamic, expiredFixed] }, 10_000_000);
+    expect(snapshotLoops().tasks.map((item) => item.id)).toEqual(['33334444']);
+  });
+});

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1288,7 +1288,7 @@ describe('capability gating', () => {
     ctx.sessionTools = true;
     const advertised = toolList(await core('tools/list')).find((tool) => tool.name === 'session');
     expect(advertised?.inputSchema).toMatchObject({
-      properties: { action: { enum: ['search', 'read'] } },
+      properties: { action: { enum: ['search', 'read', 'loop_start', 'loop_wakeup', 'loop_stop', 'loop_list', 'loop_cancel'] } },
       required: ['action']
     });
     expect(advertised?.inputSchema?.properties).not.toHaveProperty('limit');
@@ -1576,7 +1576,7 @@ describe('tool annotations', () => {
     expect(read?.annotations?.destructiveHint).toBe(false);
     // Both session actions are inspection only. Marking this as a write tool makes clients
     // apply confirmation/write semantics to searching and reading local recordings.
-    expect(session?.annotations?.readOnlyHint).toBe(true);
+    expect(session?.annotations?.readOnlyHint).toBe(false);
     expect(session?.annotations?.destructiveHint).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds a first-class `/loop` / `/proactive` workflow modeled on the current Claude Code loop contract, implemented clean-room for Chat On Steroids.

Research was cross-checked against current Claude Code scheduled-task documentation, current extracted prompt/tool fragments tracked for Claude Code v2.1.246 (August 25, 2026), and publicly reconstructed runtime code. The key finding is that modern `/loop` is not one prompt or one scheduler: fixed cadence, dynamic self-pacing, autonomous maintenance, monitoring/fallback wakes, and scheduler lifecycle are separate cooperating layers.

## Behavior

- `/loop 5m <task>` (compact `s/m/h/d`) starts a fixed loop.
- `<task> every 5 minutes` is recognized as the equivalent fixed form.
- `/loop <task>` starts a dynamic/self-paced loop.
- `/loop 15m` and `/loop every 15 minutes` run autonomous maintenance at that fixed cadence.
- bare `/loop` runs autonomous maintenance dynamically.
- maintenance prefers project `.claude/loop.md`, then `~/.claude/loop.md` when accessible, and re-reads the selected file on each iteration so edits take effect.
- `/proactive` is accepted as an alias.
- The requested task runs once immediately; scheduling controls subsequent iterations.
- Fixed intervals have a one-minute minimum/granularity.
- Dynamic iterations choose their next wake between 60 and 3600 seconds, or explicitly stop themselves.
- A bounded ~20-minute fallback heartbeat prevents a dynamic loop from silently dying if an iteration forgets to schedule the next wake; if the fallback iteration also fails to re-arm, the accidental poller retires.
- Dynamic loops stop at the seven-day lifetime without an extra wake. A fixed recurring loop that reaches the seven-day age limit is allowed its next due fire once, then is deleted, matching Claude's recurring-task age-out behavior.
- If a fixed fire is missed while the conversation is busy, missed periods collapse into one pending iteration rather than a catch-up burst.
- Loop state is durable across app/browser restart and remains scoped to the proven calling conversation/session.
- Escape clears waiting dynamic loops without cancelling fixed loops.

## Architecture

- New `src/main/loop.ts` owns parsing, durable task state, due-fire selection, final-age-out handling, delivery leases, wake/stop/cancel operations and expiry.
- Extends the existing Core `session` tool rather than adding another permanent MCP tool/schema.
- Recorder evidence remains authoritative for the `/loop` directive; model-supplied input is only a consistency check.
- Bridge + extension delivery reuse the existing conversation/tab ownership model and acknowledged-send path.
- Protocol version is bumped because the bridge surface changes.
- No raw filesystem/tool payloads are persisted by the loop scheduler.

## Claude runtime model established by research

Current Claude Code composes several mechanisms:

1. The bundled `/loop` Skill parses the request and executes the requested work immediately once.
2. Explicit cadence uses `CronCreate`; future due prompts are queued and delivered between turns rather than interrupting an active turn.
3. Prompt-only loops self-pace. The model performs an iteration and then uses `ScheduleWakeup` for its next 1–60 minute wake or explicitly stops. Current dynamic orchestration may prefer a persistent `Monitor` when there is a concrete event to wait for and retains a scheduled fallback heartbeat.
4. Bare/interval-only loops enter separate autonomous-maintenance behavior, with project/user `loop.md` support and conversation/PR work prioritized over invented busywork.
5. Scheduler runtime owns busy deferral, no-catch-up behavior, task limits, local-time cron handling, expiry, and cron jitter.

## Deliberate platform adaptations

This ports the behavior onto Chat On Steroids rather than pretending Anthropic-only infrastructure exists:

- Claude fixed loops are cron-backed and can round awkward intervals such as `7m`/`90m` to a clean cron-representable cadence, with deterministic cron jitter. The local COS scheduler can represent those intervals directly, so it preserves the requested minute cadence instead of inventing Claude's model-chosen rounding decision or jitter.
- Claude dynamic wake targets are ultimately minute-rounded by its cron-backed wake implementation and may be adjusted around prompt-cache TTL. COS uses the model-selected 60–3600 second local wake directly because it has no equivalent prompt-cache scheduler.
- Claude may use native persistent `Monitor` tasks; COS has no equivalent Anthropic service, so dynamic loops use the local wake/fallback mechanism.
- Current `ScheduleWakeup` also exposes presentation/control details such as `noop` collapsing and `stop`; COS exposes explicit local `loop_wakeup` and `loop_stop` operations rather than fabricating terminal/push-notification semantics it does not own.
- Claude's autonomous-loop machinery can inject cached/truncated `loop.md` content (25,000-byte cap) into turns. COS instead instructs the model to re-read the accessible file each iteration, which keeps edits live without duplicating Claude's prompt-cache internals.
- Claude can offer cloud schedules/push behavior in supported environments. This PR stays local and does not emulate those proprietary services.
- Claude local loops are session-scoped and restored via resume/continue. COS persists the loop state in its existing durable app state, so browser/app restart recovery is native to this harness.

## Safety / idempotency

- Loop control requires a proven ChatGPT caller and unique recorded session.
- The same recorded `/loop` user turn cannot create duplicate tasks.
- Delivery uses expiring leases tied to the claiming browser client.
- A final aged fixed tick is deleted only after successful browser delivery; a failed send remains retryable.
- Unknown/stale loop IDs fail rather than mutating another task.
- Per-session task count, prompt size, wake delay and lifetime are bounded.

## Validation

The exact final feature tree is:

`df38c02c03988b9a0ce4b9d03b1d364fc80aa3a3`

It was validated on GitHub Actions before squashing with:

- `npm ci`
- `npm run rg`
- `npm run typecheck`
- `npx vitest run --exclude test/mcp-shutdown.test.ts`
- `npx vitest run test/mcp-shutdown.test.ts`
- `npm run build`

Final results:

- **1,732 tests passed, 93 skipped, 0 failed** across the main suite.
- **2/2 shutdown tests passed** in isolation.
- Production Electron/Vite build passed for main, preload and renderer.
- The Core MCP discovery-size budget remains enforced by the test suite.

`npm run verify:ci` was also attempted first, but its `verify:privacy` step audits the fork's entire inherited Git history and stops on historical upstream commits containing old maintainer email addresses. Those commits predate this PR and are not changed by it; the actual typecheck, complete code test suite, shutdown isolation and production build were therefore run explicitly as listed above and all passed.

The branch was then squashed by reusing the exact byte-tested Git tree. Final PR head:

`0f31b56496bb7ba3628fc934f0143f51de9916a3`

## Notes

This is a clean-room behavioral implementation based on official public documentation plus publicly shipped/extracted/reverse-engineered artifacts used to establish observable mechanics. It does not copy or redistribute Anthropic proprietary source code or long internal prompts verbatim. A reconstructed source hint for `/loop until <condition>` was found, but no sufficiently proven current execution semantics were established in the official docs/runtime path, so this PR deliberately does **not** invent that feature.