### PR TITLE
fix: keep redeemed Compact & Resume lease alive past 90s

### DIFF
--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -101,6 +101,7 @@ import {
   attachSummary,
   claimContinuationNow,
   commitContinuationResult,
+  CONTINUATION_TTL_MS,
   continuationByToken,
   continuationForSession,
   openContinuationNow,
@@ -147,7 +148,8 @@ const RATE_LIMIT = 900;
  * A deadline, not a retry interval. One command is one delivery: the app opens the exact
  * chat, and this is how long that page has to redeem the marker, type the bootstrap and
  * report which conversation it landed in. Long enough for a tab to open, ChatGPT to finish
- * loading and the composer to accept text on a slow machine.
+ * loading and the composer to accept text on a slow machine. A redeemed resume may keep waiting
+ * only while its existing continuation is still alive; that continuation already has its own TTL.
  *
  * What happens when it runs out is `drop()`, which is an ending rather than another go:
  * the continuation is aborted and the session stays in the chat it is already in, or the
@@ -1970,6 +1972,8 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
         const claimed = await claimContinuationNow(command.spec.token, `${command.id}:${client}`);
         if (!claimed) return json(res, 409, { error: 'continuation_not_claimable' }, origin);
         claimedSummary = claimed.summary;
+        // Replace the short page-open timer with the continuation's existing outer lifetime.
+        armDeadline(command);
       } catch (err) {
         logWarn(`bridge: could not durably claim ${specKey(command.spec)} — ${err instanceof Error ? err.message : String(err)}`);
         return json(res, 503, { error: 'continuation_claim_not_durable', retryable: true }, origin);
@@ -3418,10 +3422,13 @@ function commandDeadlineDelay(command: Command, now = Date.now()): number | null
   // exact worker chat may still be rendering the assistant message that contains agents.finish,
   // so the content script deliberately refuses to redeem until that page is submit-ready. That
   // wait must survive a tab reload/browser restart without turning ordinary ChatGPT busyness into
-  // a failed broker revival. Once a document actually redeems (`owner !== null`), the ordinary
-  // short acknowledgement deadline applies again: text may be about to cross the irreversible
-  // send boundary and a dead document must not own it indefinitely.
+  // a failed broker revival. A redeemed resume is already bounded by its continuation lifetime,
+  // so let that existing state machine remain the outer deadline while ChatGPT exposes chat B.
   if (waitingForRevivalReadiness(command)) return null;
+  if (command.spec.type === 'resume' && command.owner !== null) {
+    const continuation = continuationByToken(command.spec.token);
+    if (continuation?.state === 'claimed') return continuation.openedAt + CONTINUATION_TTL_MS - now;
+  }
   const claimedAt = command.claimedAt ?? now;
   return claimedAt + COMMAND_DEADLINE_MS - now;
 }
@@ -3703,7 +3710,7 @@ const isLeased = (command: Command): boolean => {
   if (Date.now() - command.claimedAt < COMMAND_DEADLINE_MS) return true;
   if (command.spec.type !== 'resume') return false;
   const state = continuationByToken(command.spec.token)?.state;
-  return state === 'committing' || state === 'committed';
+  return state === 'claimed' || state === 'committing' || state === 'committed';
 };
 
 /**

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -3306,15 +3306,16 @@ describe('targeted open', () => {
     );
   });
 
-  it('renews the command deadline when the opened page finally redeems it', async () => {
+  it('keeps a redeemed resume alive past the short ACK deadline without outliving its continuation', async () => {
     vi.useFakeTimers();
     try {
       setBrowserOpener(async (url) => {
         opened.push(url);
       });
       await pair();
+      const sourceConversation = '44444444-5555-6666-7777-888888888888';
       const { sessionId, token } = await compactedSession(
-        '44444444-5555-6666-7777-888888888888',
+        sourceConversation,
         'the slow-start brief'
       );
       const command = queueResume(sessionId, token)!;
@@ -3323,11 +3324,18 @@ describe('targeted open', () => {
       await vi.advanceTimersByTimeAsync(60_000);
       expect((await redeem(command.id, 'slow-tab')).text).toContain('the slow-start brief');
 
-      // content.js can still legitimately be waiting for the composer/conversation id here.
-      // The original timer would fire 30s after redeem despite `claimedAt` having been renewed.
-      await vi.advanceTimersByTimeAsync(60_000);
+      // Hidden Chromium tabs can stretch content.js's conversation-id wait beyond 90s. The exact
+      // page already owns the one-shot continuation, so the short command deadline must not abort
+      // it while that existing continuation is still valid.
+      await vi.advanceTimersByTimeAsync(2 * 60_000);
       expect(pendingCommands().map((entry) => entry.what)).toEqual([`resume:${sessionId}`]);
-      expect(continuationByToken(token)?.state).not.toBe('aborted');
+      expect(continuationByToken(token)?.state).toBe('claimed');
+
+      // No new lifetime is invented: the existing 10m continuation TTL remains the outer bound.
+      await vi.advanceTimersByTimeAsync(7 * 60_000);
+      expect(pendingCommands()).toEqual([]);
+      expect(continuationByToken(token)?.state).toBe('aborted');
+      expect((await getSession(sessionId))?.conversationId).toBe(sourceConversation);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## Summary

Fixes a Compact & Resume race where the replacement page has already redeemed the single-use continuation, but a background Chromium delay lets the bridge's 90-second command deadline fire before ChatGPT exposes the new conversation id. The same page can then create/resume chat B a few seconds later, after A -> B was already aborted, leaving an orphan resumed chat.

Closes #32.

## Minimal fix

Keep the existing 90-second command deadline unchanged for the normal browser-open path and for worker/revival ACKs.

For a **resume only after its continuation is durably `claimed` by the exact document**:

- re-arm the existing command timer to the **remaining existing `CONTINUATION_TTL_MS`**;
- treat continuation state `claimed` as an active lease in `isLeased()` after the short 90-second window.

That is the whole behavioral change. It deliberately does **not** add a new state, heartbeat, preflight, retry loop, fsync, network request, or new lifetime. `CONTINUATION_TTL_MS` is already the continuation state machine's outer bound (10 minutes total from continuation opening), specifically documented as covering a slow generation plus browser launch.

Worker/revival behavior is unchanged. An unclaimed/failed resume still follows the existing short failure path. A claimed resume can survive the observed >90s background-tab delay, but cannot outlive the continuation that already owns its handoff.

## Why this matches the existing design

The project already has two distinct authorities:

- `COMMAND_DEADLINE_MS`: short browser/page delivery deadline;
- `CONTINUATION_TTL_MS`: outer lifetime for the A -> B continuation, including slow generation + browser startup.

The bug came from letting the shorter command timer destroy a continuation that the exact replacement page had already durably claimed. The patch makes the command timer defer to the existing continuation lifetime at that one boundary instead of inventing another timeout policy.

The existing invariants remain intact: one command -> one page, no background retry, single claimant, and source session stays on A if the continuation ultimately expires.

## Regression coverage

The bridge regression now proves that:

- a page can redeem after slow browser startup;
- the claimed resume remains owned more than 90 seconds later;
- it remains in `claimed`, not silently extended into a new state;
- the existing 10-minute continuation TTL is still the outer bound;
- expiry leaves the local session attached to the source conversation.

The existing test for an unredeemed page still verifies the normal 90-second failure path.

## Verification

Final simplified patch:

- `npx vitest run test/bridge.test.ts` - **129/129 passed**
- `npm test` - **69/69 test files passed; 1806 passed, 18 skipped**
- `npm run typecheck` - passed
- `npm run build` - passed
- `git diff --check` - passed

Production diff is limited to `src/main/bridge.ts`; the only other changed file is the regression test.
