### PR TITLE
Fix stale Firefox revival tabs after restart

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,6 +86,7 @@ jobs:
             'Chat-On-Steroids-Linux-arm64.AppImage',
             'Chat-On-Steroids-Linux-arm64.deb',
             'Chat-On-Steroids-Extension.zip',
+            'Chat-On-Steroids-Firefox.zip',
             'SHA256SUMS.txt'
           ]) {
             if (!notes.includes(`\`${artifact}\``)) throw new Error(`${notesPath} is missing ${artifact}`);
@@ -181,6 +182,7 @@ jobs:
             publish/Chat-On-Steroids-Linux-arm64.AppImage \
             publish/Chat-On-Steroids-Linux-arm64.deb \
             publish/Chat-On-Steroids-Extension.zip \
+            publish/Chat-On-Steroids-Firefox.zip \
             publish/SHA256SUMS.txt \
             --title "Chat On Steroids ${TAG#v}" \
             --notes-file "docs/release-notes/$TAG.md"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,6 +324,27 @@ jobs:
             unzip -Z1 release/Chat-On-Steroids-Extension.zip | grep -Fxq "$required" || { echo "Extension zip missing $required" >&2; exit 1; }
           done
 
+      - name: Package Firefox AMO extension
+        run: |
+          set -euo pipefail
+          npm run extension:firefox:stage
+          (cd release/firefox-extension && zip -qr ../Chat-On-Steroids-Firefox.zip . -x '*.map')
+          node <<'NODE'
+          const fs = require('node:fs');
+          const manifest = JSON.parse(fs.readFileSync('release/firefox-extension/manifest.json', 'utf8'));
+          const pkg = require('./package.json');
+          if (manifest.version !== pkg.version) throw new Error('Firefox extension version mismatch');
+          if (manifest.background?.scripts?.[0] !== 'background.js' || manifest.background?.service_worker) {
+            throw new Error('Firefox background manifest was not transformed');
+          }
+          if (manifest.browser_specific_settings?.gecko?.id !== 'chat-on-steroids-companion@local') {
+            throw new Error('Firefox add-on id changed');
+          }
+          NODE
+          for required in manifest.json background.js chatgpt-dom.js content.js fiber.js overlay.css popup.html popup.css popup.js icons/icon16.png icons/icon32.png icons/icon48.png icons/icon128.png LICENSE; do
+            unzip -Z1 release/Chat-On-Steroids-Firefox.zip | grep -Fxq "$required" || { echo "Firefox extension zip missing $required" >&2; exit 1; }
+          done
+
       - name: Create SHA-256 checksums
         run: |
           set -euo pipefail
@@ -339,6 +360,7 @@ jobs:
             release/Chat-On-Steroids-Linux-arm64.AppImage
             release/Chat-On-Steroids-Linux-arm64.deb
             release/Chat-On-Steroids-Extension.zip
+            release/Chat-On-Steroids-Firefox.zip
           )
           for file in "${files[@]}"; do test -f "$file" || { echo "Missing $file" >&2; exit 1; }; done
           (cd release && sha256sum \
@@ -352,7 +374,8 @@ jobs:
             Chat-On-Steroids-Linux-x64.deb \
             Chat-On-Steroids-Linux-arm64.AppImage \
             Chat-On-Steroids-Linux-arm64.deb \
-            Chat-On-Steroids-Extension.zip > SHA256SUMS.txt)
+            Chat-On-Steroids-Extension.zip \
+            Chat-On-Steroids-Firefox.zip > SHA256SUMS.txt)
           cat release/SHA256SUMS.txt
 
       - name: Upload release candidate
@@ -373,6 +396,7 @@ jobs:
             release/Chat-On-Steroids-Linux-arm64.AppImage
             release/Chat-On-Steroids-Linux-arm64.deb
             release/Chat-On-Steroids-Extension.zip
+            release/Chat-On-Steroids-Firefox.zip
             release/SHA256SUMS.txt
           if-no-files-found: error
           retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ The app and the `extension/` companion are versioned together. **Reload the
 extension after updating the app**. If their bridge protocols are incompatible,
 the app refuses the extension and asks you to reload the matching copy.
 
+## [2.0.3] — 2026-09-01
+
+2.0.3 is a browser/session recovery hardening release. It closes a Firefox restart failure where
+an inert deferred worker-wake marker could outlive its app-side command and recreate an old ChatGPT
+conversation on every browser start.
+
+### Fixed
+- **Firefox/browser restart recovery now validates deferred worker revivals before opening UI.**
+  The extension batches its persisted `{command id, conversation}` markers through the app's new
+  read-only `/commands/revivals/pending` fence. Cancelled, committed, superseded and otherwise stale
+  markers are pruned before `tabs.create`; if validation is unavailable, recovery fails closed and
+  opens nothing rather than guessing.
+- **Repeated resume-shadow repair polling no longer keeps replaying an already-satisfied prime
+  transfer.** This removes the stale-resume condition that previously required manual session-state
+  cleanup after some app/browser restarts.
+- **Redeemed resume leases survive the acknowledgement window correctly**, preventing a valid
+  browser-owned continuation from being reopened as a second delivery after its earlier lease was
+  already acquired.
+- **Stale Fiber request attribution cannot overwrite a newer exact request owner**, and ChatGPT
+  Project conversation routes are recognised as normal conversation routes.
+
+### Changed
+- **Bridge protocol is now 9.** The restart-revival validation contract is intentionally not
+  backward-compatible: a 2.0.3 extension paired to an older app must fail loudly/fail closed rather
+  than silently fall back to the unsafe startup behaviour.
+- **Firefox packaging is reproducible from the shared extension source.** Release CI now derives an
+  AMO-compatible manifest with the stable Gecko id instead of relying on manual manifest edits, and
+  publishes `Chat-On-Steroids-Firefox.zip` alongside the Chromium package.
+
 ## [2.0.2] — 2026-08-26
 
 2.0.2 is the native cross-platform release port. The already-published 2.0.1 release remains the

--- a/docs/release-notes/v2.0.3.md
+++ b/docs/release-notes/v2.0.3.md
@@ -1,0 +1,69 @@
+Chat On Steroids 2.0.3 is a browser/session recovery hardening release. The desktop app and
+companion extension are versioned together; update both sides before relying on worker revival after
+a browser restart.
+
+Choose the artifact for your operating system and CPU:
+
+- `Chat-On-Steroids-Setup-x64.exe` — Windows x64 (Intel/AMD)
+- `Chat-On-Steroids-Setup-arm64.exe` — Windows on Arm
+- `Chat-On-Steroids-macOS-x64.dmg` — macOS Intel disk image
+- `Chat-On-Steroids-macOS-x64.zip` — macOS Intel app archive
+- `Chat-On-Steroids-macOS-arm64.dmg` — macOS Apple silicon disk image
+- `Chat-On-Steroids-macOS-arm64.zip` — macOS Apple silicon app archive
+- `Chat-On-Steroids-Linux-x64.AppImage` — Linux x64 portable AppImage
+- `Chat-On-Steroids-Linux-x64.deb` — Linux x64 Debian/Ubuntu package
+- `Chat-On-Steroids-Linux-arm64.AppImage` — Linux ARM64 portable AppImage
+- `Chat-On-Steroids-Linux-arm64.deb` — Linux ARM64 Debian/Ubuntu package
+- `Chat-On-Steroids-Extension.zip` — standalone Chromium companion extension
+- `Chat-On-Steroids-Firefox.zip` — Firefox/AMO upload-ready companion extension
+- `SHA256SUMS.txt` — SHA-256 checksums for every release artifact above
+
+> **macOS caveat:** the 2.0.3 DMG and ZIP builds remain publisher-unsigned (no Apple Developer ID)
+> and unnotarized. Apple-silicon Mach-O files may contain platform-required ad-hoc signatures; those
+> do not identify a publisher or establish Gatekeeper trust.
+
+## 2.0.3
+
+### Firefox restart tab-loop fix
+
+Firefox can persist the extension's small deferred worker-revival marker longer than the desktop
+app retains the command that originally created it. In 2.0.2 that browser-local marker was treated
+as enough authority to recreate `/c/<conversation>?clf=<command>` on startup. If the command had
+already been committed, cancelled or retired, the old conversation could therefore be reopened on
+every browser restart even though the app had no work left for it.
+
+2.0.3 makes the app the source of truth. Before browser-restart recovery may query or create any
+ChatGPT tab, the extension sends its bounded set of inert marker ids and exact conversation ids to
+the authenticated, read-only `/commands/revivals/pending` route. The app returns only currently live
+worker revival ids. Dead markers are durably removed first. Transport errors, bridge recovery and
+older incompatible peers fail closed: the extension keeps the inert marker for a later retry but
+does **not** create a tab.
+
+The new contract is bridge protocol 9 so an old app/new extension or new app/old extension cannot
+silently fall back to the unsafe behaviour.
+
+### Reproducible Firefox packaging
+
+The repository now derives the Firefox AMO manifest from the same canonical extension source used
+by Chromium. The staging step preserves the stable add-on id
+`chat-on-steroids-companion@local`, Firefox 128 minimum, required AMO data-collection declarations,
+Firefox background-script form, runtime permissions and shared content scripts. Release CI packages
+that stage as `Chat-On-Steroids-Firefox.zip`, eliminating the manual manifest-edit step that could
+otherwise let the Firefox and Chromium companions drift.
+
+### Other post-2.0.2 recovery fixes included
+
+- Repeated no-Goal resume-shadow repair polling is idempotent instead of replaying an already-moved
+  prime projection indefinitely.
+- A redeemed resume command keeps its browser-owned lease through the acknowledgement window.
+- Stale Fiber request attribution cannot replace newer exact ownership evidence.
+- ChatGPT Project conversation routes are recognised as conversation routes.
+
+### Validation
+
+- Extension suite covers stale-marker pruning, live-marker survival and fail-closed validation.
+- Bridge suite proves validation is read-only: a checked worker wake remains redeemable afterwards.
+- Firefox packaging has a deterministic manifest regression test.
+- Full repository verification is required by the normal release workflow before publication.
+
+> Beta despite the version number. Behaviour may still change between releases.

--- a/extension/background.js
+++ b/extension/background.js
@@ -24,7 +24,7 @@ const PORTS = [8765, 8766, 8767, 8768, 8769];
 const HELLO_TIMEOUT_MS = 1200;
 const REQUEST_TIMEOUT_MS = 10_000;
 /** Bumped only when the request/response shape changes; the app compares it. */
-const BRIDGE_PROTOCOL = 8;
+const BRIDGE_PROTOCOL = 9;
 
 /**
  * Journal caps. The byte figure is what actually matters — chrome.storage.session has a
@@ -2544,6 +2544,35 @@ function deferredRevivalUrl(entry) {
 }
 
 /**
+ * Reconciles browser-persisted wake markers with the app before recovery can create a tab.
+ *
+ * The marker deliberately survives a browser restart, while the corresponding app command can
+ * be cancelled, committed, superseded or retired during the same interval. Treating the marker
+ * itself as proof of live work lets a dead id reopen its old ChatGPT conversation on every
+ * browser startup. The app owns command truth, so ask it once for the whole bounded set and fail
+ * closed on transport/version errors: keeping an inert marker for a later retry is harmless;
+ * opening an unproven tab is not.
+ */
+async function reconcileDeferredRevivalsWithApp() {
+  if (deferredRevivals.length === 0) return true;
+  const entries = deferredRevivals
+    .map((entry) => ({ id: deferredRevivalId(entry?.id), conversationId: cleanConversationId(entry?.conversationId) }))
+    .filter((entry) => entry.id && entry.conversationId)
+    .slice(-100);
+  const result = await call('/commands/revivals/pending', {
+    method: 'POST',
+    body: JSON.stringify({ entries })
+  });
+  if (!result.ok || !Array.isArray(result.data?.pending)) return false;
+
+  const pending = new Set(result.data.pending.filter((id) => typeof id === 'string'));
+  const before = deferredRevivals.length;
+  deferredRevivals = deferredRevivals.filter((entry) => pending.has(entry?.id));
+  if (deferredRevivals.length !== before) await persistLive();
+  return true;
+}
+
+/**
  * Re-presents deferred revival markers after MV3/document/browser lifetime loss.
  *
  * There is deliberately no command text here and no local "sent" decision. An existing exact
@@ -2563,6 +2592,13 @@ function recoverDeferredRevivals() {
       (entry) => deferredRevivalId(entry?.id) && cleanConversationId(entry?.conversationId) && !ackIds.has(entry.id)
     );
     if (deferredRevivals.length !== before) await persistLive();
+    if (deferredRevivals.length === 0) return;
+
+    // A browser-local marker is correlation metadata, not authority to create UI. Revalidate it
+    // against the app's durable command state before querying or creating tabs. If the app is
+    // unavailable or an older build does not support the read-only route, keep the marker and do
+    // nothing; the next lifecycle wake retries without spraying recovery tabs.
+    if (!(await reconcileDeferredRevivalsWithApp())) return;
     if (deferredRevivals.length === 0) return;
 
     let tabs = [];

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Chat On Steroids companion",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Records your ChatGPT session into the local Chat On Steroids app and labels its MCP tool calls with what they actually did.",
   "minimum_chrome_version": "116",
   "permissions": ["storage", "scripting", "alarms"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chat-on-steroids",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chat-on-steroids",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chat-on-steroids",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Local coding bridge for ChatGPT over MCP, with Windows-only desktop control and approved-folder capability limits.",
   "license": "MIT",
   "author": "Chat On Steroids",
@@ -18,6 +18,7 @@
     "verify:privacy": "node scripts/verify-public-history.mjs",
     "hooks:install": "node scripts/install-git-hooks.mjs",
     "icon": "node scripts/make-icon.mjs",
+    "extension:firefox:stage": "node scripts/stage-firefox-extension.mjs",
     "tunnel": "node scripts/fetch-tunnel-client.mjs",
     "rg": "node scripts/fetch-ripgrep.mjs",
     "packaging:prepare": "node scripts/prepare-packaging-native.mjs",

--- a/scripts/stage-firefox-extension.d.mts
+++ b/scripts/stage-firefox-extension.d.mts
@@ -1,0 +1,2 @@
+export function firefoxManifest(source: Record<string, unknown>): Record<string, unknown>;
+export function stageFirefoxExtension(output?: string): Promise<string>;

--- a/scripts/stage-firefox-extension.mjs
+++ b/scripts/stage-firefox-extension.mjs
@@ -1,0 +1,61 @@
+import { cp, mkdir, readFile, rm, writeFile, copyFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const extensionRoot = path.join(root, 'extension');
+const releaseRoot = path.join(root, 'release');
+const defaultOutput = path.join(releaseRoot, 'firefox-extension');
+
+/**
+ * Firefox and Chromium consume the same runtime JavaScript, but Firefox's signed AMO package
+ * needs a Gecko-specific MV3 manifest. Keep that small compatibility delta generated from the
+ * canonical extension manifest so browser releases cannot silently drift apart.
+ */
+export function firefoxManifest(source) {
+  const manifest = structuredClone(source);
+  delete manifest.minimum_chrome_version;
+  manifest.background = {
+    scripts: ['background.js'],
+    type: 'module'
+  };
+  manifest.content_security_policy = {
+    extension_pages: "script-src 'self'; object-src 'self'"
+  };
+  manifest.browser_specific_settings = {
+    gecko: {
+      id: 'chat-on-steroids-companion@local',
+      strict_min_version: '128.0',
+      data_collection_permissions: {
+        required: ['personalCommunications', 'websiteContent']
+      }
+    }
+  };
+  return manifest;
+}
+
+function safeOutput(output) {
+  const resolved = path.resolve(output);
+  const relative = path.relative(releaseRoot, resolved);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Firefox extension staging must stay inside ${releaseRoot}; got ${resolved}`);
+  }
+  return resolved;
+}
+
+export async function stageFirefoxExtension(output = defaultOutput) {
+  const target = safeOutput(output);
+  const sourceManifest = JSON.parse(await readFile(path.join(extensionRoot, 'manifest.json'), 'utf8'));
+
+  await mkdir(releaseRoot, { recursive: true });
+  await rm(target, { recursive: true, force: true });
+  await cp(extensionRoot, target, { recursive: true, force: true });
+  await writeFile(path.join(target, 'manifest.json'), `${JSON.stringify(firefoxManifest(sourceManifest), null, 2)}\n`, 'utf8');
+  await copyFile(path.join(root, 'LICENSE'), path.join(target, 'LICENSE'));
+  return target;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const target = await stageFirefoxExtension(process.argv[2] ?? defaultOutput);
+  process.stdout.write(`${target}\n`);
+}

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -1878,6 +1878,43 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
     );
   }
 
+  // Browser-restart recovery keeps only inert command ids in extension storage. Before the
+  // extension is allowed to recreate any ChatGPT tab, let it reconcile those ids against the
+  // app's current durable command state in one read-only batch. This route deliberately exposes
+  // no command text and acquires no owner/lease: it is only a freshness fence for recovery
+  // markers that can outlive the command they once referred to.
+  if (route === '/commands/revivals/pending' && req.method === 'POST') {
+    let body: Record<string, unknown>;
+    try {
+      body = (await readBody(req)) as Record<string, unknown>;
+    } catch (err) {
+      if ((err as Error).message === 'body_too_large') return tooLarge(res, origin);
+      return json(res, 400, { error: 'bad_request' }, origin);
+    }
+    const rawEntries = Array.isArray(body['entries']) ? body['entries'] : null;
+    if (!rawEntries || rawEntries.length > 100) {
+      return json(res, 400, { error: 'bad_revival_entries' }, origin);
+    }
+
+    tidyCommands();
+    const pending: string[] = [];
+    for (const raw of rawEntries) {
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+      const candidate = raw as Record<string, unknown>;
+      const wanted = typeof candidate['id'] === 'string' ? candidate['id'].slice(0, 128) : '';
+      const reportedConversation = conversationId(candidate['conversationId']);
+      if (!wanted || !reportedConversation) continue;
+
+      const command = commands.find((entry) => entry.id === wanted);
+      if (!command || command.spec.type !== 'revive') continue;
+      if (command.spec.conversationId !== reportedConversation) continue;
+      const revival = revivalFor(command.spec.agent);
+      if (!revival || revival.conversationId !== reportedConversation) continue;
+      pending.push(wanted);
+    }
+    return json(res, 200, { pending }, origin);
+  }
+
   // The targeted-open path: one page, opened by the app, redeeming the one command the
   // app opened it for. The id is not a credential — this route is behind the same bearer
   // token as everything else — it is a correlation marker, which is why a leaked URL or a

--- a/src/main/version.ts
+++ b/src/main/version.ts
@@ -12,7 +12,7 @@
  * extension does nothing" into a diagnosable mismatch.
  */
 
-export const APP_VERSION = '2.0.2';
+export const APP_VERSION = '2.0.3';
 
 /**
  * Standalone extension recovery must stay on the app's own release. Using GitHub's moving
@@ -47,5 +47,9 @@ export function extensionDownloadUrl(version = APP_VERSION): string {
  *     `disconnected`, protected routes distinguish that revocation from a stale token, and
  *     /pair accepts `reconnect: true` only for an explicit browser-side reconnect. An older
  *     extension would otherwise silently undo the user's app-side Disconnect on its next 401.
+ * 9 — browser-restart worker revival markers are revalidated against app-owned durable command
+ *     state before the extension may recreate a ChatGPT tab. `/commands/revivals/pending` is a
+ *     read-only batch freshness fence; an older peer cannot provide this guarantee, so the
+ *     protocol must fail loudly instead of falling back to the unsafe startup behaviour.
  */
-export const BRIDGE_PROTOCOL = 8;
+export const BRIDGE_PROTOCOL = 9;

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -1967,6 +1967,39 @@ describe('delivering a bootstrap', () => {
     expect(stale.body.error).toBe('no_such_command');
   });
 
+  it('validates deferred revival ids read-only before browser restart recovery opens a tab', async () => {
+    await pair();
+    spawn({ workers: [{ task: 'sleep and wake for recovery validation' }], caller: { conversationId: PRIME_CHAT } });
+    const bootstrap = await redeem();
+    const conversationId = 'abababab-1111-4222-8333-444444444444';
+    await request('POST', '/commands/ack', {
+      body: { id: bootstrap.id, status: 'sent', conversationId, agent: 'worker-1' }
+    });
+    finishAgent({ conversationId }, 'sleep now');
+    wake([{ to: 'worker-1', text: 'wake once after restart' }]);
+    await waitForOpened(2);
+    const id = new URL(opened[1]!).searchParams.get('clf')!;
+
+    const checked = await request('POST', '/commands/revivals/pending', {
+      body: {
+        entries: [
+          { id, conversationId },
+          { id: 'dead-command-id', conversationId },
+          { id, conversationId: '99999999-1111-4222-8333-444444444444' }
+        ]
+      }
+    });
+    expect(checked.status).toBe(200);
+    expect(checked.body).toEqual({ pending: [id] });
+
+    // Validation must not consume or lease the command. The actual page can still redeem the
+    // exact same wake afterwards, which preserves the existing one-page arbitration boundary.
+    const claimed = await request('POST', '/commands/redeem', {
+      body: { id, client: 'validated-restart-tab', conversationId }
+    });
+    expect(claimed.status).toBe(200);
+  });
+
   it('keeps a redeemed revival browser-owned until its exact sent acknowledgement', async () => {
     await pair();
     spawn({ workers: [{ task: 'write the audit' }], caller: { conversationId: PRIME_CHAT } });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -38,8 +38,8 @@ describe('extension release metadata', () => {
     expect(lock.version).toBe(APP_VERSION);
     expect(lock.packages?.['']?.version).toBe(APP_VERSION);
     expect(manifest.version).toBe(APP_VERSION);
-    expect(BRIDGE_PROTOCOL).toBe(8);
-    expect(backgroundSource).toContain('const BRIDGE_PROTOCOL = 8;');
+    expect(BRIDGE_PROTOCOL).toBe(9);
+    expect(backgroundSource).toContain('const BRIDGE_PROTOCOL = 9;');
   });
 
   /**
@@ -959,9 +959,17 @@ describe('extension revival delivery', () => {
   const REVIVAL_URL = `https://chatgpt.com/c/${CHAT}?clf=cmd-wake#clf=cmd-wake`;
 
   const quiet = () =>
-    vi.fn(async (input: string) => {
+    vi.fn(async (input: string, init: Record<string, unknown> = {}) => {
       const url = new URL(input);
       if (url.pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
+      if (url.pathname === '/commands/revivals/pending') {
+        const body = JSON.parse(String(init.body || '{}')) as { entries?: Array<{ id?: string }> };
+        return response(200, {
+          pending: (Array.isArray(body.entries) ? body.entries : [])
+            .map((entry) => entry?.id)
+            .filter((id): id is string => typeof id === 'string')
+        });
+      }
       return response(404, {});
     });
 
@@ -1159,16 +1167,60 @@ describe('extension revival delivery', () => {
 
     // Full browser restart: storage.session is gone, but the small inert recovery marker is in
     // storage.local. With no surviving ChatGPT tab, recovery recreates exactly the marked target.
+    const restartFetch = vi.fn(async (input: string) => {
+      const url = new URL(input);
+      if (url.pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
+      if (url.pathname === '/commands/revivals/pending') {
+        return response(200, { pending: ['cmd-persisted-wake'] });
+      }
+      return response(404, {});
+    });
     const restarted = loadWorker({
       local,
       session: new FakeStorageArea(),
-      fetch: quiet(),
+      fetch: restartFetch,
       tabsQuery: async () => []
     });
     await vi.waitFor(() => expect(restarted.tabsCreate).toHaveBeenCalledTimes(1));
     const created = String(restarted.tabsCreate.mock.calls[0]?.[0]?.url || '');
     expect(created).toContain(`/c/${CHAT}`);
     expect(created).toContain('clf=cmd-persisted-wake');
+  });
+
+  it('prunes a stale deferred revival before browser startup can recreate its ChatGPT tab', async () => {
+    const local = new FakeStorageArea({
+      ...paired,
+      deferredRevivals: [{ id: 'cmd-dead-after-restart', conversationId: CHAT, queuedAt: Date.now() }]
+    });
+    const fetch = vi.fn(async (input: string) => {
+      const url = new URL(input);
+      if (url.pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
+      if (url.pathname === '/commands/revivals/pending') return response(200, { pending: [] });
+      return response(404, {});
+    });
+
+    const restarted = loadWorker({ local, session: new FakeStorageArea(), fetch, tabsQuery: async () => [] });
+    await vi.waitFor(() => expect(fetch.mock.calls.some(([input]) => new URL(String(input)).pathname === '/commands/revivals/pending')).toBe(true));
+
+    expect(restarted.tabsCreate).not.toHaveBeenCalled();
+    expect(local.data.deferredRevivals).toEqual([]);
+  });
+
+  it('fails closed when deferred-revival validation is unavailable instead of opening an unproven tab', async () => {
+    const marker = { id: 'cmd-validation-unavailable', conversationId: CHAT, queuedAt: Date.now() };
+    const local = new FakeStorageArea({ ...paired, deferredRevivals: [marker] });
+    const fetch = vi.fn(async (input: string) => {
+      const url = new URL(input);
+      if (url.pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
+      if (url.pathname === '/commands/revivals/pending') return response(503, { error: 'bridge_recovering' });
+      return response(404, {});
+    });
+
+    const restarted = loadWorker({ local, session: new FakeStorageArea(), fetch, tabsQuery: async () => [] });
+    await vi.waitFor(() => expect(fetch.mock.calls.some(([input]) => new URL(String(input)).pathname === '/commands/revivals/pending')).toBe(true));
+
+    expect(restarted.tabsCreate).not.toHaveBeenCalled();
+    expect(local.data.deferredRevivals).toMatchObject([marker]);
   });
 
   it('replaces an older deferred marker for the same worker chat when a newer wake reaches browser custody', async () => {

--- a/test/firefox-extension-package.test.ts
+++ b/test/firefox-extension-package.test.ts
@@ -1,0 +1,34 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const { APP_VERSION } = await import('../src/main/version.js');
+const { firefoxManifest } = await import('../scripts/stage-firefox-extension.mjs');
+
+describe('Firefox companion packaging', () => {
+  it('derives the signed-AMO manifest from the canonical shared extension without runtime drift', async () => {
+    const source = JSON.parse(await fs.readFile(path.join(process.cwd(), 'extension', 'manifest.json'), 'utf8'));
+    const manifest = firefoxManifest(source);
+
+    expect(manifest.version).toBe(APP_VERSION);
+    expect(manifest.minimum_chrome_version).toBeUndefined();
+    expect(manifest.background).toEqual({ scripts: ['background.js'], type: 'module' });
+    expect(manifest.browser_specific_settings).toEqual({
+      gecko: {
+        id: 'chat-on-steroids-companion@local',
+        strict_min_version: '128.0',
+        data_collection_permissions: {
+          required: ['personalCommunications', 'websiteContent']
+        }
+      }
+    });
+    expect(manifest.content_security_policy).toEqual({
+      extension_pages: "script-src 'self'; object-src 'self'"
+    });
+
+    // Runtime and permission surfaces come from the shared source rather than a Firefox fork.
+    expect(manifest.permissions).toEqual(source.permissions);
+    expect(manifest.host_permissions).toEqual(source.host_permissions);
+    expect(manifest.content_scripts).toEqual(source.content_scripts);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a browser-restart failure where a persisted deferred worker-revival marker could outlive its app-side command and recreate an old ChatGPT conversation on every Firefox startup.

### Root cause

`deferredRevivals` intentionally survives browser restarts, but 2.0.2 treated that browser-local marker as sufficient authority to recreate `/c/<conversation>?clf=<command>`. The desktop app can meanwhile commit, cancel, supersede or retire the command. A stale marker therefore remained capable of opening UI even when the app's durable command queue was empty.

### Fix

- add authenticated read-only `POST /commands/revivals/pending` batch validation
- reconcile persisted revival markers against app-owned command truth before any recovery `tabs.create`
- durably prune stale markers
- fail closed on bridge/version/transport errors: keep the inert marker for later retry, but open no tab
- keep validation read-only so a confirmed live wake can still be redeemed by the exact worker page afterwards
- bump bridge protocol to 9 so mixed old/new peers cannot silently fall back to the unsafe behavior

### Firefox release path

- bump app/extension release metadata to 2.0.3
- add deterministic Firefox staging from the shared extension source
- preserve the existing AMO add-on id `chat-on-steroids-companion@local`, Firefox 128 minimum and required data-collection declarations
- add `Chat-On-Steroids-Firefox.zip` to release candidate/checksum/publication workflows
- add 2.0.3 changelog/release notes

## Validation

- TypeScript: pass
- production `electron-vite build`: pass
- main Vitest matrix: **1815 passed, 18 skipped, 0 failed**
- shutdown suite: **2 passed, 0 failed**
- focused extension suite: **83/83 passed**
- focused bridge suite: **130/130 passed**
- `git diff --check`: pass
- staged privacy check: pass
- generated Firefox manifest/package verified locally

`npm run verify:ci` currently stops at the public-history privacy gate because two commits already reachable from upstream `main` use a non-noreply maintainer identity (`9e27c0fafc20bf2c81509844d5f92868678b4168` and `03acfbaad9d753d09487761e97cc1eade8eb8b22`). That ancestry issue predates this change; this commit itself passes `verify-public-history.mjs --staged`.