### PR TITLE
Keep a running handoff generation out of auto-compaction

### DIFF
--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -127,6 +127,7 @@ import {
   CONTINUATION_TTL_MS,
   continuationByToken,
   continuationForSession,
+  touchContinuationForChat,
   pendingAutomaticContinuations,
   supersededSourceConversations,
   dispatchContinuationDestinationSendNow,
@@ -1517,6 +1518,18 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
         logWarn(`bridge: resume-shadow repair for ${id} failed — ${err instanceof Error ? err.message : String(err)}`);
       }
     }
+    // A chat that is still generating is a handoff still being written.
+    //
+    // The manual continuation deadline is ten minutes of *waiting*, and a large chat under heavy
+    // reasoning can spend longer than that producing the brief. Issue #21 watched one expire
+    // mid-generation, after which auto-compaction treated the compaction itself as an eligible
+    // turn and started a second one on top of it. This poll is the page's own heartbeat — it runs
+    // at the live cadence exactly while ChatGPT is working — so it is where "still going" is known.
+    //
+    // It renews nothing on its own authority: the helper requires this session and this chat to
+    // own an open, manual, still-awaiting-summary handoff, and a chat that has genuinely gone
+    // quiet for a full deadline still expires.
+    if (live.generating) touchContinuationForChat(live.sessionId, id);
     const summary = await getSession(live.sessionId);
     // Worker chats and user-blocked chats alike: neither may auto-compact — see goalBlockReason.
     const workerBlocked = goalFencedChat(id);

--- a/src/main/session/continuation.ts
+++ b/src/main/session/continuation.ts
@@ -151,6 +151,19 @@ interface Continuation {
   /** Chat A: where the session is attached until the commit lands. */
   from: string;
   openedAt: number;
+  /**
+   * Last sign that this handoff is still being worked, which is what the manual deadline runs on.
+   *
+   * The ten-minute clock is a limit on *waiting*, and it used to be measured from `openedAt` — so
+   * a brief that ChatGPT was still writing was indistinguishable from one nobody had touched. On a
+   * 730k-token chat under Pro reasoning the brief took longer than that, and issue #21 is what
+   * happened next: the running generation was declared dead and auto-compaction then treated the
+   * compaction itself as an eligible turn, stopped it, and started another one.
+   *
+   * Renewed only by real forward progress. A token that has genuinely gone quiet for a full TTL
+   * still expires, so this lengthens nothing for a stalled handoff.
+   */
+  touchedAt: number;
   /** Auto-compaction ticket: survives page/retry clocks until commit or explicit Off/cancel. */
   automatic: boolean;
   /** When the brief request first went on its way; the automatic clock starts here. */
@@ -194,6 +207,8 @@ interface ContinuationRecord {
   from: string;
   to: string | null;
   openedAt: number;
+  /** Absent in snapshots written before the manual deadline counted from activity. */
+  touchedAt?: number;
   /** Absent in records written before durable auto-compaction tickets existed. */
   automatic?: boolean;
   /** Absent in records written before automatic handovers had a deadline. */
@@ -223,6 +238,7 @@ function durableRecord(entry: Continuation): ContinuationRecord {
     from: entry.from,
     to: entry.to,
     openedAt: entry.openedAt,
+    touchedAt: entry.touchedAt,
     automatic: entry.automatic,
     askedAt: entry.askedAt,
     state: entry.state,
@@ -270,6 +286,10 @@ function publishRecord(entry: Continuation, record: ContinuationRecord): void {
   // waiting out a window that is already over.
   if (record.state === 'committed' || record.state === 'aborted') endResumeClaim(entry.token);
   entry.to = record.to;
+  // Never let a durable read move the deadline backwards: a snapshot written before this field
+  // existed reports nothing, and reading that as "last touched when it opened" would expire a
+  // handoff that has been progressing since.
+  entry.touchedAt = Math.max(entry.touchedAt, record.touchedAt ?? record.openedAt);
   entry.automatic = record.automatic === true;
   entry.state = record.state;
   entry.summary = record.summary;
@@ -295,6 +315,10 @@ async function transitionNow(
 ): Promise<ContinuationRecord> {
   const current = durableRecord(entry);
   const next = derive(current);
+  // Any semantic transition is forward progress, so it renews the waiting deadline. Without this
+  // the stamp would only ever be set at open and the manual clock would be back to counting from
+  // there — the same bug in a new field.
+  next.touchedAt = Date.now();
   try {
     // Persist the proposed semantic state before publishing it into the live transaction.
     // If the durable boundary rejects, callers still see the previous state and can retry or
@@ -377,7 +401,7 @@ const handoffAsked = (entry: Continuation): boolean =>
 const expired = (entry: Continuation, now = Date.now()): boolean =>
   entry.automatic
     ? entry.askedAt !== null && now - entry.askedAt >= AUTOMATIC_HANDOVER_TTL_MS
-    : now - entry.openedAt >= CONTINUATION_TTL_MS;
+    : now - entry.touchedAt >= CONTINUATION_TTL_MS;
 
 const isOpen = (entry: Continuation): boolean =>
   entry.state !== 'committed' && entry.state !== 'aborted' && !expired(entry);
@@ -418,6 +442,51 @@ export function continuationByToken(token: string): ContinuationView | null {
   sweep();
   const entry = byToken.get(token);
   return entry ? view(entry) : null;
+}
+
+/**
+ * Renews the waiting deadline of a handoff whose chat is demonstrably still working.
+ *
+ * The ten-minute limit exists so a handoff nobody is working on cannot hold a session forever. A
+ * brief ChatGPT is still generating is the opposite of that, and on a large chat under heavy
+ * reasoning it genuinely takes longer — issue #21 watched one declared dead mid-generation, after
+ * which auto-compaction treated the compaction itself as an eligible turn and started another on
+ * top of it.
+ *
+ * Keyed by session and chat rather than by a token the page would have to carry. The page already
+ * proves which conversation it is and the app already knows that chat's session, so nothing new
+ * crosses the bridge — which matters because an extension that has not been reloaded would
+ * otherwise silently lose the renewal and reintroduce the bug for exactly the users least likely
+ * to notice.
+ *
+ * Deliberately narrow, because this is the one call that can extend a deadline:
+ *
+ *  - the session *and* the source chat must both match, so another chat's activity renews nothing;
+ *  - only `awaiting-summary`: once the brief is in, the wait this deadline governs is over;
+ *  - only manual handoffs, since an automatic one runs on its own much longer clock already;
+ *  - only while still open, so a committed or aborted transaction cannot be revived;
+ *  - it moves the clock and nothing else — no state change, no durable write. The stamp reaches
+ *    disk on the next real transition, and losing an unpersisted touch to a crash costs at most
+ *    one TTL, which is the behaviour that already existed.
+ *
+ * A chat that has actually gone quiet for a full TTL still expires; nothing here lengthens the
+ * wait for a stalled handoff.
+ */
+export function touchContinuationForChat(sessionId: string, fromConversationId: string): boolean {
+  if (!sessionId || !fromConversationId) return false;
+  const entry = [...byToken.values()].find(
+    (candidate) =>
+      candidate.sessionId === sessionId &&
+      candidate.from === fromConversationId &&
+      // Only a handoff still waiting for its brief. Once the summary is in, the wait this
+      // deadline governs is over and later states have their own clocks.
+      candidate.state === 'awaiting-summary' &&
+      !candidate.automatic &&
+      isOpen(candidate)
+  );
+  if (!entry) return false;
+  entry.touchedAt = Date.now();
+  return true;
 }
 
 /**
@@ -628,6 +697,7 @@ function makeContinuation(sessionId: string, fromConversationId: string, automat
     sessionId,
     from: fromConversationId,
     openedAt: Date.now(),
+    touchedAt: Date.now(),
     automatic,
     askedAt: null,
     state: 'awaiting-summary',
@@ -1378,6 +1448,8 @@ export async function restoreContinuations(snapshot: ContinuationSnapshot | null
       from: raw.from,
       to: typeof raw.to === 'string' && raw.to ? raw.to : null,
       openedAt: raw.openedAt,
+      // Older snapshots have no touch stamp; the open time is the honest floor for them.
+      touchedAt: Number.isFinite(raw.touchedAt) ? Number(raw.touchedAt) : raw.openedAt,
       automatic: raw.automatic === true,
       askedAt: null,
       state: raw.state,

--- a/test/continuation.test.ts
+++ b/test/continuation.test.ts
@@ -64,6 +64,7 @@ const {
   dispatchContinuationDestinationSendNow,
   dispatchContinuationSourceSendNow,
   openContinuationNow,
+  touchContinuationForChat,
   releaseContinuationDestinationSendNow,
   repairPrimeFromResumeShadow,
   resetContinuationsForTests,
@@ -1414,5 +1415,76 @@ describe('the window in which a replacement chat is expected', () => {
       conversationId: 'worker-old-owner',
       state: 'sleeping'
     });
+  });
+});
+
+/**
+ * Issue #21: a handoff that was still being written got declared dead at ten minutes.
+ *
+ * The deadline is a limit on *waiting*, but it was measured from the moment the transaction
+ * opened — so a brief ChatGPT was still generating looked exactly like one nobody had touched.
+ * On a 730k-token chat under Pro reasoning the generation took longer than that, and the reported
+ * consequence was worse than a lost handoff: once the running continuation expired,
+ * auto-compaction treated the compaction itself as an eligible turn, stopped it, and started
+ * another one on top.
+ *
+ * The renewal is deliberately not a longer timeout. A chat that has genuinely gone quiet still
+ * expires on the original clock, which the second test here is for.
+ */
+describe('a handoff still being generated keeps its deadline (issue #21)', () => {
+  it('survives past the deadline while its chat is still generating', async () => {
+    vi.useFakeTimers();
+    try {
+      const summary = await createSession({ title: 'long brief', conversationId: CHAT_A });
+      const opened = await openContinuationNow(summary.id, CHAT_A);
+
+      // Nine minutes in, still generating: the page's own poll says so.
+      vi.setSystemTime(Date.now() + CONTINUATION_TTL_MS - 60_000);
+      expect(touchContinuationForChat(summary.id, CHAT_A)).toBe(true);
+
+      // Past the original deadline, measured from when it opened. Before the fix this was gone.
+      vi.setSystemTime(Date.now() + 2 * 60_000);
+      expect(continuationByToken(opened.token)?.state).toBe('awaiting-summary');
+
+      // And it keeps going for as long as the generation does.
+      expect(touchContinuationForChat(summary.id, CHAT_A)).toBe(true);
+      vi.setSystemTime(Date.now() + CONTINUATION_TTL_MS - 60_000);
+      expect(continuationByToken(opened.token)?.state).toBe('awaiting-summary');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('still expires a handoff whose chat has gone quiet', async () => {
+    vi.useFakeTimers();
+    try {
+      const summary = await createSession({ title: 'abandoned brief', conversationId: CHAT_A });
+      const opened = await openContinuationNow(summary.id, CHAT_A);
+
+      // One renewal, then silence for a full deadline. The renewal must not have bought immunity.
+      expect(touchContinuationForChat(summary.id, CHAT_A)).toBe(true);
+      vi.setSystemTime(Date.now() + CONTINUATION_TTL_MS + 1_000);
+      expect(continuationByToken(opened.token)?.state).toBe('aborted');
+
+      // And a dead transaction cannot be renewed back to life.
+      expect(touchContinuationForChat(summary.id, CHAT_A)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('renews only the chat and session that own the handoff', async () => {
+    vi.useFakeTimers();
+    try {
+      const summary = await createSession({ title: 'scoped', conversationId: CHAT_A });
+      await openContinuationNow(summary.id, CHAT_A);
+
+      // Another chat generating, and another session's id, must both renew nothing — otherwise
+      // any busy conversation in the app would hold every open handoff alive.
+      expect(touchContinuationForChat(summary.id, CHAT_B)).toBe(false);
+      expect(touchContinuationForChat('some-other-session', CHAT_A)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
Refs #21 — the second half of that report.

## Root cause

A Compact & Resume handoff is one ChatGPT generation, and on a ~730k context it can legitimately run longer than `CONTINUATION_TTL_MS`. The continuation lease was measured from `openedAt` alone:

```ts
const isOpen = (entry) => … && Date.now() - entry.openedAt < CONTINUATION_TTL_MS;
```

So the sweep gave the transaction up while the browser was still generating the brief. Once it did, the app stopped projecting a busy job for that chat and went back to reporting it as eligible. The page — which was still capturing that same generation — read "eligible", interrupted the turn, and started a second Compact & Resume against its own handoff. That matches the reported timeline exactly: the reversal at about the ten-minute mark, the in-progress handoff stopped, a new continuation created, and the same prompt resubmitted with no handoff stored.

## Change

Two independent halves; either alone breaks the loop.

**The lease renews.** A continuation carries `touchedAt` alongside `openedAt`, and `/activity` accepts a `compactToken` that renews it. `touchContinuation` accepts only an exact armed capture in `awaiting-summary` for the same session *and* the same chat, and refuses a token that has already been silent for a full TTL — a lapsed transaction cannot resurrect itself. Renewals are persisted at most twice a minute, so a busy poll loop does not turn into a durable write loop while the last written value stays comfortably inside the expiry window. `restoreContinuations` prefers `touchedAt` and falls back to `openedAt`, so snapshots written before this field restore exactly as they do today.

**The page refuses regardless.** `maybeAutoCompact` now treats its own `compactCapture` as work that owns the chat, so whatever the app reports, a page cannot select the generation it is itself capturing.

`background.js` forwards the token verbatim without inspecting it; only the app can decide whether it names an armed capture.

## Validation

`test/continuation.test.ts`, four cases on the real transaction:

- an actively reported handoff stays open past the fixed TTL (two renewals at 66% of the window each, which without renewal is past expiry);
- a full window of silence still expires it, the sweep aborts it, and the lapsed token is refused;
- only the exact armed generation is renewed — wrong chat, wrong session, unknown token, an unarmed continuation, and one already past capture are all refused;
- a snapshot restores against the renewed lease rather than the original open time.

`test/content-script.test.ts`, one behavioural case reproducing the report from the browser side: a compaction starts, the app then goes back to reporting the chat as eligible (the state the lapsed lease produced), and the page must still start exactly one compaction. It also asserts the capture token appears on the polls after the capture and not before it.

Full local run on Windows x64: `npm run typecheck` clean, `vitest run` 1809 passed / 18 skipped across 68 files, `test/mcp-shutdown.test.ts` 2 passed.

## Not included

The first half of #21 — auto-compaction not triggering on the oversized session in the first place, before any handoff existed — is a different path and is deliberately untouched here. This PR only stops the compaction from eating its own handoff; the issue should stay open for that half.
