### PR TITLE
Fix repeated resume-shadow recovery polling

### DIFF
--- a/src/main/session/continuation.ts
+++ b/src/main/session/continuation.ts
@@ -366,7 +366,8 @@ export async function repairPrimeFromResumeShadow(conversationId: string): Promi
 
   const source = await getSession(sourceSessionId).catch(() => null);
   if (!source?.conversationId) return false;
-  const sourceOwner = agentForOwnedConversation(source.conversationId);
+  const fromConversationId = source.conversationId;
+  const sourceOwner = agentForOwnedConversation(fromConversationId);
   if (sourceOwner && sourceOwner !== PRIME_ID) return false;
   // PRIME on both sides proves two separately retained/active owner records. In particular,
   // an old A run may have parked before the exact shadow/descendant C later started a fresh run
@@ -374,12 +375,20 @@ export async function repairPrimeFromResumeShadow(conversationId: string): Promi
   // recovery already moved the *same* run A→C, only C remains owned and this idempotent
   // projection repair is still allowed — that is the live 2.0.1 damage pattern this exists for.
   if (targetOwner === PRIME_ID && sourceOwner === PRIME_ID) return false;
+  // Once the same run's prime ownership has already reached B and A has no remaining Goal or
+  // workspace projection, there is nothing left for this browser poll to repair. The broker
+  // recovery hook deliberately reports an already-satisfied A→B as success, so calling it again
+  // would otherwise turn every /activity poll into another "moved missing projections" warning
+  // (and another exact-handoff event scan) forever on resumed chats that have no Goal.
+  if (targetOwner === PRIME_ID && !workspaceForChat(fromConversationId) && !goalObjectiveFor(fromConversationId)) {
+    return false;
+  }
   const failed = [...byToken.values()].find(
     (entry) =>
       entry.sessionId === sourceSessionId &&
       entry.state === 'aborted' &&
       entry.error === RESUME_SHADOW_COLLISION &&
-      entry.from === source.conversationId
+      entry.from === fromConversationId
   );
   const handoffId = failed?.handoffId ?? source.lastHandoffId;
   if (!handoffId) return false;
@@ -402,6 +411,23 @@ export async function repairPrimeFromResumeShadow(conversationId: string): Promi
   if (!exactBootstrap) return false;
   const proof = failed ? `collision WAL + exact handoff ${handoffId}` : `exact handoff ${handoffId}`;
 
+  // The proof above crosses filesystem awaits. Another activity poll or agents call can finish
+  // the same repair while this one is reading it, so ownership captured before those awaits is
+  // no longer authoritative. Re-read both sides immediately before the synchronous projection
+  // mutations; no await follows until the decision has been made.
+  const currentTargetOwner = agentForOwnedConversation(conversationId);
+  const currentSourceOwner = agentForOwnedConversation(fromConversationId);
+  if (currentTargetOwner && currentTargetOwner !== PRIME_ID) return false;
+  if (currentSourceOwner && currentSourceOwner !== PRIME_ID) return false;
+  if (currentTargetOwner === PRIME_ID && currentSourceOwner === PRIME_ID) return false;
+  if (
+    currentTargetOwner === PRIME_ID &&
+    !workspaceForChat(fromConversationId) &&
+    !goalObjectiveFor(fromConversationId)
+  ) {
+    return false;
+  }
+
   // The durable session rebind never landed in this legacy race, so normal
   // publishCommittedProjection() never ran either. Once the exact app-created resume shadow +
   // positive proof above identifies which A→B attempt this is, repair only projections that are
@@ -409,7 +435,6 @@ export async function repairPrimeFromResumeShadow(conversationId: string): Promi
   // state before an upgraded build gets its first chance to heal the old collision; that newer
   // target state wins. The stale A projection is still removed so opening A later cannot keep
   // using authority that belongs to the continued chat.
-  const fromConversationId = source.conversationId;
   let workspaceChanged = false;
   if (workspaceForChat(conversationId)) {
     workspaceChanged = clearChatWorkspace(fromConversationId);
@@ -425,7 +450,14 @@ export async function repairPrimeFromResumeShadow(conversationId: string): Promi
   } else {
     goalChanged = moveGoalObjective(fromConversationId, conversationId);
   }
-  const repaired = recoveryHooks.repairPrimeTransfer?.(fromConversationId, conversationId) ?? false;
+  // The recovery hook uses success semantics: replaying an already-repaired target returns true
+  // by design. Here this boolean means "changed on this call" and drives a user-visible warning,
+  // so an already-owned target must not be counted as a fresh broker mutation. Missing Goal or
+  // workspace projections above are still repaired normally.
+  const repaired =
+    currentTargetOwner === PRIME_ID
+      ? false
+      : (recoveryHooks.repairPrimeTransfer?.(fromConversationId, conversationId) ?? false);
   if (repaired || workspaceChanged || goalChanged) {
     logWarn(
       `resume-shadow repair (${proof}) moved missing projections into chat ${conversationId}`

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -106,6 +106,7 @@ const {
 );
 const { makeTempDir, removeTempDir, SAMPLE_BRIEF } = await import('./helpers.js');
 const { resumeBootstrapText } = await import('../src/main/session/handoff.js');
+const { getLog } = await import('../src/main/logger.js');
 
 const EXTENSION_ORIGIN = 'chrome-extension://abcdefghijklmnopabcdefghijklmnop';
 /** The chat that spawns the swarm in these tests: only a proven conversation can. */
@@ -3608,6 +3609,55 @@ describe('the goal loop over the bridge', () => {
     } finally {
       globalThis.fetch = realFetch;
     }
+  });
+
+  it('does not report the same no-Goal resume-shadow repair on every activity poll', async () => {
+    await pair();
+    const from = 'cafe0041-0000-4000-8000-000000000041';
+    const to = 'cafe0042-0000-4000-8000-000000000042';
+    const source = await createSession({ title: 'prime before no-goal resume-shadow collision', conversationId: from });
+    spawn({ workers: [{ task: 'keep reusable ownership across the broken resume' }], caller: { conversationId: from } });
+
+    const openedContinuation = await openContinuationNow(source.id, from);
+    const handoff = await attachSummary(openedContinuation.token, SAMPLE_BRIEF);
+    expect(handoff).not.toBeNull();
+    await claimContinuationNow(openedContinuation.token, 'no-goal-shadow-owner');
+    await createSession({
+      title: 'Resumed · prime before no-goal resume-shadow collision',
+      conversationId: to,
+      origin: { kind: 'resume', fromSessionId: source.id, agentId: null, task: '' }
+    });
+    await recordChatObservations(to, [
+      {
+        kind: 'user_message',
+        time: Date.now(),
+        text: resumeBootstrapText(handoff!.text),
+        messageId: 'm-no-goal-shadow-resume'
+      }
+    ]);
+    expect(await commitContinuation(openedContinuation.token, to)).toBe(false);
+    abortContinuation(openedContinuation.token, 'the replacement chat already belongs to another local session');
+    setContinuationRecoveryHooks({ repairPrimeTransfer: repairPrimeConversationAfterRecovery });
+
+    const repairWarnings = (): number =>
+      getLog().filter(
+        (entry) =>
+          entry.level === 'warn' &&
+          entry.message.includes('resume-shadow repair (') &&
+          entry.message.endsWith(`moved missing projections into chat ${to}`)
+      ).length;
+    const warningsBefore = repairWarnings();
+
+    const first = await request('GET', `/activity?conversationId=${to}`);
+    expect(first.status).toBe(200);
+    expect(snapshotSwarm()?.primeConversationId).toBe(to);
+    expect(first.body.goal.objective).toBe('');
+    expect(repairWarnings()).toBe(warningsBefore + 1);
+
+    const second = await request('GET', `/activity?conversationId=${to}`);
+    expect(second.status).toBe(200);
+    expect(second.body.goal.objective).toBe('');
+    expect(repairWarnings()).toBe(warningsBefore + 1);
   });
 
   /** The page needs to know three things, and it gets them on the feed it already polls. */

--- a/test/continuation.test.ts
+++ b/test/continuation.test.ts
@@ -1056,6 +1056,10 @@ describe('the window in which a replacement chat is expected', () => {
     expect(goalObjectiveFor(to)).toBe('finish the release from the replacement chat');
     expect(workspaceEntries().filter((held) => held.key.startsWith('chat:')).map((held) => held.key)).toEqual([`chat:${to}`]);
 
+    // The broker hook itself intentionally treats an already-satisfied replay as success. The
+    // resume-shadow wrapper reports actual projection changes, so a later browser poll is a no-op.
+    expect(await repairPrimeFromResumeShadow(to)).toBe(false);
+
     // Same-origin-looking data without the exact authored bootstrap is not takeover authority.
     const stranger = '84848484-1111-2222-3333-444444444444';
     await createSession({
@@ -1064,6 +1068,32 @@ describe('the window in which a replacement chat is expected', () => {
       origin: { kind: 'resume', fromSessionId: source.id, agentId: null, task: '' }
     });
     expect(await repairPrimeFromResumeShadow(stranger)).toBe(false);
+    expect(primeConversation()).toBe(to);
+  });
+
+  it('counts two concurrent exact-shadow repair attempts as one mutation', async () => {
+    const from = '81818181-aaaa-bbbb-cccc-444444444444';
+    const to = '82828282-aaaa-bbbb-cccc-444444444444';
+    const source = await createSession({ title: 'prime before concurrent shadow repair', conversationId: from });
+    spawn({ workers: [{ task: 'keep ownership alive during the concurrent repair' }], caller: { conversationId: from } });
+    const opened = await openContinuationNow(source.id, from);
+    const handoff = await attachSummary(opened.token, SAMPLE_BRIEF);
+    expect(handoff).not.toBeNull();
+    await claimContinuationNow(opened.token, 'concurrent-shadow-owner');
+    await createSession({
+      title: 'Resumed · prime before concurrent shadow repair',
+      conversationId: to,
+      origin: { kind: 'resume', fromSessionId: source.id, agentId: null, task: '' }
+    });
+    await recordChatObservations(to, [
+      { kind: 'user_message', time: Date.now(), text: resumeBootstrapText(handoff!.text), messageId: 'm-concurrent-shadow' }
+    ]);
+    expect(await commitContinuation(opened.token, to)).toBe(false);
+    abortContinuation(opened.token, 'the replacement chat already belongs to another local session');
+    setContinuationRecoveryHooks({ repairPrimeTransfer: repairPrimeConversationAfterRecovery });
+
+    const results = await Promise.all([repairPrimeFromResumeShadow(to), repairPrimeFromResumeShadow(to)]);
+    expect(results.filter(Boolean)).toHaveLength(1);
     expect(primeConversation()).toBe(to);
   });
 


### PR DESCRIPTION
## What changed

After a Compact & Resume shadow recovery had already transferred PRIME ownership, repeated `/activity` polling could keep re-entering the repair path. The broker recovery hook intentionally reports an already-satisfied transfer as success, but the resume-shadow wrapper treated that success as a fresh mutation, rescanned the exact handoff evidence, and emitted the same recovery warning again.

This keeps the hook's idempotent-success contract while making the wrapper report only actual projection changes:

- return early once the target already owns PRIME and the source has no Goal/workspace projection left;
- re-read source/target ownership after the asynchronous handoff proof so concurrent polls cannot act on stale ownership state;
- do not count an already-owned target as a fresh broker mutation.

Regression coverage checks both repeated activity polling and two concurrent exact-shadow repair attempts.

## Validation

- [x] Added or updated a deterministic regression test where behavior changed.
- [x] `npm run verify` passes: 1,804 passed / 18 skipped, plus 2/2 isolated shutdown tests.
- [x] Packaging/runtime smoke was run when the change can differ after bundling.
- [x] No unrelated formatting, generated output, local debugging notes, or private data is included.
- [x] Screenshots, logs and examples use placeholders instead of real usernames, paths, chat text, IDs or credentials.
- [x] Security-sensitive details are being handled privately instead of disclosed here.

`npm run build` also passes. A packaged combined-fix build was exercised on Windows; this PR changes main-process logic and tests only.
