### PR TITLE
Release 2.0.5: install the update, and stop refetching it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ The app and the `extension/` companion are versioned together. **Reload the
 extension after updating the app**. If their bridge protocols are incompatible,
 the app refuses the extension and asks you to reload the matching copy.
 
+## [2.0.5] — 2026-09-04
+
+**The update installs.**
+
+- **An Install update button.** Next to Connect, and in the notice, whenever a verified download
+  is waiting. The app quits, the installer runs, and the app comes back as the new version.
+  Until now the only way to apply an update was a real quit — and this app is closed to the
+  tray, so ending it in the Task Manager instead skipped the handoff entirely and installed
+  nothing, however many times it had been downloaded.
+- **A download is fetched once.** The staged artifact is kept under the release it belongs to and
+  reverified against the release's own published checksums on the next start, instead of being
+  forgotten with the process and refetched — a hundred megabytes per start, forever, for an
+  installation that never quits.
+- **The update notice no longer breaks the window.** The banner between the header and the panels
+  had no row of its own to sit in, so showing it squeezed itself to a sliver of clipped text and
+  pushed the whole window's contents out from under it.
+
 ## [2.0.4] — 2026-09-04
 
 **astra broke me**

--- a/docs/release-notes/v2.0.5.md
+++ b/docs/release-notes/v2.0.5.md
@@ -1,0 +1,33 @@
+## 2.0.5
+
+**The update installs.**
+
+- **An Install update button.** Next to Connect, and in the update notice, whenever a verified
+  download is waiting. The app quits, the installer runs, and the app comes back as the new
+  version. Until now the only thing that applied an update was a real quit — and this app is
+  closed to the tray, so ending it any other way skipped the handoff and installed nothing,
+  however many times the update had been downloaded.
+- **A download is fetched once.** The staged artifact is kept under the release it belongs to and
+  reverified against the release's own published checksums on the next start, instead of being
+  forgotten with the process and fetched again from scratch on every single start.
+- **The update notice no longer breaks the window.** The banner between the header and the panels
+  had no row of its own to sit in, so showing it clipped the banner to a sliver and drew the
+  panels straight over the top of it.
+
+**Reload the browser extension after updating the app.**
+
+### Downloads
+
+- `Chat-On-Steroids-Setup-x64.exe` — Windows x64
+- `Chat-On-Steroids-Setup-arm64.exe` — Windows on Arm
+- `Chat-On-Steroids-macOS-x64.dmg` · `Chat-On-Steroids-macOS-x64.zip` — macOS Intel
+- `Chat-On-Steroids-macOS-arm64.dmg` · `Chat-On-Steroids-macOS-arm64.zip` — macOS Apple silicon
+- `Chat-On-Steroids-Linux-x64.AppImage` · `Chat-On-Steroids-Linux-x64.deb` — Linux x64
+- `Chat-On-Steroids-Linux-arm64.AppImage` · `Chat-On-Steroids-Linux-arm64.deb` — Linux ARM64
+- `Chat-On-Steroids-Extension.zip` — standalone Chrome companion extension
+- `SHA256SUMS.txt` — SHA-256 checksums for every artifact above
+
+> **macOS:** the builds are publisher-unsigned and unnotarized, so Gatekeeper may warn; verify the checksum first. They require macOS 13 Ventura or newer.
+> **Linux:** prefer the DEB on Debian/Ubuntu. Where unprivileged user namespaces are disabled, the AppImage launcher can fall back to `--no-sandbox`.
+
+Beta despite the version number. Behaviour may still change between releases.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Chat On Steroids companion",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Records your ChatGPT session into the local Chat On Steroids app and labels its MCP tool calls with what they actually did.",
   "minimum_chrome_version": "116",
   "permissions": ["storage", "scripting", "alarms"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chat-on-steroids",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chat-on-steroids",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chat-on-steroids",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Local coding bridge for ChatGPT over MCP, with native desktop control and approved-folder capability limits.",
   "license": "MIT",
   "author": "Chat On Steroids",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -346,7 +346,16 @@ void app.whenReady().then(async () => {
 
   // From here on a second launch may safely focus/recreate the window: renderer security policy
   // is installed and the renderer's fixed IPC methods already have handlers before it can load.
-  registerIpc(() => window);
+  // The same quit the tray's Quit performs. It has to go through `quitting` for the window's
+  // close-to-tray handler to let go: without it, quitting to install would hide the window and
+  // leave the app running, which is exactly the trap the Install button exists to end.
+  registerIpc(
+    () => window,
+    () => {
+      quitting = true;
+      app.quit();
+    }
+  );
   windowActivation.enable();
   windowActivation.request();
   // macOS `activate` can fire on first launch, so do not wire it at module load where it could

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -63,7 +63,7 @@ import { tokenPressure } from '../shared/session.js';
 import { forgetWorkspaceRoot, renameWorkspaceRoot } from './workspace.js';
 import { hostPlatformInfo } from './platform.js';
 import { openInPreferredBrowser } from './browser.js';
-import { onUpdateChange, updateStatus } from './update.js';
+import { markInstallOnQuit, onUpdateChange, updateStatus } from './update.js';
 import {
   getMacOSDesktopAccess,
   onMacOSDesktopAccessChange,
@@ -307,7 +307,7 @@ function handle<T>(channel: string, fn: (payload: unknown) => Promise<T>): void 
   });
 }
 
-export function registerIpc(getWindow: () => BrowserWindow | null): void {
+export function registerIpc(getWindow: () => BrowserWindow | null, quitToInstall: () => void): void {
   handle('state:get', async () => {
     const state = await buildState();
     // Native package smoke uses this as the end-to-end renderer readiness barrier. Unlike
@@ -533,6 +533,18 @@ export function registerIpc(getWindow: () => BrowserWindow | null): void {
   handle('clipboard:write', async (payload) => {
     const { text } = z.object({ text: z.string().max(1_000_000) }).parse(payload);
     clipboard.writeText(text);
+    return true;
+  });
+
+  // The Install button. The renderer decides nothing about what is installed - it cannot
+  // name a file, a version or a path - it only says "now", and only a staged, digest-checked
+  // artifact makes that mean anything. The quit is what applies it, at the end of the same
+  // shutdown sequence every other quit runs; refusing here is how a press with nothing staged
+  // avoids closing the app for no reason.
+  handle('update:install', async () => {
+    if (!markInstallOnQuit()) throw new Error('There is no downloaded update to install yet');
+    logInfo('update: install requested; quitting to hand the update over');
+    quitToInstall();
     return true;
   });
 

--- a/src/main/update.ts
+++ b/src/main/update.ts
@@ -15,8 +15,12 @@
  *   promise, so a second call while a download is running joins it rather than starting a
  *   second download of the same file. That is what makes the repeat timer free: a pass that
  *   finds the release it already staged stops at the release call.
- * - **The user restarts, not this app.** A staged update is applied during the ordinary quit
- *   sequence. Nothing here quits, relaunches, or interrupts what the user is doing.
+ * - **The user says when.** A staged update is applied during the ordinary quit sequence, and
+ *   `installStagedUpdate` is the button that starts that quit on purpose. Nothing here quits or
+ *   interrupts anything on its own.
+ * - **A staged artifact outlives the process that fetched it.** It is kept under the version it
+ *   belongs to, so the next start recognises the file it already has and reverifies it rather
+ *   than spending another hundred megabytes on the same installer.
  *
  * **What updates itself, and what does not.** Windows, and Linux installed as an AppImage. A
  * Linux `.deb` is owned by the system package manager and cannot be replaced without root, and
@@ -36,7 +40,7 @@
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { chmod, copyFile, mkdir, rename, rm } from 'node:fs/promises';
-import { createWriteStream } from 'node:fs';
+import { createReadStream, createWriteStream, existsSync } from 'node:fs';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -104,6 +108,8 @@ const CLEAR: UpdateStatus = { current: APP_VERSION, latest: null, stage: 'idle',
 let status: UpdateStatus = CLEAR;
 let staged: { version: string; file: string; kind: 'installer' | 'appimage'; target: string } | null = null;
 let pass: Promise<void> | null = null;
+/** Set by `markInstallOnQuit`: the user pressed Install, so bring the app back afterwards. */
+let runAfterInstall = false;
 const listeners = new Set<() => void>();
 
 export function onUpdateChange(listener: () => void): () => void {
@@ -176,11 +182,60 @@ async function runPass(): Promise<void> {
     set({ latest: release.version, stage: 'ready' });
     return;
   }
+  // One read of the release's own checksums, for whichever of the two paths below runs. It is
+  // both the manifest of what the release contains and the proof of what may be executed, so
+  // neither adopting a file nor fetching one happens without it.
+  const expected = (await releaseDigests(release.version)).get(artifact.name);
+  if (!expected) throw new Error(`release ${release.version} publishes no ${artifact.name}`);
+  const carried = await adopt(release.version, artifact.name, expected);
+  if (carried) {
+    staged = { version: release.version, file: carried, kind: artifact.kind, target: artifact.target };
+    set({ latest: release.version, stage: 'ready' });
+    logInfo(`update: ${release.version} was already downloaded and is ready to install`);
+    return;
+  }
   set({ latest: release.version, stage: 'downloading' });
-  const file = await download(release.version, artifact.name);
+  const file = await download(release.version, artifact.name, expected);
   staged = { version: release.version, file, kind: artifact.kind, target: artifact.target };
   set({ stage: 'ready' });
-  logInfo(`update: ${release.version} is staged and installs the next time the app starts`);
+  logInfo(`update: ${release.version} is downloaded and ready to install`);
+}
+
+/** Where one release's artifact is kept. Versioned, so no build is ever taken for another. */
+function stagingDir(version: string): string {
+  return path.join(app.getPath('userData'), 'updates', version);
+}
+
+/** The SHA-256 of a file already on disk. */
+async function fileDigest(file: string): Promise<string> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(file), hash);
+  return hash.digest('hex');
+}
+
+/**
+ * The artifact a previous run of this app already fetched and proved, or null for anything else.
+ *
+ * Staging is per version, so this is a question the file system alone can answer and there is no
+ * second record of it to fall out of step. The digest is checked again, against the release's
+ * own published sums rather than anything this app wrote beside the file: what makes an artifact
+ * safe to hand to an installer is that it still matches what the release publishes, and a staged
+ * update can sit here for days before anyone quits.
+ *
+ * Reusing it is not an optimisation. This app lives in the tray and is closed to it, so an
+ * update staged on Monday is applied whenever the user next really quits — and without this,
+ * every start in between refetched the same hundred megabytes to arrive at the same file.
+ */
+async function adopt(version: string, name: string, expected: string): Promise<string | null> {
+  const file = path.join(stagingDir(version), name);
+  if (!existsSync(file)) return null;
+  try {
+    if ((await fileDigest(file)) !== expected) throw new Error('it is not the published file');
+    return file;
+  } catch (err) {
+    logWarn(`update: the staged ${version} download cannot be reused (${(err as Error).message}); fetching it again`);
+    return null;
+  }
 }
 
 /** The one fact the release API is asked for: which version is newest. */
@@ -244,13 +299,11 @@ async function get(url: string, timeout: number, headers: Record<string, string>
  * `.part` until it has passed: the rename is what publishes it, so a download that was
  * interrupted or is not the right file can never be handed to an installer.
  */
-async function download(version: string, name: string): Promise<string> {
-  const expected = (await releaseDigests(version)).get(name);
-  if (!expected) throw new Error(`release ${version} publishes no ${name}`);
-  const dir = path.join(app.getPath('userData'), 'updates');
+async function download(version: string, name: string, expected: string): Promise<string> {
+  const dir = stagingDir(version);
   // One staged build at a time. Anything already here is either this same download starting
   // over or an artifact for a release nobody is going to install now.
-  await rm(dir, { recursive: true, force: true });
+  await rm(path.join(app.getPath('userData'), 'updates'), { recursive: true, force: true });
   await mkdir(dir, { recursive: true });
   const file = path.join(dir, name);
   const response = await get(assetUrl(version, name), DOWNLOAD_TIMEOUT_MS);
@@ -266,6 +319,25 @@ async function download(version: string, name: string): Promise<string> {
   }
   await rename(`${file}.part`, file);
   return file;
+}
+
+/**
+/**
+ * Records that the user pressed Install, and says whether there was anything to install.
+ *
+ * It deliberately installs nothing itself. The handoff belongs at the end of the ordinary
+ * shutdown sequence and nowhere else: that is what guarantees the bridge has drained, the child
+ * processes are gone and every durable write has landed before an installer starts replacing
+ * files underneath them. All this does is record that the user asked — which is also what makes
+ * the difference between an update applied on the way out of a quit the user wanted for other
+ * reasons, and one they are waiting to come back from.
+ *
+ * The caller quits. This module still never does.
+ */
+export function markInstallOnQuit(): boolean {
+  if (!staged) return false;
+  runAfterInstall = true;
+  return true;
 }
 
 /**
@@ -286,11 +358,18 @@ async function download(version: string, name: string): Promise<string> {
  */
 export async function applyStagedUpdate(): Promise<void> {
   const ready = staged;
+  const relaunch = runAfterInstall;
   staged = null;
+  runAfterInstall = false;
   if (!ready) return;
   try {
     if (ready.kind === 'installer') {
-      const installer = spawn(ready.file, ['/S'], { detached: true, stdio: 'ignore', windowsHide: true });
+      // `--updated` tells the assisted NSIS installer this is an upgrade of the install it
+      // already owns, so it keeps the location and the shortcuts instead of asking about them.
+      // `--force-run` is added only when the user pressed Install and is waiting for the app to
+      // come back; an update applied on the way out of an ordinary quit must not reopen it.
+      const args = relaunch ? ['/S', '--updated', '--force-run'] : ['/S', '--updated'];
+      const installer = spawn(ready.file, args, { detached: true, stdio: 'ignore', windowsHide: true });
       // An installer that cannot start reports it asynchronously, and an unhandled 'error' on a
       // child process would take the quit down with it.
       installer.on('error', (err: Error) => logWarn(`the ${ready.version} installer did not start: ${err.message}`));
@@ -300,8 +379,15 @@ export async function applyStagedUpdate(): Promise<void> {
       await copyFile(ready.file, next);
       await chmod(next, 0o755);
       await rename(next, ready.target);
+      // No installer to hand the "start it again" to, so this process arranges its own successor.
+      // Electron spawns it as this one exits, which is the app.exit() that ends the shutdown.
+      if (relaunch) app.relaunch({ execPath: ready.target });
     }
-    logInfo(`update: ${ready.version} handed over; the next start of this app is the new version`);
+    logInfo(
+      relaunch
+        ? `update: installing ${ready.version} now; the app starts itself again as the new version`
+        : `update: ${ready.version} handed over; the next start of this app is the new version`
+    );
   } catch (err) {
     // Nothing is retried and nothing is left half-applied. The next app start checks again.
     logWarn(`could not apply the staged ${ready.version} update: ${(err as Error).message}`);
@@ -313,5 +399,6 @@ export function resetUpdateForTests(): void {
   status = CLEAR;
   staged = null;
   pass = null;
+  runAfterInstall = false;
   listeners.clear();
 }

--- a/src/main/version.ts
+++ b/src/main/version.ts
@@ -12,7 +12,7 @@
  * extension does nothing" into a diagnosable mismatch.
  */
 
-export const APP_VERSION = '2.0.4';
+export const APP_VERSION = '2.0.5';
 
 /**
  * Standalone extension recovery must stay on the app's own release. Using GitHub's moving

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -85,6 +85,10 @@ const api = {
   getLogJson: () => call<string>('log:json'),
   writeClipboard: (text: string) => call<boolean>('clipboard:write', { text }),
   openLink: (url: string) => call<boolean>('link:open', { url }),
+  // Applies the update this app has already downloaded and verified: the app quits, the
+  // installer runs, and the app comes back as the new version. It takes no argument because
+  // there is nothing here to choose - the main process knows what is staged.
+  installUpdate: () => call<boolean>('update:install'),
 
   // Sessions, compaction and the browser bridge. Everything here is read-only or a
   // named action; there is still no channel that takes a path or a command.

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -81,6 +81,13 @@
           <button class="btn btn-icon" id="themeBtn" type="button" title="Switch to dark mode">
             <svg class="ico" viewBox="0 0 24 24"><use href="#i-moon" id="themeIcon" /></svg>
           </button>
+          <!-- Only ever visible with a downloaded, digest-checked update waiting. This app
+               lives in the tray and is closed to it, so "installs the next time you start it"
+               can mean days. This is the press that means now. -->
+          <button class="btn btn-install" id="installUpdate" type="button" hidden>
+            <svg class="ico" viewBox="0 0 24 24"><use href="#i-bolt" /></svg>
+            <span>Install update</span>
+          </button>
           <span class="live" id="live">
             <span class="dot"></span>
             <span id="liveState">Not connected</span>
@@ -100,6 +107,7 @@
         <svg class="ico" viewBox="0 0 24 24"><use href="#i-bolt" /></svg>
         <span id="updateText"></span>
         <button class="btn btn-quiet" id="updateGet" type="button" hidden>Get it</button>
+        <button class="btn btn-quiet" id="updateInstall" type="button" hidden>Install now</button>
       </div>
 
       <main>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -726,9 +726,9 @@ function updateSummary({ bridge, update }: AppState): { text: string; tone: Upda
     // is not one the app can update by itself. That is when the button matters.
     lines.push(
       update.stage === 'ready'
-        ? `Chat On Steroids ${update.latest} is downloaded and installs the next time you start the app.`
+        ? `Chat On Steroids ${update.latest} is downloaded and ready. Install it now, or it installs the next time you quit.`
         : update.stage === 'downloading'
-          ? `Chat On Steroids ${update.latest} is downloading. Keep working; it installs on your next start.`
+          ? `Chat On Steroids ${update.latest} is downloading. Keep working; you can install it when it lands.`
           : update.stage === 'failed'
             ? `Chat On Steroids ${update.latest} could not be downloaded: ${update.error ?? 'the download stopped'}.`
             : `Chat On Steroids ${update.latest} is out. This installation has to be updated by hand.`
@@ -767,6 +767,11 @@ function paintUpdate(next: AppState): void {
   const { update } = next;
   $('updateText').textContent = summary.text;
   $<HTMLButtonElement>('updateGet').hidden = !update.latest || update.stage === 'downloading' || update.stage === 'ready';
+  // `ready` is the only state with a verified artifact on disk, and therefore the only one in
+  // which pressing Install can do anything. Both buttons ask the same question of the same fact.
+  const installable = update.stage === 'ready';
+  $<HTMLButtonElement>('updateInstall').hidden = !installable;
+  $<HTMLButtonElement>('installUpdate').hidden = !installable;
   notice.hidden = !summary.notice;
   line.textContent = summary.text;
   line.className = `upline${summary.tone === 'ok' ? ' is-ok' : summary.tone === 'bad' ? ' is-bad' : ''}`;
@@ -1500,6 +1505,21 @@ $('wizExpand').addEventListener('click', () => {
   if (state) apply(state);
 });
 $('updateGet').addEventListener('click', () => void run(api.openLink(RELEASES_PAGE)));
+
+/**
+ * Install the update that is already downloaded.
+ *
+ * The app quits to do it — that is the only moment an installer can replace files nothing is
+ * holding open — so say so before it happens rather than leaving a window that vanishes on a
+ * click looking like a crash. Both buttons are the same action; either can be the one pressed.
+ */
+function installUpdate(): void {
+  toast('Installing the update. Chat On Steroids closes and starts again as the new version.');
+  void run(api.installUpdate());
+}
+
+$('updateInstall').addEventListener('click', installUpdate);
+$('installUpdate').addEventListener('click', installUpdate);
 $('connectBtn').addEventListener('click', () => void toggleConnection());
 $('wizConnect').addEventListener('click', () => void toggleConnection());
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -147,12 +147,23 @@ code {
   font-size: 0.92em;
 }
 
-/* The whole window: header, one scrolling middle, nav. Nothing else grows. */
+/* The whole window: header, an optional notice, one scrolling middle, nav. Nothing else
+   grows. A column rather than fixed grid rows, because the notice between the header and
+   `main` appears and disappears: with a three-row template its row was the one that had to
+   stretch, so a visible notice pushed `main` into an auto row sized to its whole content -
+   the banner clipped to a sliver and the panels overflowing the window under it. In a column
+   only `main` flexes, and the count of siblings above it stops mattering. */
 .app {
   height: 100%;
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  display: flex;
+  flex-direction: column;
   background: var(--page);
+}
+
+.app > header,
+.app > .notice,
+.app > nav {
+  flex: none;
 }
 
 /* ------------------------------------------------------------------ header */
@@ -284,6 +295,7 @@ header {
 /* ------------------------------------------------------------------ panels */
 
 main {
+  flex: 1 1 auto;
   min-height: 0;
   display: grid;
   grid-template-rows: minmax(0, 1fr);
@@ -522,6 +534,26 @@ main {
   background: var(--red-wash);
   border-radius: var(--pill);
   padding: 2px 8px;
+}
+
+/* The one button in the header that asks for something rather than reporting it. Ink, the
+   single accent this design has, so a waiting update reads as an action next to Connect. */
+.btn-install {
+  background: var(--ink);
+  color: var(--page);
+  padding: 8px 14px;
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.btn-install:hover:not(:disabled) {
+  background: var(--ink);
+  color: var(--page);
+  filter: brightness(1.35);
+}
+
+:root[data-theme='dark'] .btn-install:hover:not(:disabled) {
+  filter: brightness(0.86);
 }
 
 /* ----------------------------------------------------------------- notice */

--- a/test/ipc.test.ts
+++ b/test/ipc.test.ts
@@ -72,6 +72,8 @@ let currentWindow: {
   isDestroyed: () => boolean;
   webContents: { send: ReturnType<typeof vi.fn> };
 } | null = null;
+/** How many times the IPC layer asked the app to quit so a staged update can be applied. */
+let quitToInstallCalls = 0;
 
 const save = (patch: unknown, base: unknown = getConfig()): Promise<any> =>
   handlers.get('settings:save')!(null, { patch, base }) as Promise<any>;
@@ -105,7 +107,12 @@ beforeAll(async () => {
   onSwarmPersistNow((snapshot) => writeDurableNow('ipc-swarm', snapshot));
   onRetiredWorkersPersist(() => writeDurableSoon('ipc-retired-workers', snapshotRetiredWorkers()));
   onRetiredWorkersPersistNow((snapshot) => writeDurableNow('ipc-retired-workers', snapshot));
-  registerIpc(() => currentWindow as any);
+  registerIpc(
+    () => currentWindow as any,
+    () => {
+      quitToInstallCalls += 1;
+    }
+  );
 });
 
 afterAll(async () => {
@@ -517,6 +524,23 @@ describe('every link the window offers', () => {
 });
 
 /**
+ * The Install button, from the renderer's side of the wire.
+ *
+ * There is one thing to be sure of here: a press with nothing staged must not quit the app. The
+ * button exists because this app is closed to the tray and a quit is rare and deliberate, so a
+ * press that closed the window and installed nothing would be worse than no button at all.
+ */
+describe('installing a downloaded update on request', () => {
+  it('refuses, and does not quit, when nothing has been downloaded', async () => {
+    const before = quitToInstallCalls;
+    const reply = (await handlers.get('update:install')!(null, undefined)) as { ok: boolean; error: string };
+    expect(reply.ok).toBe(false);
+    expect(reply.error).toMatch(/no downloaded update/i);
+    expect(quitToInstallCalls).toBe(before);
+  });
+});
+
+/**
  * OpenRouter publishes twelve ids that begin with `~` — `~deepseek/deepseek-v4-flash-latest`
  * and its siblings — and they are aliases that always resolve to the newest model in a
  * family. The picker lists them because the catalogue does, so a validator that refused the
@@ -723,7 +747,10 @@ describe('renderer pushes after the window is gone', () => {
       }
     } as unknown as import('electron').BrowserWindow;
 
-    registerIpc(() => destroyed);
+    registerIpc(
+      () => destroyed,
+      () => {}
+    );
     expect(() => logInfo('teardown progress written after the window went away')).not.toThrow();
     expect(touchedWebContents).toBe(false);
   });

--- a/test/renderer-state.test.ts
+++ b/test/renderer-state.test.ts
@@ -687,10 +687,21 @@ it('reports a staged update in the Activity line and the header bar', async () =
   const doc = mounted.window.document;
   const line = doc.getElementById('updateLine')!;
   expect(line.className).toBe('upline');
-  expect(line.textContent).toContain('2.0.3 is downloaded and installs the next time');
+  expect(line.textContent).toContain('2.0.3 is downloaded and ready');
   expect(doc.getElementById('updateNotice')!.hidden).toBe(false);
   // There is nothing to fetch by hand once it is on disk.
   expect((doc.getElementById('updateGet') as HTMLButtonElement).hidden).toBe(true);
+  // ...and this is the one state in which there is something to install. Both buttons show,
+  // because a tray app closed to the tray may not see the header for days.
+  expect((doc.getElementById('updateInstall') as HTMLButtonElement).hidden).toBe(false);
+  expect((doc.getElementById('installUpdate') as HTMLButtonElement).hidden).toBe(false);
+
+  // Still downloading is not yet installable: there is no verified file to hand over.
+  const downloading = structuredClone(staged) as any;
+  downloading.update = { ...downloading.update, stage: 'downloading' };
+  mounted.push(downloading);
+  expect((doc.getElementById('updateInstall') as HTMLButtonElement).hidden).toBe(true);
+  expect((doc.getElementById('installUpdate') as HTMLButtonElement).hidden).toBe(true);
 
   const broken = structuredClone(staged) as any;
   broken.update = { current: '2.0.2', latest: null, stage: 'failed', error: 'latest answered 503', checkedAt: null };
@@ -699,6 +710,7 @@ it('reports a staged update in the Activity line and the header bar', async () =
   expect(line.textContent).toContain('503');
   // A check that could not reach GitHub is a diagnostic, not something the user can act on.
   expect(doc.getElementById('updateNotice')!.hidden).toBe(true);
+  expect((doc.getElementById('installUpdate') as HTMLButtonElement).hidden).toBe(true);
 });
 
 /**

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -29,7 +29,16 @@ vi.mock('node:child_process', () => ({
 
 let userData = '';
 let packaged = true;
-vi.mock('electron', () => ({ app: { getPath: () => userData, get isPackaged() { return packaged; } } }));
+const relaunched: Array<{ execPath?: string }> = [];
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => userData,
+    get isPackaged() {
+      return packaged;
+    },
+    relaunch: (options: { execPath?: string }) => relaunched.push(options)
+  }
+}));
 vi.mock('../src/main/logger.js', () => ({ logInfo: () => undefined, logWarn: () => undefined }));
 
 const { APP_VERSION } = await import('../src/main/version.js');
@@ -37,6 +46,7 @@ const { isNewer } = await import('../src/shared/types.js');
 const {
   applyStagedUpdate,
   checkForUpdates,
+  markInstallOnQuit,
   releaseVersion,
   resetUpdateForTests,
   stagedArtifact,
@@ -104,6 +114,7 @@ beforeEach(() => {
   userData = mkdtempSync(path.join(tmpdir(), 'cos-update-'));
   packaged = true;
   spawned.length = 0;
+  relaunched.length = 0;
   resetUpdateForTests();
 });
 
@@ -202,13 +213,14 @@ describe('staging the new version', () => {
     expect(updateStatus()).toMatchObject({ latest: NEXT, stage: 'ready', error: null });
     expect(asked).toEqual(['latest', 'SHA256SUMS.txt', WINDOWS_ASSET]);
 
-    const staged = path.join(userData, 'updates', WINDOWS_ASSET);
+    const staged = path.join(userData, 'updates', NEXT, WINDOWS_ASSET);
     expect(readFileSync(staged, 'utf8')).toBe(body);
     expect(existsSync(`${staged}.part`)).toBe(false);
 
-    // The quit half of the restart: the file that was staged is the one handed over, silently.
+    // The quit half of the restart: the file that was staged is the one handed over, silently,
+    // and without starting the app again behind a user who quit for their own reasons.
     await applyStagedUpdate();
-    expect(spawned).toEqual([{ file: staged, args: ['/S'] }]);
+    expect(spawned).toEqual([{ file: staged, args: ['/S', '--updated'] }]);
   });
 
   /**
@@ -222,7 +234,8 @@ describe('staging the new version', () => {
 
     expect(updateStatus().stage).toBe('failed');
     expect(updateStatus().error).toContain('not the published file');
-    expect(readdirSync(path.join(userData, 'updates'))).toEqual([]);
+    // The `.part` is gone with it: nothing a later quit could find and run is left behind.
+    expect(readdirSync(path.join(userData, 'updates', NEXT))).toEqual([]);
 
     await applyStagedUpdate();
     expect(spawned).toEqual([]);
@@ -313,5 +326,121 @@ describe('one pass at a time, and one more next time the app opens', () => {
     await applyStagedUpdate();
     await applyStagedUpdate();
     expect(spawned).toHaveLength(1);
+  });
+});
+
+/**
+ * The failure this exists for: this app is closed to the tray and can go days without a real
+ * quit, and a staged artifact used to live only in the memory of the process that fetched it.
+ * Every start after that downloaded the same hundred megabytes, staged it, and ended in the
+ * same place - and any start that ended by being killed rather than quit applied none of it.
+ */
+describe('a download that survives the process that fetched it', () => {
+  it('reuses the artifact a previous run already staged instead of fetching it again', async () => {
+    const first = github();
+    await asPlatform('win32', undefined, () => checkForUpdates());
+    expect(first.asked).toEqual(['latest', 'SHA256SUMS.txt', WINDOWS_ASSET]);
+
+    // A new run of the app: same disk, no memory of what the last one did.
+    resetUpdateForTests();
+    const second = github();
+    await asPlatform('win32', undefined, () => checkForUpdates());
+
+    // The sums are read again — the proof has to be current, not remembered — and the artifact
+    // itself is not. That request is the hundred megabytes.
+    expect(second.asked).toEqual(['latest', 'SHA256SUMS.txt']);
+    expect(updateStatus()).toMatchObject({ latest: NEXT, stage: 'ready', error: null });
+
+    await applyStagedUpdate();
+    expect(spawned).toEqual([
+      { file: path.join(userData, 'updates', NEXT, WINDOWS_ASSET), args: ['/S', '--updated'] }
+    ]);
+  });
+
+  /**
+   * Reuse is never trust. A file that no longer matches what the release publishes - a corrupted
+   * disk, a re-cut release under the same tag - is not adopted and not run; it is fetched again.
+   */
+  it('fetches again when the artifact on disk is not what the release publishes', async () => {
+    github();
+    await asPlatform('win32', undefined, () => checkForUpdates());
+    writeFileSync(path.join(userData, 'updates', NEXT, WINDOWS_ASSET), 'something else entirely');
+
+    resetUpdateForTests();
+    const second = github();
+    await asPlatform('win32', undefined, () => checkForUpdates());
+
+    expect(second.asked).toEqual(['latest', 'SHA256SUMS.txt', WINDOWS_ASSET]);
+    expect(updateStatus().stage).toBe('ready');
+    expect(readFileSync(path.join(userData, 'updates', NEXT, WINDOWS_ASSET), 'utf8')).toBe(second.body);
+  });
+
+  /** A staged build for a release nobody is going to install is not kept alongside the new one. */
+  it('keeps one version staged at a time', async () => {
+    github({ version: '98.0.0' });
+    await asPlatform('win32', undefined, () => checkForUpdates());
+    expect(readdirSync(path.join(userData, 'updates'))).toEqual(['98.0.0']);
+
+    resetUpdateForTests();
+    github();
+    await asPlatform('win32', undefined, () => checkForUpdates());
+    expect(readdirSync(path.join(userData, 'updates'))).toEqual([NEXT]);
+  });
+});
+
+/**
+ * The Install button. It applies nothing itself: it records that the user is waiting, and the
+ * quit it triggers runs the same handoff every other quit runs. The difference the flag makes is
+ * the one the user can see - the app comes back.
+ */
+describe('installing on request', () => {
+  it('asks the installer to start the app again', async () => {
+    github();
+    await asPlatform('win32', undefined, () => checkForUpdates());
+
+    expect(markInstallOnQuit()).toBe(true);
+    await applyStagedUpdate();
+    expect(spawned).toEqual([
+      { file: path.join(userData, 'updates', NEXT, WINDOWS_ASSET), args: ['/S', '--updated', '--force-run'] }
+    ]);
+  });
+
+  it('relaunches an AppImage install itself, having no installer to ask', async () => {
+    const live = path.join(userData, 'Chat-On-Steroids.AppImage');
+    writeFileSync(live, 'the old build');
+    const { body } = github();
+
+    await asPlatform('linux', live, async () => {
+      await checkForUpdates();
+      expect(markInstallOnQuit()).toBe(true);
+      await applyStagedUpdate();
+    });
+
+    expect(readFileSync(live, 'utf8')).toBe(body);
+    expect(relaunched).toEqual([{ execPath: live }]);
+  });
+
+  /** Nothing staged, nothing to do — and above all, no quit. */
+  it('refuses when there is nothing downloaded to install', async () => {
+    github({ version: APP_VERSION });
+    await asPlatform('win32', undefined, () => checkForUpdates());
+    expect(markInstallOnQuit()).toBe(false);
+  });
+
+  /** The flag belongs to one press. A later ordinary quit must not reopen the app. */
+  it('does not carry the request into the next quit', async () => {
+    github();
+    await asPlatform('win32', undefined, () => checkForUpdates());
+    expect(markInstallOnQuit()).toBe(true);
+    await applyStagedUpdate();
+
+    resetUpdateForTests();
+    spawned.length = 0;
+    github();
+    await asPlatform('win32', undefined, () => checkForUpdates());
+    await applyStagedUpdate();
+    expect(spawned).toEqual([
+      { file: path.join(userData, 'updates', NEXT, WINDOWS_ASSET), args: ['/S', '--updated'] }
+    ]);
   });
 });


### PR DESCRIPTION
2.0.4 downloaded itself correctly and then never installed. Three fixes, and a note on what
this means for the 2.0.4 release.

### The update never installed

A staged update is applied in the quit sequence. This app is closed to the tray — the window's
close button hides it — so the only path that ever reached `will-quit` was the tray's Quit.
Ending the app any other way skipped the handoff completely. On an affected machine the log has
no shutdown line in it at all: 2.0.4 downloaded and staged nine times in one morning, installed
zero times.

**Install update** now sits in the header beside Connect, and in the update notice, whenever a
downloaded and digest-checked artifact is waiting. It quits and installs, and the app comes back
as the new version.

Nothing about *how* an update is applied moves. The handoff stays where it was, at the end of
the same shutdown sequence, after the bridge has drained and every durable write has landed. The
button only decides that the quit happens and that the app returns — `--force-run` for the NSIS
installer, `app.relaunch` for an AppImage, which has no installer to ask. `--updated` is passed
as well, so the assisted installer keeps the location and shortcuts of the install it replaces.

The renderer names nothing across the wire: no file, no version, no path. It says "now", and
only a staged artifact makes that mean anything; a press with nothing staged is refused rather
than closing the app for no reason.

### The same hundred megabytes, every start

A staged artifact lived only in the memory of the process that fetched it, and the staging
directory was emptied at the start of every download. Every start of an installation that had
not managed to quit yet refetched the whole installer to arrive at the file it had just thrown
away.

It is now kept under the version it belongs to, and reverified on the next start against the
release's own published checksums — not against anything this app wrote beside it, and never
adopted on the strength of a file name. The checksums are read once per pass and handed to
whichever path runs, so adopting a file costs one small request and fetching one costs no more
than before.

### The notice broke the window

The shell was three grid rows for four children, so the notice landed in the row that had to
stretch and `main` fell into an auto row sized to its whole content. With a full Home panel the
banner was squeezed to a clipped sliver and the panels were drawn over the top of it.

Measured at a 380px window — before: notice 17px tall holding 19px of text, `main` starting at
the notice's own top edge. After: notice at its own 39px, `main` starting below it. The shell is
a column now and only `main` flexes, so the number of things above it stops mattering.

### About v2.0.4

v2.0.4 is the build with both faults, and an install of it can only be updated by quitting
through the tray. Its release is being withdrawn once this ships, so nobody installs it fresh;
anyone already on it is offered 2.0.5 normally.
