### PR TITLE
RFC: define a bounded Codex Desktop thread bridge

### DIFF
--- a/docs/codex-desktop-bridge.md
+++ b/docs/codex-desktop-bridge.md
@@ -4,37 +4,42 @@
 
 Design draft only. This document deliberately adds no production tool yet.
 
-The missing piece is not the thread API. Codex app-server already has bounded methods for
-listing, reading, creating and messaging threads. The missing piece is a supported way for a
-separate local app to bind those methods to the **specific Codex Desktop instance the user is
-looking at**, rather than to an unrelated CLI/default daemon.
+The transport picture changed after this RFC was opened. Codex CLI 0.152.1 ships an official
+`codex queue --thread <UUID> --message ...` command against the shared local app-server. On a Mac
+running Codex Desktop, queuing to the UUID of a task already visible in Desktop delivered the next
+user turn to that exact task and the task continued there, without foreground activation or GUI
+automation.
 
-Implementing before that ownership boundary is agreed would recreate the bug this proposal is
-meant to remove: a successful backend acknowledgement that affected the wrong task.
+That materially shrinks the original blocker: background **send to a known existing Desktop thread**
+is now proven through a supported Codex surface. The remaining integration question is narrower:
+which supported list/read/wait primitives provide bounded identity and transcript/status evidence
+for those same Desktop threads, and what host-instance guarantees should Chat On Steroids require
+before it exposes them to the model.
 
 ## Problem
 
-Chat On Steroids can inspect local recordings and can control the desktop, but neither is the
-right default for supervising an existing Codex Desktop task:
+Chat On Steroids can inspect local recordings and can control the desktop, but neither is the right
+default for supervising an existing Codex Desktop task:
 
 - GUI automation steals focus and competes with the user's foreground work;
 - writing into Codex's persisted databases bypasses its ordering and notification contracts;
-- invoking `codex queue` or another CLI command may reach a different app-server daemon;
-- a successful CLI response therefore does not prove the visible Desktop task received anything.
+- title-only or default-daemon addressing is ambiguous;
+- a transport acknowledgement alone is not enough unless the bridge can name and read back the
+  exact thread that received the message.
 
 The desired workflow is background-first:
 
 ```text
 ChatGPT
   -> Chat On Steroids Core
-  -> the user's current Codex Desktop app-server
-  -> one explicitly identified Desktop thread
+  -> supported Codex local thread surface
+  -> one explicitly identified Codex Desktop thread
   -> that thread may use its own control-chrome integration
 ```
 
 The browser part stays inside Codex Desktop. The bridge does not proxy browser cookies, tabs or
-profiles; it only sends a normal user message to a Desktop thread. That thread can then use the
-same Chrome/Dia state it already owns.
+profiles; it only supervises Codex threads. A Desktop thread can then use the Chrome/Dia state it
+already owns.
 
 ## Proposed model-facing contract
 
@@ -62,62 +67,57 @@ The tool should return enough identity to prevent same-title mistakes:
 
 It should not expose arbitrary app-server RPC, raw internal events, or an unbounded thread dump.
 
-## App-server mapping
+## Codex mapping
 
-The current Codex app-server protocol already supplies the required primitives:
+The existing app-server protocol has thread list/read/start/turn primitives, while the shipped CLI
+now provides a first-party existing-thread queue operation. The first vertical slice should prefer
+these supported surfaces rather than invent a private transport.
 
-| Tool action | App-server methods |
-| --- | --- |
-| `list` | `thread/list` |
-| `read` | `thread/read`, then bounded `thread/items/list` pages |
-| `send` | `thread/queue/add` for an active task, or `turn/start` when idle |
-| `wait` | event subscription when available, otherwise bounded `thread/read` / item polling |
-| `create` | `thread/start`, followed by `turn/start` |
+A successful `send` is not complete merely because a process exits zero. The bridge should:
 
-A successful `send` is not complete at the first RPC response. The bridge must:
+1. require an exact thread id;
+2. generate or retain an operation identity when the supported surface allows it;
+3. receive the Codex acknowledgement;
+4. read that same thread back through a supported read surface;
+5. confirm the expected user message/turn is queued or present;
+6. return acknowledgement and observed thread identity together.
 
-1. generate a unique `clientUserMessageId`;
-2. receive the queue/turn acknowledgement from the bound app-server;
-3. read the same thread back;
-4. confirm that exact client message is queued or present in the thread;
-5. return the acknowledgement and observed thread identity together.
+The live `codex queue --thread <UUID>` test proves steps 1–3 can reach the exact Desktop-visible
+thread. Steps 4–6 are still the important product boundary for a model-facing CoS integration.
 
-That final read is what turns "a server accepted bytes" into "this Desktop task received the
-message".
+## Binding and identity requirement
 
-## Binding requirement
+The bridge must never silently mutate a task selected only by title, cwd, or whichever daemon
+happens to answer first. Mutations require the exact Codex thread id.
 
-The bridge must bind to the app-server instance owned by the current Codex Desktop application.
-It must not silently fall back to another locally running Codex daemon.
+For the initial existing-thread slice, a usable integration needs at least:
 
-A usable binding needs at least:
-
-- an authenticated or OS-authorized transport supplied by Codex Desktop;
-- a stable instance identity for the lifetime of the connection;
-- an initialization response that can be checked before any thread mutation;
-- disconnect/restart detection so a stale endpoint cannot be mistaken for the same app;
-- explicit failure when the Desktop instance is unavailable.
+- supported enumeration that yields exact thread ids plus enough metadata to choose safely;
+- bounded read-back for the exact id;
+- the official queue/send path for that id;
+- restart/stale-thread behavior that is detectable rather than silently redirected;
+- explicit failure when Codex cannot establish the requested thread identity.
 
 ### Current finding
 
-Codex app-server supports official WebSocket transports when a server is launched with an
-explicit `--listen` endpoint, and it also has an experimental remote-control protocol. Those are
-real integration contracts.
+The earlier version of this RFC treated Desktop binding itself as the unsolved transport problem.
+That is now too strong.
 
-The current packaged Codex Desktop instance, however, does not expose a documented local
-app-server endpoint to unrelated processes. Its internal dynamic app-tools pipe is peer-authorized
-and is not a third-party integration surface. An external Chat On Steroids process is rejected,
-which is the correct boundary; this proposal must not weaken or bypass it.
+On Codex CLI 0.152.1, this was verified end to end against a task already visible in Codex Desktop:
 
-Therefore the first implementation requires one of these supported seams:
+```text
+codex queue --thread <exact-visible-thread-uuid> --message <harmless message>
+```
 
-1. Codex Desktop publishes a scoped local app-server endpoint or capability token;
-2. Codex remote-control pairing exposes the current Desktop instance to an approved local client;
-3. Codex Desktop supplies a small first-party app tool that forwards only the allowlisted thread
-   operations.
+The message became the next user turn in that exact Desktop task and execution continued there.
+There was no GUI focus/click/type path and no separately created replacement thread.
 
-Until one of those is available, connecting to a separately launched app-server can validate the
-protocol client but cannot honestly be called control of the user's current Desktop task.
+Therefore we should not build or bypass a private Desktop pipe merely to obtain background send.
+The remaining work is to verify the supported enumeration/read/wait surface and its identity/staleness
+semantics, then wrap only the subset CoS actually needs.
+
+A separately launched generic app-server remains useful as a protocol test fixture, but production
+code should not silently fall back to it when the user asked to supervise an existing Desktop task.
 
 ## Rejected approaches
 
@@ -126,10 +126,11 @@ protocol client but cannot honestly be called control of the user's current Desk
 Useful for testing the UI itself, but wrong for task coordination. It changes foreground state and
 provides no durable thread acknowledgement.
 
-### Bare Codex CLI commands
+### Unscoped/default CLI addressing
 
-The CLI binary and Codex Desktop share lower-level runtime code, but they are not the same product
-instance. A default daemon acknowledgement is not proof about the visible Desktop task.
+The fact that `codex queue --thread <exact UUID>` is now useful does not make title-only or implicit
+default-task mutation acceptable. The bridge must always carry exact thread identity and should
+read the target back after mutation.
 
 ### Direct database writes
 
@@ -138,8 +139,8 @@ persistence, not a mutation API.
 
 ### Attaching to private pipes
 
-The packaged app's private pipe is peer-authorized. Spoofing or disabling that check would turn a
-narrow convenience feature into an unsupported privilege boundary.
+Codex Desktop's internal pipes are not a third-party integration contract. There is no reason to
+weaken or spoof that boundary when a first-party queue path already exists for the key send use case.
 
 ### Generic RPC passthrough
 
@@ -171,23 +172,32 @@ thread to use `control-chrome` is a message to that thread, not browser credenti
 - No foreground activation of Codex Desktop.
 - No automatic creation when an existing task was requested.
 - No title-only addressing; mutations require the exact thread id.
-- No retry against a different endpoint after disconnect.
-- A Desktop restart invalidates the client and requires a fresh instance handshake.
+- No silent retry against a different thread or daemon after failure.
+- Stale/unknown thread identity fails closed.
 - `wait` is bounded and returns an update cursor; it is not an unbounded background process.
-- Ambiguous or stale identity fails closed.
+- Successful send should include read-back evidence when the supported Codex read surface permits it.
 
 ## Staged implementation
 
-### Phase 1: transport decision
+### Phase 1: verify the remaining supported identity surface
 
-Agree with the maintainer which supported Codex Desktop binding seam this project is willing to
-depend on. Retain the explicit app-server WebSocket client as a protocol test fixture, not as a
-claim of Desktop integration.
+Keep the already-proven exact-thread `codex queue` send path. Verify how current Codex exposes:
+
+- bounded thread enumeration;
+- bounded thread read/tail;
+- active/idle status;
+- update/wait semantics;
+- behavior across Codex Desktop restart and stale thread ids.
+
+Do not use private pipes or database mutation to fill a missing capability.
 
 ### Phase 2: bounded vertical slice
 
-Implement `list`, `read` and `send` behind one `codex_desktop` schema, with separate read/control
-permissions and deterministic fake-app-server tests. Verify exact `clientUserMessageId` delivery.
+Implement existing-thread `list`, `read` and `send` behind one `codex_desktop` schema, with separate
+read/control permissions and deterministic fake/runtime tests. Use the supported queue path for send
+unless a lower-level first-party contract is demonstrably required.
+
+Leave `create` out of the first slice unless it naturally falls out of the same supported surface.
 
 ### Phase 3: live acceptance
 
@@ -195,17 +205,19 @@ From ChatGPT, without focusing Codex Desktop:
 
 1. list Desktop tasks and identify one by id + title + cwd;
 2. read its current tail;
-3. send a harmless message;
-4. observe the same message in that exact task;
+3. send a harmless message to the exact id;
+4. read back the same thread and observe that message;
 5. wait for its next assistant update;
 6. verify the task can use its existing `control-chrome` browser state.
 
-Only this live proof closes the original problem.
+The direct `codex queue` experiment has already proven step 3 outside CoS. The full slice closes the
+loop only when the read/list identity path is equally explicit.
 
 ## Questions for review
 
 1. Is a Codex Desktop bridge within this project's scope, or should it remain an external plugin?
-2. Which supported binding should Chat On Steroids target: a local capability endpoint,
-   remote-control pairing, or a first-party forwarding app tool?
+2. Is wrapping the shipped exact-thread CLI/app-server surface acceptable, or does the maintainer
+   prefer CoS to target a lower-level first-party contract once its read/list guarantees are clear?
 3. Does the one-schema/two-permission contract fit the current Core surface?
-4. Should `create` ship in the first slice, or follow after existing-thread supervision is proven?
+4. Should the first slice stop at existing-thread `list/read/send`, leaving `wait`/`create` for
+   follow-ups if their supported contracts are less mature?

--- a/docs/codex-desktop-bridge.md
+++ b/docs/codex-desktop-bridge.md
@@ -1,0 +1,211 @@
+# RFC: bounded Codex Desktop thread bridge
+
+## Status
+
+Design draft only. This document deliberately adds no production tool yet.
+
+The missing piece is not the thread API. Codex app-server already has bounded methods for
+listing, reading, creating and messaging threads. The missing piece is a supported way for a
+separate local app to bind those methods to the **specific Codex Desktop instance the user is
+looking at**, rather than to an unrelated CLI/default daemon.
+
+Implementing before that ownership boundary is agreed would recreate the bug this proposal is
+meant to remove: a successful backend acknowledgement that affected the wrong task.
+
+## Problem
+
+Chat On Steroids can inspect local recordings and can control the desktop, but neither is the
+right default for supervising an existing Codex Desktop task:
+
+- GUI automation steals focus and competes with the user's foreground work;
+- writing into Codex's persisted databases bypasses its ordering and notification contracts;
+- invoking `codex queue` or another CLI command may reach a different app-server daemon;
+- a successful CLI response therefore does not prove the visible Desktop task received anything.
+
+The desired workflow is background-first:
+
+```text
+ChatGPT
+  -> Chat On Steroids Core
+  -> the user's current Codex Desktop app-server
+  -> one explicitly identified Desktop thread
+  -> that thread may use its own control-chrome integration
+```
+
+The browser part stays inside Codex Desktop. The bridge does not proxy browser cookies, tabs or
+profiles; it only sends a normal user message to a Desktop thread. That thread can then use the
+same Chrome/Dia state it already owns.
+
+## Proposed model-facing contract
+
+Expose one flat Core tool, not five schemas:
+
+```text
+codex_desktop action=list
+codex_desktop action=read   thread_id=...
+codex_desktop action=send   thread_id=... message=...
+codex_desktop action=wait   thread_id=... cursor=...
+codex_desktop action=create cwd=... message=...
+```
+
+`create` must be used only when the user explicitly asks for a new Desktop task. Ordinary
+supervision should locate and continue an existing thread.
+
+The tool should return enough identity to prevent same-title mistakes:
+
+- thread id;
+- user-facing title;
+- working directory;
+- runtime status and active flags;
+- updated time;
+- a compact user/assistant transcript or update cursor.
+
+It should not expose arbitrary app-server RPC, raw internal events, or an unbounded thread dump.
+
+## App-server mapping
+
+The current Codex app-server protocol already supplies the required primitives:
+
+| Tool action | App-server methods |
+| --- | --- |
+| `list` | `thread/list` |
+| `read` | `thread/read`, then bounded `thread/items/list` pages |
+| `send` | `thread/queue/add` for an active task, or `turn/start` when idle |
+| `wait` | event subscription when available, otherwise bounded `thread/read` / item polling |
+| `create` | `thread/start`, followed by `turn/start` |
+
+A successful `send` is not complete at the first RPC response. The bridge must:
+
+1. generate a unique `clientUserMessageId`;
+2. receive the queue/turn acknowledgement from the bound app-server;
+3. read the same thread back;
+4. confirm that exact client message is queued or present in the thread;
+5. return the acknowledgement and observed thread identity together.
+
+That final read is what turns "a server accepted bytes" into "this Desktop task received the
+message".
+
+## Binding requirement
+
+The bridge must bind to the app-server instance owned by the current Codex Desktop application.
+It must not silently fall back to another locally running Codex daemon.
+
+A usable binding needs at least:
+
+- an authenticated or OS-authorized transport supplied by Codex Desktop;
+- a stable instance identity for the lifetime of the connection;
+- an initialization response that can be checked before any thread mutation;
+- disconnect/restart detection so a stale endpoint cannot be mistaken for the same app;
+- explicit failure when the Desktop instance is unavailable.
+
+### Current finding
+
+Codex app-server supports official WebSocket transports when a server is launched with an
+explicit `--listen` endpoint, and it also has an experimental remote-control protocol. Those are
+real integration contracts.
+
+The current packaged Codex Desktop instance, however, does not expose a documented local
+app-server endpoint to unrelated processes. Its internal dynamic app-tools pipe is peer-authorized
+and is not a third-party integration surface. An external Chat On Steroids process is rejected,
+which is the correct boundary; this proposal must not weaken or bypass it.
+
+Therefore the first implementation requires one of these supported seams:
+
+1. Codex Desktop publishes a scoped local app-server endpoint or capability token;
+2. Codex remote-control pairing exposes the current Desktop instance to an approved local client;
+3. Codex Desktop supplies a small first-party app tool that forwards only the allowlisted thread
+   operations.
+
+Until one of those is available, connecting to a separately launched app-server can validate the
+protocol client but cannot honestly be called control of the user's current Desktop task.
+
+## Rejected approaches
+
+### GUI typing as the normal path
+
+Useful for testing the UI itself, but wrong for task coordination. It changes foreground state and
+provides no durable thread acknowledgement.
+
+### Bare Codex CLI commands
+
+The CLI binary and Codex Desktop share lower-level runtime code, but they are not the same product
+instance. A default daemon acknowledgement is not proof about the visible Desktop task.
+
+### Direct database writes
+
+They bypass app-server ordering, queues, notifications and renderer state. The database is
+persistence, not a mutation API.
+
+### Attaching to private pipes
+
+The packaged app's private pipe is peer-authorized. Spoofing or disabling that check would turn a
+narrow convenience feature into an unsupported privilege boundary.
+
+### Generic RPC passthrough
+
+The model should never receive a method name plus arbitrary JSON. The bridge owns a small method
+allowlist and validates every request and response.
+
+## Permission and privacy model
+
+Keep one model-facing schema but separate the user grants:
+
+- **Read Codex tasks**: list, read and wait;
+- **Control Codex tasks**: send and create.
+
+Global read-only mode disables the control grant but can leave bounded reads available.
+
+Thread reads can contain private prompts and code context. Results should therefore be bounded,
+redacted through the same secret handling used by session recording, and limited by default to:
+
+- user messages;
+- assistant messages;
+- compact status/tool headlines;
+- no raw command output or arbitrary MCP arguments unless a future explicit detail action earns it.
+
+The bridge must never expose browser storage, cookies or authentication material. Asking a Desktop
+thread to use `control-chrome` is a message to that thread, not browser credential transfer.
+
+## Lifecycle and failure behavior
+
+- No foreground activation of Codex Desktop.
+- No automatic creation when an existing task was requested.
+- No title-only addressing; mutations require the exact thread id.
+- No retry against a different endpoint after disconnect.
+- A Desktop restart invalidates the client and requires a fresh instance handshake.
+- `wait` is bounded and returns an update cursor; it is not an unbounded background process.
+- Ambiguous or stale identity fails closed.
+
+## Staged implementation
+
+### Phase 1: transport decision
+
+Agree with the maintainer which supported Codex Desktop binding seam this project is willing to
+depend on. Retain the explicit app-server WebSocket client as a protocol test fixture, not as a
+claim of Desktop integration.
+
+### Phase 2: bounded vertical slice
+
+Implement `list`, `read` and `send` behind one `codex_desktop` schema, with separate read/control
+permissions and deterministic fake-app-server tests. Verify exact `clientUserMessageId` delivery.
+
+### Phase 3: live acceptance
+
+From ChatGPT, without focusing Codex Desktop:
+
+1. list Desktop tasks and identify one by id + title + cwd;
+2. read its current tail;
+3. send a harmless message;
+4. observe the same message in that exact task;
+5. wait for its next assistant update;
+6. verify the task can use its existing `control-chrome` browser state.
+
+Only this live proof closes the original problem.
+
+## Questions for review
+
+1. Is a Codex Desktop bridge within this project's scope, or should it remain an external plugin?
+2. Which supported binding should Chat On Steroids target: a local capability endpoint,
+   remote-control pairing, or a first-party forwarding app tool?
+3. Does the one-schema/two-permission contract fit the current Core surface?
+4. Should `create` ship in the first slice, or follow after existing-thread supervision is proven?


### PR DESCRIPTION
## What changed

This remains a design-only RFC for a bounded bridge from Chat On Steroids Core to Codex Desktop threads, but one major assumption has changed since the draft was opened.

Codex CLI 0.152.1 now ships an official:

```text
codex queue --thread <UUID> --message ...
```

On a Mac running Codex Desktop, I tested that command against the UUID of a task already visible in Desktop. The queued message became the next user turn in that exact task and the task continued there, without foreground activation or GUI automation.

That removes the original “can we background-send to the actual Desktop task at all?” blocker. The remaining problem is narrower: verify the supported `list` / `read` / `wait` surface and its thread identity / stale-thread guarantees, then wrap only the bounded subset CoS needs.

The RFC in [`docs/codex-desktop-bridge.md`](docs/codex-desktop-bridge.md) has been updated around that evidence.

## Proposed first slice

One model-facing `codex_desktop` schema, initially focused on existing threads:

- `list`
- `read`
- `send`

with exact thread-id addressing, separate read/control grants, bounded results, and read-back after mutation when the supported Codex surface permits it.

`wait` and `create` can follow if their supported contracts are equally clear; there is no reason to invent a private Desktop pipe merely to obtain send.

## Why keep this as a draft

The transport is no longer hypothetical, but I still do not want to land runtime code before two product decisions are clear:

1. Is supervising Codex Desktop threads in scope for CoS Core, or better kept as an external/meta-harness integration?
2. Is wrapping the shipped exact-thread CLI/app-server surface an acceptable dependency, once its read/list identity guarantees are verified?

## Safety / ownership constraints

- no foreground activation of Codex Desktop;
- no title-only mutation;
- no direct database writes;
- no private-pipe bypass;
- no generic model-controlled RPC passthrough;
- no silent fallback to a different thread/daemon after failure;
- thread reads remain bounded and privacy-reduced;
- browser work stays inside the target Codex Desktop task, which can use its own `control-chrome` state.

## Current evidence

- [x] exact-thread background send reaches the same task already visible in Codex Desktop;
- [x] no GUI focus/click/type is required for that send;
- [x] RFC updated to remove the obsolete transport blocker;
- [ ] supported enumeration/read/status semantics verified;
- [ ] CoS runtime implementation added;
- [ ] live `list → read → send → read-back` acceptance through CoS.

## Review questions

1. Is this integration in scope for the project?
2. Does the one-schema / separate read-control grant model fit the Core surface budget?
3. Should the first implementation stop at existing-thread `list/read/send`?
4. Once verified, is the first-party CLI/app-server thread surface an acceptable dependency, or would you prefer another supported Codex contract?
