### PR TITLE
Fix Windows installer permissions for Electron sandbox

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -67,6 +67,7 @@ win:
       filter: ['**/*']
 
 nsis:
+  include: scripts/windows-installer-acl.nsh
   oneClick: false
   perMachine: false
   buildUniversalInstaller: false

--- a/scripts/windows-installer-acl.nsh
+++ b/scripts/windows-installer-acl.nsh
@@ -1,0 +1,25 @@
+!macro grantSandboxReadAccess
+  ClearErrors
+  ExecWait '"$SYSDIR\icacls.exe" "$INSTDIR" /grant "*S-1-15-2-2:(OI)(CI)(RX)" /Q' $0
+  ${If} ${Errors}
+    StrCpy $0 2
+  ${EndIf}
+  ${If} $0 != 0
+    SetErrorLevel 2
+    Abort "Windows could not set the folder access needed to start Chat On Steroids safely."
+  ${EndIf}
+!macroend
+
+!macro customInit
+  # initMultiUser has resolved a previous custom install path by this point.
+  # Repair an existing install before an update removes its runnable version.
+  ${If} ${FileExists} "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
+    !insertmacro grantSandboxReadAccess
+  ${EndIf}
+!macroend
+
+!macro customInstall
+  # Chromium's Windows sandbox needs read and execute access through the app tree.
+  # Add one inheritable grant to the final install directory without resetting other ACLs.
+  !insertmacro grantSandboxReadAccess
+!macroend

--- a/test/packaging.test.ts
+++ b/test/packaging.test.ts
@@ -131,6 +131,27 @@ describe('cross-platform packaging targets', () => {
     expect(smoke).toContain('runtime.electron !== expectedElectronVersion');
   });
 
+  it('repairs only the installed app tree for Windows sandbox startup', () => {
+    const config = yamlFile('electron-builder.yml');
+    const installer = readFileSync(path.join(root, 'scripts', 'windows-installer-acl.nsh'), 'utf8');
+
+    expect(config.nsis.include).toBe('scripts/windows-installer-acl.nsh');
+    expect(installer).toContain('!macro customInit');
+    expect(installer).toContain('!macro customInstall');
+    expect(installer).toContain('${FileExists} "$INSTDIR\\${APP_EXECUTABLE_FILENAME}"');
+    expect(installer).toContain('!insertmacro grantSandboxReadAccess');
+    expect(installer).toContain('$SYSDIR\\icacls.exe');
+    expect(installer).toContain('"$INSTDIR"');
+    expect(installer).toContain('*S-1-15-2-2:(OI)(CI)(RX)');
+    expect(installer).toContain('ExecWait');
+    expect(installer).toContain('${If} ${Errors}');
+    expect(installer).toContain('${If} $0 != 0');
+    expect(installer).toContain('Abort "Windows could not set the folder access needed');
+    expect(installer).not.toMatch(/\/(?:reset|remove|T)\b/i);
+    expect(installer).not.toContain('nsExec::');
+    expect(installer).not.toMatch(/(?:no-sandbox|disable-gpu-sandbox)/i);
+  });
+
   it('assembles every platform artifact in the reusable release workflow', () => {
     const workflow = readFileSync(path.join(root, '.github', 'workflows', 'release.yml'), 'utf8');
     const parsed = yamlFile('.github/workflows/release.yml');


### PR DESCRIPTION
## What changed

Refs #61.

The Windows installer now adds the inherited read and execute grant that fixed the reported Electron sandbox launch failure. It repairs an existing custom-path install before a silent update replaces files, applies the grant to the final folder, and stops if Windows rejects it.

## Validation

- [x] Packaging test: 21 passed
- [x] x64 NSIS installer compiled
- [x] Disposable custom-path fresh install, silent update, exact ACL check, sandboxed launch (4 processes, 1 visible window), and uninstall cleanup
- [ ] `npm run verify`: 2,167 passed and 22 skipped; one unrelated 30-second `exec-hints` timeout
- [x] Serial retry: `exec-hints` 116/116 and `mcp-shutdown` 2/2
- [x] No unrelated files or private data included