### PR TITLE
Prevent stale Fiber request attribution conflicts

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -2629,7 +2629,7 @@
     return found;
   }
 
-  function confirmLiveRequestOwners(calls, ownerConversation) {
+  async function confirmLiveRequestOwners(calls, ownerConversation) {
     if (!Array.isArray(calls) || calls.length === 0 || !ownerConversation) return;
     const byRequest = new Map();
     for (const call of calls) {
@@ -2642,11 +2642,12 @@
     }
     const batch = [...byRequest.values()];
     if (batch.length === 0) return;
-    void ask({
-      type: 'correlate',
-      conversationId: ownerConversation,
-      calls: batch
-    }).then((reply) => {
+    try {
+      const reply = await ask({
+        type: 'correlate',
+        conversationId: ownerConversation,
+        calls: batch
+      });
       const data = reply && reply.ok === true && reply.data && typeof reply.data === 'object' ? reply.data : null;
       const confirmed = new Set(data && Array.isArray(data.confirmed) ? data.confirmed : []);
       for (const call of batch) {
@@ -2667,11 +2668,11 @@
         traceStage(call.requestId, 'sent');
         traceStage(call.requestId, 'app', 'request_id');
       }
-    }).catch(() => {
+    } catch {
       for (const call of batch) backOffRequestOwner(`${ownerConversation}\u0000${call.requestId}`);
-    }).finally(() => {
+    } finally {
       for (const call of batch) requestOwnersPending.delete(`${ownerConversation}\u0000${call.requestId}`);
-    });
+    }
   }
   async function refreshFiber(settled = null) {
     // A bound chat can briefly lose its /c/<id> route during React/router churn, and a real
@@ -2841,7 +2842,22 @@
           }
         }
       }
-      confirmLiveRequestOwners(ownerCalls, askedConversation);
+      const ownerConfirmation = confirmLiveRequestOwners(ownerCalls, askedConversation);
+      // `ownedPageTurn` has one deliberately narrow exception to the ordinary conversation
+      // filter: on a fresh chat, the real /c/<id> can exist while that live turn's React branch
+      // still carries a provisional client thread id. The explicit /correlations handshake is
+      // what distinguishes that harmless race from a stale Fiber object belonging to another
+      // chat. Do not let the ordinary fire-and-forget tool_evidence path race ahead of that
+      // verdict: it would re-assert the URL conversation, bypass a rejected handshake and turn
+      // an already-proven request owner into a sticky conflict.
+      const ownedPageConversation = ownedPageTurn ? concreteConversation(ownedPageTurn.conversationId) : null;
+      if (ownedPageTurn && ownedPageConversation && ownedPageConversation !== askedConversation) {
+        await ownerConfirmation;
+        // The ownership read-back added a new async boundary to this scan. Re-prove the same
+        // document/route before any observation from the pre-await Fiber frame can be emitted.
+        if (epoch !== askedEpoch || conversationId !== askedConversation) return;
+        if (CLF_DOM.conversationId() !== askedConversation) return;
+      }
     }
     // A terminal message can finish the local turn before ChatGPT removes a stale Stop
     // control. While that latch is active, observe() keeps Fiber probing the newest visible
@@ -2855,7 +2871,22 @@
     }
     for (let index = 0; index < answer.turns.length; index++) {
       const turn = answer.turns[index];
+      const pageConversation = concreteConversation(turn.conversationId);
+      const provisionalOwnedTurn = Boolean(
+        turn === ownedPageTurn &&
+        askedConversation &&
+        pageConversation &&
+        pageConversation !== askedConversation
+      );
       const fresh = turn.calls.filter((call) => {
+        // A mismatched owned turn is admissible only as a provisional-first-turn candidate.
+        // Its request id must have survived the app's explicit owner read-back before the
+        // transcript channel may repeat that evidence. A rejected/stale id is simply omitted;
+        // the already-proven owner remains authoritative and no sticky conflict is manufactured.
+        if (
+          provisionalOwnedTurn &&
+          (!call.requestId || requestOwnersConfirmed.get(call.requestId) !== askedConversation)
+        ) return false;
         const owner = index === activeTurnIndex ? activeLocalTurnId || '' : '';
         const signature = `${call.tool}\u0000${call.requestId || ''}\u0000${call.answered ? '1' : '0'}\u0000${owner}`;
         if (callsReported.get(call.messageId) === signature) return false;

--- a/src/main/session/correlation.ts
+++ b/src/main/session/correlation.ts
@@ -37,17 +37,19 @@ interface HeldCorrelation {
 const MAX_CORRELATIONS = 50_000;
 const CORRELATIONS_STATE = 'request-correlations';
 /**
- * 3 drops the conflicts version 2 wrote.
+ * 4 drops only the sticky conflicts version 3 wrote while preserving its proven owners.
  *
- * Until this version a page whose URL and React tree disagreed for one tick marked every
- * request id in that sighting contradictory, and a contradiction is permanent — nothing
- * republishes it and the repair pass skips it. Those verdicts are on disk in every profile
- * that ran an earlier build, holding otherwise provable calls in Unattributed activity for
- * good. Reading them back as *absent* rather than as contradictory lets the evidence decide
- * again; a real contradiction is two conversations claiming one id, and merge() makes that
- * one sticky again the moment it recurs.
+ * Version 3 correctly stopped treating a URL/Fiber mismatch itself as a contradiction, but a
+ * second path remained: the content script deliberately retained the currently-owned Fiber
+ * turn across the fresh-chat provisional-client-thread race, asked `/correlations` whether its
+ * request ids really belonged to the new URL, then emitted ordinary `tool_evidence` before that
+ * acknowledged verdict. A stale retained turn could therefore be rejected by the safe handshake
+ * and still immediately poison the registry through the transcript channel. Those v3 conflict
+ * rows cannot be distinguished on disk from a real contradiction. Drop them once and let exact
+ * evidence/history decide again, while retaining all non-conflicted v3 owners so migration does
+ * not throw away the durable index merely to repair two bad rows.
  */
-const CORRELATIONS_STATE_VERSION = 3;
+const CORRELATIONS_STATE_VERSION = 4;
 
 const byRequest = new Map<string, HeldCorrelation>();
 const waiters = new Map<string, Set<() => void>>();
@@ -176,13 +178,15 @@ async function restoreRequestCorrelationsOnce(): Promise<void> {
 
   const saved = await readDurable<PersistedCorrelations>(CORRELATIONS_STATE);
   let loaded = false;
-  if (saved?.version === CORRELATIONS_STATE_VERSION && Array.isArray(saved.entries)) {
+  const migrateV3 = saved?.version === 3 && Array.isArray(saved.entries);
+  if ((saved?.version === CORRELATIONS_STATE_VERSION || migrateV3) && Array.isArray(saved.entries)) {
     for (const raw of saved.entries.slice(-MAX_CORRELATIONS)) {
       if (!raw || typeof raw !== 'object' || typeof raw.requestId !== 'string') continue;
       if (raw.conflicted === true) {
-        // Kept, and still permanent: this snapshot is version 3, so every conflict in it was
-        // written by merge() — two conversations claiming one request id — rather than by a
-        // page caught mid-navigation.
+        // v3 cannot tell a real contradiction from the provisional-owned-turn bypass fixed in
+        // v4. Forget only that verdict; recent attributed history below can immediately restore
+        // the legitimate first owner. Conflicts created by v4's corrected protocol remain sticky.
+        if (migrateV3) continue;
         byRequest.set(raw.requestId, { value: null, conflicted: true });
         loaded = true;
         continue;
@@ -232,7 +236,7 @@ async function restoreRequestCorrelationsOnce(): Promise<void> {
       });
     }
   }
-  if (byRequest.size > 0 || loaded) persist();
+  if (byRequest.size > 0 || loaded || migrateV3) persist();
 }
 
 /**

--- a/src/main/session/recorder.ts
+++ b/src/main/session/recorder.ts
@@ -59,6 +59,7 @@ import {
   awaitRequestCorrelation,
   observeRequestCorrelations,
   requestCorrelation,
+  requestCorrelationConflicted,
   resetCorrelationRegistryForTests,
 } from './correlation.js';
 import { resumeOpeningChat } from './resume-gate.js';
@@ -711,6 +712,16 @@ function noteCallEvidence(
   }
   const observedAt = Math.min(at, Date.now());
   const evidencedCalls = calls.filter((call): call is PageCallEvidence & { requestId: string } => !!call.requestId);
+  // One ChatGPT workflow request id can legitimately cover dozens of connector calls. Capture
+  // the pre-batch state once so a single cross-conversation contradiction produces one useful
+  // transition warning, rather than one identical line per call. A later at-least-once replay
+  // of an already-conflicted id contains no new diagnostic fact and stays silent.
+  const alreadyConflicted = new Set(
+    evidencedCalls.map((call) => call.requestId).filter((requestId) => requestCorrelationConflicted(requestId))
+  );
+  const priorOwners = new Map(
+    evidencedCalls.map((call) => [call.requestId, requestCorrelation(call.requestId)?.conversationId ?? null] as const)
+  );
   const results = observeRequestCorrelations(
     evidencedCalls.map((call) => ({
       requestId: call.requestId,
@@ -721,10 +732,19 @@ function noteCallEvidence(
       observedAt
     }))
   );
+  const warnedConflicts = new Set<string>();
   for (const [index, call] of evidencedCalls.entries()) {
     const result = results[index]!;
     if (result === 'conflict') {
-      logWarn(`request attribution conflict for ${call.requestId}; ownership will remain unattributed`);
+      if (!alreadyConflicted.has(call.requestId) && !warnedConflicts.has(call.requestId)) {
+        warnedConflicts.add(call.requestId);
+        const prior = priorOwners.get(call.requestId);
+        logWarn(
+          `request attribution conflict for ${call.requestId}` +
+            (prior ? `: conversation ${prior} vs ${conversationId}` : '') +
+            '; ownership will remain unattributed'
+        );
+      }
     } else if (result === 'stored') {
       logInfo(`request attribution: ${call.requestId} -> conversation ${conversationId}`);
       if (unattributedSessionId) scheduleAttributionRepair();

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -5461,6 +5461,64 @@ describe('evidence from the page context', () => {
     expect(live.sent.filter((message) => message.type === 'correlate')).toHaveLength(1);
   });
 
+  it('does not let a stale owned Fiber turn bypass a rejected live ownership handshake', async () => {
+    live = await harness();
+    const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const staleConversation = '11111111-2222-3333-4444-555555555555';
+    const requestId = 'wfr_already_owned_by_stale_chat';
+    live.reply.set('correlate', () => ({
+      ok: true,
+      status: 200,
+      data: {
+        ok: true,
+        conversationId,
+        requestIds: [requestId],
+        confirmed: [],
+        conflicts: [requestId],
+        complete: false
+      }
+    }));
+
+    // This is the dangerous ambiguity behind the live restart repro. The DOM section is the
+    // generation this document owns, so the provisional-first-turn exception keeps its Fiber
+    // descriptor even though that branch names another concrete conversation. The explicit
+    // /correlations handshake can distinguish a harmless provisional client thread from stale
+    // history: here it says the request id already belongs elsewhere. Ordinary tool_evidence
+    // must not get a second chance to assert the URL conversation after that rejection.
+    startGenerating(live.document);
+    assistantTurn(live.document, 'stale-owned-turn', []);
+    live.hook.observe();
+    await settle();
+
+    await replyFiber([], [{
+      turnId: 'stale-owned-turn',
+      conversationId: staleConversation,
+      calls: [{
+        messageId: 'stale-owned-request',
+        tool: 'exec_command',
+        order: 0,
+        answered: true,
+        requestId,
+        createTime: 1_700_000_001
+      }],
+      messages: []
+    }]);
+    await settle();
+    await live.hook.flush();
+
+    expect(live.sent.filter((message) => message.type === 'correlate')).toEqual([
+      expect.objectContaining({
+        conversationId,
+        calls: [expect.objectContaining({ requestId, messageId: 'stale-owned-request' })]
+      })
+    ]);
+    expect(
+      emitted(live.sent, 'tool_evidence').filter((entry) =>
+        (entry.event.calls || []).some((call: any) => call.requestId === requestId)
+      )
+    ).toHaveLength(0);
+  });
+
   it('confirms a live request when the virtualized renderer published no data-turn-id', async () => {
     live = await harness();
     const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';

--- a/test/correlation.test.ts
+++ b/test/correlation.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { flushDurable, initDurableStore, resetDurableForTests } from '../src/main/durable.js';
+import { flushDurable, initDurableStore, resetDurableForTests, writeDurableNow } from '../src/main/durable.js';
 import {
   appendEvent,
   createSession,
@@ -167,6 +167,50 @@ describe('request correlation ownership', () => {
       expect(requestCorrelation(requestId)?.sessionId).toBe('session-durable');
     } finally {
       resetCorrelationRegistryForTests();
+      resetDurableForTests();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('migrates v3 proven owners but discards v3 sticky conflicts created by stale provisional evidence', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'clf-correlation-v3-conflict-'));
+    try {
+      resetDurableForTests();
+      resetSessionStoreForTests();
+      initDurableStore(dir);
+      initSessionStore(dir);
+      await writeDurableNow('request-correlations', {
+        version: 3,
+        entries: [
+          {
+            requestId: 'wfr_v3_proven_owner',
+            value: {
+              requestId: 'wfr_v3_proven_owner',
+              conversationId: 'conv-v3-proven',
+              sessionId: 'session-v3-proven',
+              messageId: 'message-v3-proven',
+              tool: 'read',
+              observedAt: 100
+            },
+            conflicted: false
+          },
+          {
+            requestId: 'wfr_v3_false_conflict',
+            value: null,
+            conflicted: true
+          }
+        ]
+      });
+
+      resetCorrelationRegistryForTests();
+      await restoreRequestCorrelations();
+      expect(requestCorrelation('wfr_v3_proven_owner')?.conversationId).toBe('conv-v3-proven');
+      expect(requestCorrelationConflicted('wfr_v3_false_conflict')).toBe(false);
+      expect(requestCorrelation('wfr_v3_false_conflict')).toBeNull();
+    } finally {
+      resetCorrelationRegistryForTests();
+      resetSessionStoreForTests();
+      unsetSessionRootForTests();
       resetDurableForTests();
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -14,6 +14,7 @@ import { defaultConfig, initConfigPath, saveConfig } from '../src/main/config.js
 import { lineDelta, formatDelta } from '../src/main/diffstat.js';
 import { chunkText } from '../src/main/mcp/tools.js';
 import { emptyEvidence } from '../src/main/mcp/call-context.js';
+import { getLog } from '../src/main/logger.js';
 import {
   closeConversation,
   liveConversations,
@@ -1664,6 +1665,51 @@ describe('canonical recorder 1.8', () => {
     const call = await tool('wfr_identity_conflict', now);
     expect(call?.attributionMethod).toBe('unattributed');
     expect(call?.conversationId).toBeNull();
+  });
+
+  it('logs one transition when a shared request id becomes conflicted, not one warning per call or replay', async () => {
+    const firstConversation = 'conv-conflict-log-first';
+    const secondConversation = 'conv-conflict-log-second';
+    const requestId = `wfr_conflict_log_${Date.now()}`;
+    const now = Date.now();
+    await sessionForConversation(firstConversation);
+    await sessionForConversation(secondConversation);
+    await recordChatObservations(firstConversation, [{
+      kind: 'tool_evidence',
+      time: now,
+      fiberConversationId: firstConversation,
+      calls: [{ messageId: 'first-proof', tool: 'read', order: 0, answered: true, requestId }]
+    }]);
+
+    const warnings = (): number => getLog().filter(
+      (entry) => entry.level === 'warn' && entry.message.includes(`request attribution conflict for ${requestId}`)
+    ).length;
+    const before = warnings();
+    const conflictingCalls = Array.from({ length: 35 }, (_, index) => ({
+      messageId: `conflicting-call-${index}`,
+      tool: index % 2 === 0 ? 'read' : 'exec_command',
+      order: index,
+      answered: true,
+      requestId
+    }));
+    await recordChatObservations(secondConversation, [{
+      kind: 'tool_evidence',
+      time: now + 1,
+      fiberConversationId: secondConversation,
+      calls: conflictingCalls
+    }]);
+    expect(warnings()).toBe(before + 1);
+
+    // Once the registry is already in the fail-closed state, another at-least-once browser
+    // replay contains no new diagnostic fact. It must not refill the Activity panel with the
+    // same warning again.
+    await recordChatObservations(secondConversation, [{
+      kind: 'tool_evidence',
+      time: now + 2,
+      fiberConversationId: secondConversation,
+      calls: conflictingCalls
+    }]);
+    expect(warnings()).toBe(before + 1);
   });
 
   /**


### PR DESCRIPTION
## What changed

A retained Fiber turn can briefly carry a different client-thread conversation id while a fresh ChatGPT route converges. The explicit request-ownership handshake already rejects a request id that is proven to belong to another conversation, but ordinary `tool_evidence` could race ahead of that verdict and re-assert the current URL conversation. That could turn an otherwise valid request id into a sticky fail-closed attribution conflict.

This fixes the earliest ownership boundary rather than hiding the resulting warning:

- wait for the acknowledged ownership read-back before emitting evidence from a mismatched retained turn;
- emit only request ids explicitly confirmed for the current conversation;
- revalidate the navigation epoch and route after the new async boundary;
- migrate durable request-correlation state to v4, preserving proven v3 owners while dropping ambiguous v3 sticky-conflict verdicts once;
- report a real request-id conflict once per state transition instead of once per connector call or replay.

The fail-closed behavior is preserved: conflicting ownership is never guessed or moved to another chat.

## Validation

- [x] Added or updated a deterministic regression test where behavior changed.
- [x] `npm run verify` passes: 1,804 passed / 18 skipped, plus 2/2 isolated shutdown tests.
- [x] Packaging/runtime smoke was run when the change can differ after bundling.
- [x] No unrelated formatting, generated output, local debugging notes, or private data is included.
- [x] Screenshots, logs and examples use placeholders instead of real usernames, paths, chat text, IDs or credentials.
- [x] Security-sensitive details are being handled privately instead of disclosed here.

`npm run build` also passes. The packaged Windows build was checked to contain both the updated extension and v4 main-process correlation logic and was exercised after restart.
