### PR TITLE
Recognise Project conversation routes as conversations

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1600,7 +1600,9 @@ function conversationFromUrl(value) {
   try {
     const url = new URL(String(value || ''));
     if (url.protocol !== 'https:' || (url.hostname !== 'chatgpt.com' && url.hostname !== 'chat.openai.com')) return null;
-    const match = /^\/c\/([0-9a-f-]{8,64})/i.exec(url.pathname);
+    // Matches chatgpt-dom.js: a Project conversation is `/g/<project>/c/<id>`, while
+    // `/share/c/<id>` is a public snapshot the service worker must never bind a tab to.
+    const match = /^\/(?:g\/[^/]+\/)?c\/([0-9a-f-]{8,64})(?:\/|$)/i.exec(url.pathname);
     return match ? match[1] : null;
   } catch {
     return null;

--- a/extension/chatgpt-dom.js
+++ b/extension/chatgpt-dom.js
@@ -257,12 +257,28 @@ var CLF_DOM = (() => {
     return /(?:message delivery timed out|unknown error occurred|there was an error generating (?:a|the) response|error in message stream|network error|something went wrong)/i.test(line);
   }
 
-  /** The conversation this tab is on, or null for a chat that has not been sent yet. */
-  function conversationId() {
+  /**
+   * The conversation a ChatGPT path names, or null when it names none.
+   *
+   * A conversation inside a Project is routed as `/g/<project>/c/<id>`, so anchoring at
+   * `/c/` recognised only chats at the site root. Everything downstream — the app session,
+   * the ownership registry, caller attribution — is keyed on this id, so in a Project the
+   * page was never recognised as being on a conversation at all.
+   *
+   * Deliberately not a loose `/c/<id>` search anywhere in the path: `/share/c/<id>` is a
+   * public read-only snapshot of someone's conversation, not a conversation this document
+   * can own, record or bind. One optional `/g/<slug>` segment is the whole exception.
+   */
+  function conversationFromPath(pathname) {
     return safe(() => {
-      const match = /^\/c\/([0-9a-f-]{8,64})/i.exec(location.pathname);
+      const match = /^\/(?:g\/[^/]+\/)?c\/([0-9a-f-]{8,64})(?:\/|$)/i.exec(String(pathname || ''));
       return match ? match[1] : null;
     }, null);
+  }
+
+  /** The conversation this tab is on, or null for a chat that has not been sent yet. */
+  function conversationId() {
+    return safe(() => conversationFromPath(location.pathname), null);
   }
 
   /** Human ChatGPT title when one has actually been generated; never conversation identity. */
@@ -1419,6 +1435,7 @@ var CLF_DOM = (() => {
 
   return {
     conversationId,
+    conversationFromPath,
     conversationTitle,
     turns,
     presentationTurns,

--- a/extension/content.js
+++ b/extension/content.js
@@ -2108,7 +2108,13 @@
     try {
       const path = location.pathname;
       if (path === seededPath) return true;
-      const named = /^\/c\//.test(path) && !/^\/c\//.test(seededPath || '');
+      // Through the canonical parser, not a second `/c/` test of its own. In a Project the
+      // route is `/g/<project>/c/<id>`, so the local test recognised no id there: a fresh
+      // Project chat being given its id looked like a navigation to a different chat, which
+      // banked the turn in flight as history and lost the evidence for the first call — the
+      // call that says who the chat is.
+      const named =
+        CLF_DOM.conversationFromPath(path) !== null && CLF_DOM.conversationFromPath(seededPath) === null;
       seededPath = path;
       return named;
     } catch {

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -7399,6 +7399,53 @@ describe('the fresh chat the app opened', () => {
     ]);
   });
 
+  /**
+   * The same acquisition, inside a Project.
+   *
+   * A Project chat is routed `/g/<project>/c/<id>`, so a `/c/` test of its own saw no id on
+   * that route: the moment ChatGPT named the fresh chat looked like a navigation to a
+   * different conversation. The bootstrap was then abandoned and the turn in flight banked
+   * as history, which is what left the chat with no app session and every later tool call
+   * without a provable caller.
+   */
+  it('acquires its id when a Project route names the fresh chat', async () => {
+    live = await harness(
+      'https://chatgpt.com/g/g-p-68abcdef1234/project?clf=cmd-project#clf=cmd-project',
+      {
+        redeem: () => ({
+          ok: true,
+          command: {
+            id: 'cmd-project',
+            type: 'resume',
+            text: 'Continue the previous ChatGPT session. Handoff: h-project',
+            agent: null
+          }
+        }),
+        ack: () => ({ ok: true })
+      },
+      (document, dom) => {
+        document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+          dom.reconfigure({
+            url: 'https://chatgpt.com/g/g-p-68abcdef1234/c/77777777-6666-5555-4444-333333333333'
+          });
+        });
+      }
+    );
+
+    await settle(400);
+
+    expect(live.sent.filter((message) => message.type === 'redeem')).toHaveLength(1);
+    expect(live.document.querySelector('#prompt-textarea')!.textContent).toContain('Handoff: h-project');
+    expect(live.sent.filter((message) => message.type === 'ack')).toMatchObject([
+      {
+        type: 'ack',
+        id: 'cmd-project',
+        status: 'sent',
+        conversationId: '77777777-6666-5555-4444-333333333333'
+      }
+    ]);
+  });
+
   it('abandons a redeemed bootstrap if SPA navigation retargets the tab before insertion', async () => {
     let page: JSDOM | null = null;
     let sends = 0;

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -202,6 +202,8 @@ function toolBlock(label = 'Called tool'): FakeNode {
 }
 
 interface DomApi {
+  conversationId(): string | null;
+  conversationFromPath(pathname: unknown): string | null;
   turns(): Array<{ node: FakeNode; nodes: FakeNode[]; id: string | null; role: string | null }>;
   messages(): Array<{ id: string; role: string; text: string; turnId: string | null }>;
   progressLine(turn: unknown): string | null;
@@ -212,12 +214,12 @@ interface DomApi {
   errors(): string[];
 }
 
-function loadDom(sections: FakeNode[]): DomApi {
+function loadDom(sections: FakeNode[], pathname = '/c/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'): DomApi {
   const document = {
     querySelectorAll: (selector: string) => (selector === TURN_SELECTOR ? sections : []),
     querySelector: () => null
   };
-  const context = vm.createContext({ document, location: { pathname: '/c/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' } });
+  const context = vm.createContext({ document, location: { pathname } });
   vm.runInContext(domSource, context, { filename: 'chatgpt-dom.js' });
   return (context as unknown as { CLF_DOM: DomApi }).CLF_DOM;
 }
@@ -227,6 +229,46 @@ function turn(role: 'user' | 'assistant', id: string): FakeNode {
 }
 
 describe('ChatGPT DOM adapter', () => {
+  const CONVERSATION = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+  /**
+   * Project conversations are routed under the project, and everything downstream — app
+   * session, ownership registry, caller attribution — is keyed on the id this returns.
+   * A shared snapshot is deliberately not a conversation this document can own.
+   */
+  it('recognises a conversation at the site root and inside a Project, and only those', () => {
+    const dom = loadDom([]);
+    for (const accepted of [
+      `/c/${CONVERSATION}`,
+      `/c/${CONVERSATION}/`,
+      `/g/g-p-68abcdef1234/c/${CONVERSATION}`,
+      `/g/g-p-68abcdef1234/c/${CONVERSATION}/`,
+      `/g/g-abcdef/c/${CONVERSATION}`
+    ]) {
+      expect(dom.conversationFromPath(accepted), accepted).toBe(CONVERSATION);
+    }
+
+    for (const rejected of [
+      '/',
+      '/c/short',
+      `/share/c/${CONVERSATION}`,
+      `/share/${CONVERSATION}`,
+      `/gpts/c/${CONVERSATION}`,
+      `/g/g-p-one/g/g-p-two/c/${CONVERSATION}`
+    ]) {
+      expect(dom.conversationFromPath(rejected), rejected).toBeNull();
+    }
+
+    expect(dom.conversationFromPath(null)).toBeNull();
+    expect(dom.conversationFromPath(undefined)).toBeNull();
+  });
+
+  it('reads the live route through that same parser', () => {
+    expect(loadDom([], `/g/g-p-68abcdef1234/c/${CONVERSATION}`).conversationId()).toBe(CONVERSATION);
+    expect(loadDom([], `/share/c/${CONVERSATION}`).conversationId()).toBeNull();
+    expect(loadDom([], '/').conversationId()).toBeNull();
+  });
+
   it('groups split assistant sections that share one data-turn-id before counting tool blocks', () => {
     const user = turn('user', 'user-1');
     const a1 = turn('assistant', 'request-1').with(TOOL_SELECTOR, [toolBlock(), toolBlock()]);


### PR DESCRIPTION
Fixes #25.

## Root cause

A conversation inside a ChatGPT Project is routed `/g/<project>/c/<id>`. Three independent parsers anchored at `/c/`, so on that route the extension recognised no conversation:

- `extension/chatgpt-dom.js` — `conversationId()`
- `extension/background.js` — `conversationFromUrl()`
- `extension/content.js` — `sameChat()`

The reporter identified the first two. The third is the one that produces the reported symptom. `sameChat()` used `/^\/c\//` on the old and the new path to distinguish "this fresh chat was just given its id" — `/` to `/c/<id>`, the same chat — from "the tab navigated to a different conversation". In a Project neither path matches that test, so the moment ChatGPT names the chat reads as a navigation away. The bootstrap is abandoned and the turn in flight is banked as history, which loses the evidence for the first call a fresh chat makes. In an agent chat that is the call that says who the chat is, which is why the popup shows a chat id alongside `app session: —` and why later tool calls cannot prove a caller.

## Change

`chatgpt-dom.js` owns a single `conversationFromPath(pathname)`; `conversationId()` applies it to `location.pathname`, `sameChat()` applies it to both paths it compares, and `background.js` uses the same pattern for tab URLs.

It accepts exactly one optional `/g/<slug>` segment. A loose `/c/<id>` search anywhere in the path would be wrong: `/share/c/<id>` is a public read-only snapshot of someone's conversation, not a conversation this document can own, record or bind. `/gpts/c/<id>` and a doubled `/g/…/g/…/c/<id>` are rejected for the same reason.

No permission, identity or recovery behaviour changes. A root-level `/c/<id>` resolves exactly as before.

## Validation

`test/extension.test.ts` — `loadDom` now takes a pathname, and two cases cover the parser directly: five accepted routes (root, Project, both with and without a trailing slash, a non-Project `/g/` slug) and six rejected ones (`/`, a too-short id, `/share/c/<id>`, `/share/<id>`, `/gpts/c/<id>`, a doubled project segment), plus `null`/`undefined`.

`test/content-script.test.ts` — a behavioural case in the fresh-chat suite: a bootstrap opened on a Project new-chat route, with ChatGPT naming the chat `/g/g-p-…/c/<id>` on send. It asserts the command is redeemed once, the handoff text reaches the composer, and the ack reports that conversation id.

Both fail against the pre-fix pattern — the parser case with `expected null to be 'aaaaaaaa-…'`, the behavioural case on the missing ack — and pass with it.

Full local run on Windows x64: `npm run typecheck` clean, `vitest run` 1807 passed / 18 skipped across 68 files, `test/mcp-shutdown.test.ts` 2 passed.

## Not included

The reporter also described a stacked prime/worker ownership problem in the same thread. That is a separate path and is not touched here.
