### PR TITLE
spawn: per-worker model and reasoning_effort

### DIFF
--- a/docs/tool-surface.md
+++ b/docs/tool-surface.md
@@ -106,7 +106,11 @@ Compact & Resume is app/browser orchestration. There is no model-visible `save_h
 Available while multi-agent mode is enabled. It has exactly four actions:
 
 - `spawn` creates worker chats from one shared context plus per-worker tasks. Used once per run:
-  a run that needs a worker again reuses one it already has.
+  a run that needs a worker again reuses one it already has. Each worker takes an optional
+  `model` slug: the worker's chat opens with `?model=<slug>` in its fresh-chat URL, so a prime
+  on a limited model can spawn workers on a cheaper one. Omitted means the account default;
+  a slug ChatGPT does not recognise opens with the default too. The model is fixed for the
+  life of that conversation, including across sleep/wake reuse.
 - `message` sends one message or an all-or-nothing batch. Messaging a sleeping worker is what
   wakes it, in the chat it already has.
 - `status` reports the run and workers, including who is asleep and how many worker slots are free.

--- a/docs/tool-surface.md
+++ b/docs/tool-surface.md
@@ -110,7 +110,10 @@ Available while multi-agent mode is enabled. It has exactly four actions:
   `model` slug: the worker's chat opens with `?model=<slug>` in its fresh-chat URL, so a prime
   on a limited model can spawn workers on a cheaper one. Omitted means the account default;
   a slug ChatGPT does not recognise opens with the default too. The model is fixed for the
-  life of that conversation, including across sleep/wake reuse.
+  life of that conversation, including across sleep/wake reuse. Each worker also takes an
+  optional `reasoning_effort`: none, minimal, low, medium, high, xhigh, max or ultra, forwarded
+  on the open URL independently of `model` — a level never selects or changes the model, and
+  omitting both inherits the normal worker defaults.
 - `message` sends one message or an all-or-nothing batch. Messaging a sleeping worker is what
   wakes it, in the chat it already has.
 - `status` reports the run and workers, including who is asleep and how many worker slots are free.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1227,6 +1227,18 @@ function commandMarkerId(value) {
   return id && id.length <= 128 ? id : null;
 }
 
+/**
+ * Requested ChatGPT model slug for a worker's fresh chat, or null for the account default.
+ *
+ * Same vocabulary the app enforces: anything shaped like a slug passes through to the open
+ * URL, anything else is dropped here rather than typed into a URL. An unknown slug is
+ * ChatGPT's to ignore — the chat then opens with the default.
+ */
+function commandModelSlug(value) {
+  const model = typeof value === 'string' ? value.trim() : '';
+  return model && /^[A-Za-z0-9._-]{1,80}$/.test(model) ? model : null;
+}
+
 function deferredRevivalId(value) {
   return commandMarkerId(value);
 }
@@ -2634,7 +2646,9 @@ async function placeSuccessorChat(raw, tabId) {
   // Both a query and a fragment, matching the app's commandUrl(): ChatGPT rewrites its own URL
   // during boot and which of the two survives has changed between builds.
   const marker = `clf=${encodeURIComponent(id)}`;
-  const create = { url: `https://chatgpt.com/?${marker}#${marker}`, windowId: home.windowId, active: true };
+  const model = commandModelSlug(raw && raw.model);
+  const query = model ? `${marker}&model=${encodeURIComponent(model)}` : marker;
+  const create = { url: `https://chatgpt.com/?${query}#${marker}`, windowId: home.windowId, active: true };
   // Directly after the chat it continues, so a handoff reads as one piece of work instead of a
   // tab appended to the far end of a long strip.
   if (typeof home.index === 'number') create.index = home.index + 1;

--- a/extension/background.js
+++ b/extension/background.js
@@ -1239,6 +1239,20 @@ function commandModelSlug(value) {
   return model && /^[A-Za-z0-9._-]{1,80}$/.test(model) ? model : null;
 }
 
+/**
+ * Requested reasoning level for a worker's fresh chat, or null to inherit.
+ *
+ * Canonical vocabulary; the app's broker is the authority and this mirrors its list.
+ * Anything outside it is dropped here rather than typed into a URL. Forwarded
+ * independently of model: a level never selects or changes the model.
+ */
+const COMMAND_REASONING_EFFORTS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
+
+function commandReasoningEffort(value) {
+  const effort = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  return effort && COMMAND_REASONING_EFFORTS.includes(effort) ? effort : null;
+}
+
 function deferredRevivalId(value) {
   return commandMarkerId(value);
 }
@@ -2647,8 +2661,11 @@ async function placeSuccessorChat(raw, tabId) {
   // during boot and which of the two survives has changed between builds.
   const marker = `clf=${encodeURIComponent(id)}`;
   const model = commandModelSlug(raw && raw.model);
-  const query = model ? `${marker}&model=${encodeURIComponent(model)}` : marker;
-  const create = { url: `https://chatgpt.com/?${query}#${marker}`, windowId: home.windowId, active: true };
+  const reasoningEffort = commandReasoningEffort(raw && raw.reasoningEffort);
+  const query = [marker];
+  if (model) query.push(`model=${encodeURIComponent(model)}`);
+  if (reasoningEffort) query.push(`reasoning_effort=${encodeURIComponent(reasoningEffort)}`);
+  const create = { url: `https://chatgpt.com/?${query.join('&')}#${marker}`, windowId: home.windowId, active: true };
   // Directly after the chat it continues, so a handoff reads as one piece of work instead of a
   // tab appended to the far end of a long strip.
   if (typeof home.index === 'number') create.index = home.index + 1;

--- a/src/main/agents.ts
+++ b/src/main/agents.ts
@@ -83,7 +83,8 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { AgentInfo, AgentMessage, AgentState, SwarmState } from '../shared/session.js';
+import type { AgentInfo, AgentMessage, AgentState, ReasoningEffort, SwarmState } from '../shared/session.js';
+import { REASONING_EFFORTS, isReasoningEffort } from '../shared/session.js';
 import { getConfig } from './config.js';
 import { logInfo, logWarn } from './logger.js';
 import { inheritWorkspace, releasePrimeWorkspace } from './workspace.js';
@@ -563,6 +564,8 @@ export interface WorkerSpawn {
   task: string;
   /** Requested ChatGPT model slug, or null for the account default. */
   model: string | null;
+  /** Requested reasoning level, or null to inherit the default. */
+  reasoningEffort: ReasoningEffort | null;
 }
 
 /** Workers that exist but have not joined: their chat is still owed. */
@@ -573,7 +576,7 @@ export function pendingWorkerSpawns(): WorkerSpawn[] {
       (agent) =>
         agent.info.role === 'worker' && agent.info.state === 'invited' && !unpublishedAgents.has(agent)
     )
-    .map((agent) => ({ id: agent.info.id, task: agent.info.task, model: agent.info.model }));
+    .map((agent) => ({ id: agent.info.id, task: agent.info.task, model: agent.info.model, reasoningEffort: agent.info.reasoningEffort }));
 }
 
 /**
@@ -871,7 +874,7 @@ Your task:
 ${task}`;
 }
 
-function makeWorker(id: string, label: string, task: string, model: string | null): Agent {
+function makeWorker(id: string, label: string, task: string, model: string | null, reasoningEffort: ReasoningEffort | null): Agent {
   return {
     info: {
       id,
@@ -879,6 +882,7 @@ function makeWorker(id: string, label: string, task: string, model: string | nul
       label,
       task,
       model,
+      reasoningEffort,
       state: 'invited',
       createdAt: Date.now(),
       activatedAt: null,
@@ -906,6 +910,7 @@ function makePrime(conversationId: string): Agent {
       label: 'Prime',
       task: 'Coordinates the workers',
       model: null,
+      reasoningEffort: null,
       state: 'active',
       createdAt: Date.now(),
       activatedAt: Date.now(),
@@ -1081,7 +1086,7 @@ export function forgetRetiredWorker(conversationId: string): void {
 // -------------------------------------------------------------------- spawn
 
 export interface SpawnInput {
-  workers: ReadonlyArray<{ label?: string; task: string; model?: string | null }>;
+  workers: ReadonlyArray<{ label?: string; task: string; model?: string | null; reasoning_effort?: string | null }>;
   /**
    * What every worker in this spawn needs to know, written once.
    *
@@ -1192,6 +1197,28 @@ export function isModelSlug(value: unknown): value is string {
 }
 
 /**
+ * Normalizes a worker's requested reasoning level: trimmed and lowercased, or null to
+ * inherit the default when omitted or blank.
+ *
+ * Unknown values fail the whole spawn rather than opening a worker under a level nobody
+ * asked for: like every other spawn validation, this runs before the first mutation, so
+ * a rejection leaves zero workers behind. There is deliberately no silent downgrade to a
+ * default — a status line claiming one level while the worker runs another is exactly the
+ * lie this refuses to tell.
+ */
+function normalizeReasoningEffort(index: number, value: string | null | undefined): ReasoningEffort | null {
+  if (value === undefined || value === null) return null;
+  const effort = value.trim().toLowerCase();
+  if (!effort) return null;
+  if (!isReasoningEffort(effort)) {
+    throw new AgentError(
+      `Worker ${index + 1}'s reasoning_effort must be one of: ${REASONING_EFFORTS.join(', ')}`
+    );
+  }
+  return effort;
+}
+
+/**
  * Plans a worker spawn behind the same durable acceptance boundary used by agents::message.
  *
  * Production must call persistCriticalSwarmNow(), then commit() on success or rollback() on
@@ -1228,7 +1255,7 @@ export function requestWorkerBootstraps(ids: readonly string[]): number {
         !unpublishedAgents.has(agent) &&
         wanted.has(agent.info.id)
     )
-    .map((agent) => ({ id: agent.info.id, task: agent.info.task, model: agent.info.model }));
+    .map((agent) => ({ id: agent.info.id, task: agent.info.task, model: agent.info.model, reasoningEffort: agent.info.reasoningEffort }));
   if (owed.length === 0) return 0;
   if (spawnRequest) spawnRequest(owed);
   else logWarn('multi-agent: no browser extension is paired, so worker chats cannot be opened automatically');
@@ -1273,11 +1300,12 @@ export function spawn(input: SpawnInput, options: SpawnOptions = {}): SpawnResul
       throw new AgentError(`Worker ${index + 1}'s label is too long (limit ${MAX_LABEL_CHARS} characters)`);
     }
     const model = normalizeModel(index, worker.model);
+    const reasoningEffort = normalizeReasoningEffort(index, worker.reasoning_effort);
     // Composed once, here, and stored as *the* task. Everything downstream — the bootstrap
     // the browser types, the repeated-spawn match, the status table, the snapshot — then
     // sees the same single string a worker actually receives, with no second field to keep
     // in step and no way for the two halves to be delivered apart.
-    return { label, task: briefFor(context, task), model };
+    return { label, task: briefFor(context, task), model, reasoningEffort };
   });
 
   const conversationId = input.caller.conversationId ?? null;
@@ -1371,7 +1399,7 @@ export function spawn(input: SpawnInput, options: SpawnOptions = {}): SpawnResul
   const createdAgents: Agent[] = [];
   for (const [index, worker] of planned.entries()) {
     const id = ids[index] as string;
-    const agent = makeWorker(id, worker.label || id, worker.task, worker.model);
+    const agent = makeWorker(id, worker.label || id, worker.task, worker.model, worker.reasoningEffort);
     activeRun.agents.set(id, agent);
     // A worker starts in the folder the prime was working in, so its first call can use the
     // same shorthand. It is a copy: a worker sent into another project overwrites its own
@@ -1413,19 +1441,19 @@ export function spawn(input: SpawnInput, options: SpawnOptions = {}): SpawnResul
  * worker still gets one; only an exact repetition of work already under way is folded back.
  */
 function matchExistingRequest(
-  requested: ReadonlyArray<{ label: string; task: string; model: string | null }>,
+  requested: ReadonlyArray<{ label: string; task: string; model: string | null; reasoningEffort: ReasoningEffort | null }>,
   live: readonly Agent[]
 ): Agent[] | null {
   if (requested.length === 0 || live.length === 0) return null;
-  // An unambiguous encoding of the (label, task, model) triple rather than a separator character.
+  // An unambiguous encoding of the (label, task, model, reasoning) tuple rather than a separator character.
   // Any separator is only as good as the assumption that it cannot occur in the operands, and
   // the first two are free text a model wrote; JSON removes the assumption entirely, so
   // ("a", "b c") and ("a b", "c") can never shape-collide into one match. It also keeps this
   // file plain text: the NUL that used to do this job was a literal byte, which made every
-  // text tool treat the source as binary. The model rides along because a retry that asks for
-  // a different model is new intent, not the same request arriving twice.
-  const shape = (label: string, task: string, model: string | null): string =>
-    JSON.stringify([label.trim(), task.trim(), model]);
+  // text tool treat the source as binary. Model and reasoning ride along because a retry that
+  // asks for a different model or level is new intent, not the same request arriving twice.
+  const shape = (label: string, task: string, model: string | null, reasoningEffort: ReasoningEffort | null): string =>
+    JSON.stringify([label.trim(), task.trim(), model, reasoningEffort]);
   const taken = new Set<Agent>();
   const matched: Agent[] = [];
   for (const worker of requested) {
@@ -1434,10 +1462,10 @@ function matchExistingRequest(
     const found = live.find(
       (agent) =>
         !taken.has(agent) &&
-        (shape(agent.info.label, agent.info.task, agent.info.model) ===
-          shape(worker.label || agent.info.id, worker.task, worker.model) ||
-          shape(agent.info.label, agent.info.task, agent.info.model) ===
-            shape(worker.label, worker.task, worker.model))
+        (shape(agent.info.label, agent.info.task, agent.info.model, agent.info.reasoningEffort) ===
+          shape(worker.label || agent.info.id, worker.task, worker.model, worker.reasoningEffort) ||
+          shape(agent.info.label, agent.info.task, agent.info.model, agent.info.reasoningEffort) ===
+            shape(worker.label, worker.task, worker.model, worker.reasoningEffort))
     );
     if (!found) return null;
     taken.add(found);
@@ -4016,6 +4044,7 @@ function deserializeAgents(entries: readonly SerializedAgent[], savedAt: number)
       info: {
         ...entry.info,
         model: isModelSlug(entry.info.model) ? entry.info.model : null,
+        reasoningEffort: isReasoningEffort(entry.info.reasoningEffort) ? entry.info.reasoningEffort : null,
         sleptAt: typeof entry.info.sleptAt === 'number' ? entry.info.sleptAt : null,
         contextTokens: Number.isFinite(entry.info.contextTokens) ? entry.info.contextTokens : 0,
         lastRevivalCommandId:

--- a/src/main/agents.ts
+++ b/src/main/agents.ts
@@ -133,6 +133,15 @@ const MAX_TASK_CHARS = 4000;
  */
 const MAX_CONTEXT_CHARS = 4000;
 const MAX_LABEL_CHARS = 60;
+/**
+ * How long a ChatGPT model slug in a worker's `model` field may be.
+ *
+ * Slugs are OpenAI's vocabulary, not ours, so this is a transport bound, not a menu: anything
+ * shaped like a slug passes through to the fresh-chat URL untouched, and an unknown slug
+ * simply opens with the account default rather than failing the spawn.
+ */
+const MAX_MODEL_CHARS = 80;
+const MODEL_SLUG_RE = /^[A-Za-z0-9._-]{1,80}$/;
 
 /**
  * How long a detached worker may make no proven tool call before the run puts it to sleep.
@@ -552,6 +561,8 @@ export interface RetiredChat {
 export interface WorkerSpawn {
   id: string;
   task: string;
+  /** Requested ChatGPT model slug, or null for the account default. */
+  model: string | null;
 }
 
 /** Workers that exist but have not joined: their chat is still owed. */
@@ -562,7 +573,7 @@ export function pendingWorkerSpawns(): WorkerSpawn[] {
       (agent) =>
         agent.info.role === 'worker' && agent.info.state === 'invited' && !unpublishedAgents.has(agent)
     )
-    .map((agent) => ({ id: agent.info.id, task: agent.info.task }));
+    .map((agent) => ({ id: agent.info.id, task: agent.info.task, model: agent.info.model }));
 }
 
 /**
@@ -860,13 +871,14 @@ Your task:
 ${task}`;
 }
 
-function makeWorker(id: string, label: string, task: string): Agent {
+function makeWorker(id: string, label: string, task: string, model: string | null): Agent {
   return {
     info: {
       id,
       role: 'worker',
       label,
       task,
+      model,
       state: 'invited',
       createdAt: Date.now(),
       activatedAt: null,
@@ -893,6 +905,7 @@ function makePrime(conversationId: string): Agent {
       role: 'prime',
       label: 'Prime',
       task: 'Coordinates the workers',
+      model: null,
       state: 'active',
       createdAt: Date.now(),
       activatedAt: Date.now(),
@@ -1068,7 +1081,7 @@ export function forgetRetiredWorker(conversationId: string): void {
 // -------------------------------------------------------------------- spawn
 
 export interface SpawnInput {
-  workers: ReadonlyArray<{ label?: string; task: string }>;
+  workers: ReadonlyArray<{ label?: string; task: string; model?: string | null }>;
   /**
    * What every worker in this spawn needs to know, written once.
    *
@@ -1148,6 +1161,37 @@ function settleSpawnStage(stage: SpawnStageState, accepted: boolean): void {
 }
 
 /**
+ * Normalizes a worker's requested ChatGPT model slug: trimmed, or null for the account
+ * default when omitted or blank.
+ *
+ * Malformed input fails the whole spawn rather than opening a worker under a model nobody
+ * asked for: like every other spawn validation, this runs before the first mutation, so a
+ * rejection leaves zero workers behind. A well-formed slug ChatGPT does not recognise is
+ * not ours to refuse — the fresh chat simply opens with the default.
+ */
+function normalizeModel(index: number, value: string | null | undefined): string | null {
+  if (value === undefined || value === null) return null;
+  const model = value.trim();
+  if (!model) return null;
+  if (!isModelSlug(model)) {
+    throw new AgentError(
+      `Worker ${index + 1}'s model is not a ChatGPT model slug (letters, digits, dot, underscore, hyphen; limit ${MAX_MODEL_CHARS} characters)`
+    );
+  }
+  return model;
+}
+
+/**
+ * Whether a string is shaped like a ChatGPT model slug. The single vocabulary check for
+ * worker models, shared by the broker and the bridge's durable restore: slugs are OpenAI's
+ * vocabulary, so anything shaped like one passes through and an unknown one simply opens
+ * with the account default.
+ */
+export function isModelSlug(value: unknown): value is string {
+  return typeof value === 'string' && MODEL_SLUG_RE.test(value);
+}
+
+/**
  * Plans a worker spawn behind the same durable acceptance boundary used by agents::message.
  *
  * Production must call persistCriticalSwarmNow(), then commit() on success or rollback() on
@@ -1184,7 +1228,7 @@ export function requestWorkerBootstraps(ids: readonly string[]): number {
         !unpublishedAgents.has(agent) &&
         wanted.has(agent.info.id)
     )
-    .map((agent) => ({ id: agent.info.id, task: agent.info.task }));
+    .map((agent) => ({ id: agent.info.id, task: agent.info.task, model: agent.info.model }));
   if (owed.length === 0) return 0;
   if (spawnRequest) spawnRequest(owed);
   else logWarn('multi-agent: no browser extension is paired, so worker chats cannot be opened automatically');
@@ -1228,11 +1272,12 @@ export function spawn(input: SpawnInput, options: SpawnOptions = {}): SpawnResul
     if (label.length > MAX_LABEL_CHARS) {
       throw new AgentError(`Worker ${index + 1}'s label is too long (limit ${MAX_LABEL_CHARS} characters)`);
     }
+    const model = normalizeModel(index, worker.model);
     // Composed once, here, and stored as *the* task. Everything downstream — the bootstrap
     // the browser types, the repeated-spawn match, the status table, the snapshot — then
     // sees the same single string a worker actually receives, with no second field to keep
     // in step and no way for the two halves to be delivered apart.
-    return { label, task: briefFor(context, task) };
+    return { label, task: briefFor(context, task), model };
   });
 
   const conversationId = input.caller.conversationId ?? null;
@@ -1326,7 +1371,7 @@ export function spawn(input: SpawnInput, options: SpawnOptions = {}): SpawnResul
   const createdAgents: Agent[] = [];
   for (const [index, worker] of planned.entries()) {
     const id = ids[index] as string;
-    const agent = makeWorker(id, worker.label || id, worker.task);
+    const agent = makeWorker(id, worker.label || id, worker.task, worker.model);
     activeRun.agents.set(id, agent);
     // A worker starts in the folder the prime was working in, so its first call can use the
     // same shorthand. It is a copy: a worker sent into another project overwrites its own
@@ -1368,17 +1413,19 @@ export function spawn(input: SpawnInput, options: SpawnOptions = {}): SpawnResul
  * worker still gets one; only an exact repetition of work already under way is folded back.
  */
 function matchExistingRequest(
-  requested: ReadonlyArray<{ label: string; task: string }>,
+  requested: ReadonlyArray<{ label: string; task: string; model: string | null }>,
   live: readonly Agent[]
 ): Agent[] | null {
   if (requested.length === 0 || live.length === 0) return null;
-  // An unambiguous encoding of the (label, task) pair rather than a separator character.
+  // An unambiguous encoding of the (label, task, model) triple rather than a separator character.
   // Any separator is only as good as the assumption that it cannot occur in the operands, and
-  // both of these are free text a model wrote; JSON removes the assumption entirely, so
+  // the first two are free text a model wrote; JSON removes the assumption entirely, so
   // ("a", "b c") and ("a b", "c") can never shape-collide into one match. It also keeps this
   // file plain text: the NUL that used to do this job was a literal byte, which made every
-  // text tool treat the source as binary.
-  const shape = (label: string, task: string): string => JSON.stringify([label.trim(), task.trim()]);
+  // text tool treat the source as binary. The model rides along because a retry that asks for
+  // a different model is new intent, not the same request arriving twice.
+  const shape = (label: string, task: string, model: string | null): string =>
+    JSON.stringify([label.trim(), task.trim(), model]);
   const taken = new Set<Agent>();
   const matched: Agent[] = [];
   for (const worker of requested) {
@@ -1387,8 +1434,10 @@ function matchExistingRequest(
     const found = live.find(
       (agent) =>
         !taken.has(agent) &&
-        (shape(agent.info.label, agent.info.task) === shape(worker.label || agent.info.id, worker.task) ||
-          shape(agent.info.label, agent.info.task) === shape(worker.label, worker.task))
+        (shape(agent.info.label, agent.info.task, agent.info.model) ===
+          shape(worker.label || agent.info.id, worker.task, worker.model) ||
+          shape(agent.info.label, agent.info.task, agent.info.model) ===
+            shape(worker.label, worker.task, worker.model))
     );
     if (!found) return null;
     taken.add(found);
@@ -3966,6 +4015,7 @@ function deserializeAgents(entries: readonly SerializedAgent[], savedAt: number)
     const agent: Agent = {
       info: {
         ...entry.info,
+        model: isModelSlug(entry.info.model) ? entry.info.model : null,
         sleptAt: typeof entry.info.sleptAt === 'number' ? entry.info.sleptAt : null,
         contextTokens: Number.isFinite(entry.info.contextTokens) ? entry.info.contextTokens : 0,
         lastRevivalCommandId:

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -23,7 +23,7 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto';
 import http from 'node:http';
 import type { BridgeStatus } from '../shared/types.js';
-import { CHAT_SILENCE_MS, CONTINUATION_MARKER, type SessionEvent, type SessionOrigin } from '../shared/session.js';
+import { CHAT_SILENCE_MS, CONTINUATION_MARKER, isReasoningEffort, type ReasoningEffort, type SessionEvent, type SessionOrigin } from '../shared/session.js';
 import { isChatBlocked } from './session/blocked-chats.js';
 export { CHAT_ACTIVE_MS, CHAT_SILENCE_MS } from '../shared/session.js';
 import { getConfig, updateConfig } from './config.js';
@@ -347,6 +347,14 @@ type CommandSpec =
        * typed into the chat or shown to the model.
        */
       model: string | null;
+      /**
+       * Requested reasoning level for the worker's fresh chat, or null to inherit.
+       *
+       * Forwarded as declared creation intent on the open URL, independently of model:
+       * setting a level never selects or changes the model. The app reports the requested
+       * value; only the chat's own picker state proves what ChatGPT applied.
+       */
+      reasoningEffort: ReasoningEffort | null;
       runId: string;
     }
   /**
@@ -475,13 +483,18 @@ export interface BridgeCommand {
   text: string;
   /** Agent this tab will be, when the command comes from multi-agent mode. */
   agent: string | null;
-  /**
-   * Requested ChatGPT model slug for a worker's fresh chat, or null for the account default.
-   *
+  /** Requested ChatGPT model slug for a worker's fresh chat, or null for the account default.
    * Carried on the wire so the page opening the tab can select the model in the open URL.
    * Null for every other command kind.
    */
   model: string | null;
+  /**
+   * Requested reasoning level for a worker's fresh chat, or null to inherit.
+   *
+   * Carried on the wire beside model so the open URL declares both independently.
+   * Null for every other command kind.
+   */
+  reasoningEffort: ReasoningEffort | null;
   /**
    * The conversation this command is *for*, when it is for one that already exists.
    *
@@ -3528,7 +3541,7 @@ async function startBridgeOnce(epoch: number): Promise<number | null> {
       rearmRetainedCommandDeadlines();
       dropSpawnRequestListener?.();
       dropSpawnRequestListener = onSpawnRequest((workers) => {
-        for (const worker of workers) queueWorkerBootstrap(worker.id, worker.task, worker.model);
+        for (const worker of workers) queueWorkerBootstrap(worker.id, worker.task, worker.model, worker.reasoningEffort);
       });
       // The same replay contract for waking a worker that already has a chat. A run restored
       // from disk can hold a worker left in `waking` by a crash mid-revival; registering here
@@ -4165,13 +4178,13 @@ async function cancelAutomaticResumesNow(): Promise<number> {
  * stored: the chat this opens is bound to the slot by the extension's report, and the
  * recovery key exists only if the user asks the app for one after that has failed.
  */
-export function queueWorkerBootstrap(agent: string, task: string, model: string | null): BridgeCommand | null {
+export function queueWorkerBootstrap(agent: string, task: string, model: string | null, reasoningEffort: ReasoningEffort | null): BridgeCommand | null {
   const runId = currentRunId();
   // A worker bootstrap is authority for one concrete broker incarnation. There is no safe
   // meaning for one outside a run, and manufacturing an unscoped command here is exactly how
   // stale durable work later becomes somebody else's `worker-1`.
   if (!runId) return null;
-  const command = queue({ type: 'worker', agent, task, model, runId });
+  const command = queue({ type: 'worker', agent, task, model, reasoningEffort, runId });
   // Start the clock at broker admission, exactly as a revival does. A bootstrap that never
   // reaches a page is the case that has no other clock at all.
   armDeadline(command);
@@ -4300,17 +4313,22 @@ export function chatUrl(conversationId: string): string {
 }
 
 /** Where the app opens a fresh worker/resume chat. The marker is an id, not a credential. */
-export function commandUrl(id: string, model?: string | null): string {
+export function commandUrl(id: string, model?: string | null, reasoningEffort?: ReasoningEffort | null): string {
   // Both a query and a fragment: ChatGPT is a single-page app that rewrites its own URL
   // during boot, and which of the two survives has changed between builds. The content
   // script accepts either, and redeeming still requires the extension's bearer token —
   // so a copied link, a history entry or a synced tab is worth nothing on its own.
   // A requested model rides the query only: it selects the chat's model at open and is
   // never part of the identity the page redeems with. An unknown slug is ChatGPT's to
-  // ignore — the chat then opens with the account default.
+  // ignore — the chat then opens with the account default. Reasoning rides beside it as
+  // declared creation intent, forwarded independently: it never selects or changes the
+  // model, and whether ChatGPT applies it is proven by the chat's own picker state, not
+  // by this URL.
   const marker = `clf=${encodeURIComponent(id)}`;
-  const query = model ? `${marker}&model=${encodeURIComponent(model)}` : marker;
-  return `https://chatgpt.com/?${query}#${marker}`;
+  const params = [marker];
+  if (model) params.push(`model=${encodeURIComponent(model)}`);
+  if (reasoningEffort) params.push(`reasoning_effort=${encodeURIComponent(reasoningEffort)}`);
+  return `https://chatgpt.com/?${params.join('&')}#${marker}`;
 }
 
 /**
@@ -4396,7 +4414,7 @@ export const BROWSER_PLACEMENT_MS = 20_000;
 let placementCollector: string | null = null;
 
 /** The one fresh chat currently offered to its home page, and the fallback that outlives it. */
-let placementOffer: { id: string; conversationId: string; model: string | null } | null = null;
+let placementOffer: { id: string; conversationId: string; model: string | null; reasoningEffort: ReasoningEffort | null } | null = null;
 let placementTimer: NodeJS.Timeout | null = null;
 
 /** Drops the standing offer and its fallback. Called by every path that ends a command. */
@@ -4420,7 +4438,8 @@ function offerPlacement(command: Command): boolean {
   placementOffer = {
     id: command.id,
     conversationId: home,
-    model: command.spec.type === 'worker' ? command.spec.model : null
+    model: command.spec.type === 'worker' ? command.spec.model : null,
+    reasoningEffort: command.spec.type === 'worker' ? command.spec.reasoningEffort : null
   };
   placementTimer = setTimeout(() => {
     placementTimer = null;
@@ -4442,7 +4461,7 @@ function offerPlacement(command: Command): boolean {
  * a second one. If that page fails to act, the fallback above is what recovers it, not a
  * repeated offer.
  */
-function pendingBrowserPlacement(conversationId: string): { id: string; model: string | null } | null {
+function pendingBrowserPlacement(conversationId: string): { id: string; model: string | null; reasoningEffort: ReasoningEffort | null } | null {
   const offer = placementOffer;
   if (!offer || offer.conversationId !== conversationId) return null;
   if (!commands.some((entry) => entry.id === offer.id && entry.owner === null)) {
@@ -4450,7 +4469,7 @@ function pendingBrowserPlacement(conversationId: string): { id: string; model: s
     return null;
   }
   placementOffer = null;
-  return { id: offer.id, model: offer.model };
+  return { id: offer.id, model: offer.model, reasoningEffort: offer.reasoningEffort };
 }
 
 // -------------------------------------------------------- exact browser recovery
@@ -6129,7 +6148,9 @@ async function openFreshChatInBrowser(command: Command): Promise<void> {
     // difference, and the window it opens is only ever spent by a browser failing to appear.
     if (!browserPresent()) lastBrowserLaunchAt = Date.now();
     await openInBrowser(
-      command.spec.type === 'worker' ? commandUrl(command.id, command.spec.model) : commandUrl(command.id)
+      command.spec.type === 'worker'
+        ? commandUrl(command.id, command.spec.model, command.spec.reasoningEffort)
+        : commandUrl(command.id)
     );
   } catch (err) {
     // One command is one browser-open attempt. A rejected opener can never produce an ACK,
@@ -6433,6 +6454,7 @@ function describe(command: Command, client: string | null, claimedSummary?: stri
     text,
     agent: spec.type === 'resume' ? null : spec.agent,
     model: spec.type === 'worker' ? spec.model : null,
+    reasoningEffort: spec.type === 'worker' ? spec.reasoningEffort : null,
     // The fence the page enforces before it types. Only a revival has one: the other two
     // kinds open a chat that does not exist yet, so there is nothing to compare against.
     conversationId: spec.type === 'revive' ? spec.conversationId : null
@@ -6725,11 +6747,13 @@ function restoredCommandSpec(version: number, raw: Partial<CommandSpec>): Comman
     if (workerState !== 'invited' && workerState !== 'active') return null;
     // Rows written before worker models existed carry no model; rows with a malformed one
     // are repaired to the default rather than refused, so a bad slug can never strand a run.
+    // Reasoning restores under the same rule, against the canonical vocabulary.
     return {
       type: 'worker',
       agent: worker.agent,
       task: worker.task.slice(0, 512 * 1024),
       model: isModelSlug(worker.model) ? worker.model : null,
+      reasoningEffort: isReasoningEffort(worker.reasoningEffort) ? worker.reasoningEffort : null,
       runId: worker.runId
     };
   }

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -81,6 +81,7 @@ import {
   agentInfoForOwnedConversation,
   agentForOwnedConversation,
   isWorkerConversation,
+  isModelSlug,
   bindConversation,
   claimWorkerRevival,
   closableWorkerConversations,
@@ -336,7 +337,18 @@ function boundBrief(text: string): string {
  * worker's inbox holds at hand-out time. Building both there is what keeps that true.
  */
 type CommandSpec =
-  | { type: 'worker'; agent: string; task: string; runId: string }
+  | {
+      type: 'worker';
+      agent: string;
+      task: string;
+      /**
+       * Requested ChatGPT model slug for the worker's fresh chat, or null for the account
+       * default. URL-level only: it selects which model the opened chat uses and is never
+       * typed into the chat or shown to the model.
+       */
+      model: string | null;
+      runId: string;
+    }
   /**
    * Waking a sleeping worker in the chat it already has.
    *
@@ -463,6 +475,13 @@ export interface BridgeCommand {
   text: string;
   /** Agent this tab will be, when the command comes from multi-agent mode. */
   agent: string | null;
+  /**
+   * Requested ChatGPT model slug for a worker's fresh chat, or null for the account default.
+   *
+   * Carried on the wire so the page opening the tab can select the model in the open URL.
+   * Null for every other command kind.
+   */
+  model: string | null;
   /**
    * The conversation this command is *for*, when it is for one that already exists.
    *
@@ -3509,7 +3528,7 @@ async function startBridgeOnce(epoch: number): Promise<number | null> {
       rearmRetainedCommandDeadlines();
       dropSpawnRequestListener?.();
       dropSpawnRequestListener = onSpawnRequest((workers) => {
-        for (const worker of workers) queueWorkerBootstrap(worker.id, worker.task);
+        for (const worker of workers) queueWorkerBootstrap(worker.id, worker.task, worker.model);
       });
       // The same replay contract for waking a worker that already has a chat. A run restored
       // from disk can hold a worker left in `waking` by a crash mid-revival; registering here
@@ -4146,13 +4165,13 @@ async function cancelAutomaticResumesNow(): Promise<number> {
  * stored: the chat this opens is bound to the slot by the extension's report, and the
  * recovery key exists only if the user asks the app for one after that has failed.
  */
-export function queueWorkerBootstrap(agent: string, task: string): BridgeCommand | null {
+export function queueWorkerBootstrap(agent: string, task: string, model: string | null): BridgeCommand | null {
   const runId = currentRunId();
   // A worker bootstrap is authority for one concrete broker incarnation. There is no safe
   // meaning for one outside a run, and manufacturing an unscoped command here is exactly how
   // stale durable work later becomes somebody else's `worker-1`.
   if (!runId) return null;
-  const command = queue({ type: 'worker', agent, task, runId });
+  const command = queue({ type: 'worker', agent, task, model, runId });
   // Start the clock at broker admission, exactly as a revival does. A bootstrap that never
   // reaches a page is the case that has no other clock at all.
   armDeadline(command);
@@ -4281,13 +4300,17 @@ export function chatUrl(conversationId: string): string {
 }
 
 /** Where the app opens a fresh worker/resume chat. The marker is an id, not a credential. */
-export function commandUrl(id: string): string {
+export function commandUrl(id: string, model?: string | null): string {
   // Both a query and a fragment: ChatGPT is a single-page app that rewrites its own URL
   // during boot, and which of the two survives has changed between builds. The content
   // script accepts either, and redeeming still requires the extension's bearer token —
   // so a copied link, a history entry or a synced tab is worth nothing on its own.
+  // A requested model rides the query only: it selects the chat's model at open and is
+  // never part of the identity the page redeems with. An unknown slug is ChatGPT's to
+  // ignore — the chat then opens with the account default.
   const marker = `clf=${encodeURIComponent(id)}`;
-  return `https://chatgpt.com/?${marker}#${marker}`;
+  const query = model ? `${marker}&model=${encodeURIComponent(model)}` : marker;
+  return `https://chatgpt.com/?${query}#${marker}`;
 }
 
 /**
@@ -4373,7 +4396,7 @@ export const BROWSER_PLACEMENT_MS = 20_000;
 let placementCollector: string | null = null;
 
 /** The one fresh chat currently offered to its home page, and the fallback that outlives it. */
-let placementOffer: { id: string; conversationId: string } | null = null;
+let placementOffer: { id: string; conversationId: string; model: string | null } | null = null;
 let placementTimer: NodeJS.Timeout | null = null;
 
 /** Drops the standing offer and its fallback. Called by every path that ends a command. */
@@ -4394,7 +4417,11 @@ function offerPlacement(command: Command): boolean {
   const home = commandHomeConversation(command.spec);
   if (!home || home !== placementCollector) return false;
   clearPlacementOffer();
-  placementOffer = { id: command.id, conversationId: home };
+  placementOffer = {
+    id: command.id,
+    conversationId: home,
+    model: command.spec.type === 'worker' ? command.spec.model : null
+  };
   placementTimer = setTimeout(() => {
     placementTimer = null;
     placementOffer = null;
@@ -4415,7 +4442,7 @@ function offerPlacement(command: Command): boolean {
  * a second one. If that page fails to act, the fallback above is what recovers it, not a
  * repeated offer.
  */
-function pendingBrowserPlacement(conversationId: string): { id: string } | null {
+function pendingBrowserPlacement(conversationId: string): { id: string; model: string | null } | null {
   const offer = placementOffer;
   if (!offer || offer.conversationId !== conversationId) return null;
   if (!commands.some((entry) => entry.id === offer.id && entry.owner === null)) {
@@ -4423,7 +4450,7 @@ function pendingBrowserPlacement(conversationId: string): { id: string } | null 
     return null;
   }
   placementOffer = null;
-  return { id: offer.id };
+  return { id: offer.id, model: offer.model };
 }
 
 // -------------------------------------------------------- exact browser recovery
@@ -6101,7 +6128,9 @@ async function openFreshChatInBrowser(command: Command): Promise<void> {
     // Stamped whether or not a browser was already running: this process cannot tell the
     // difference, and the window it opens is only ever spent by a browser failing to appear.
     if (!browserPresent()) lastBrowserLaunchAt = Date.now();
-    await openInBrowser(commandUrl(command.id));
+    await openInBrowser(
+      command.spec.type === 'worker' ? commandUrl(command.id, command.spec.model) : commandUrl(command.id)
+    );
   } catch (err) {
     // One command is one browser-open attempt. A rejected opener can never produce an ACK,
     // so leaving the row unleased merely blocks everything behind it until some unrelated
@@ -6403,6 +6432,7 @@ function describe(command: Command, client: string | null, claimedSummary?: stri
     type: spec.type,
     text,
     agent: spec.type === 'resume' ? null : spec.agent,
+    model: spec.type === 'worker' ? spec.model : null,
     // The fence the page enforces before it types. Only a revival has one: the other two
     // kinds open a chat that does not exist yet, so there is nothing to compare against.
     conversationId: spec.type === 'revive' ? spec.conversationId : null
@@ -6693,7 +6723,15 @@ function restoredCommandSpec(version: number, raw: Partial<CommandSpec>): Comman
     // already be durable while the leased browser command is still waiting for its retry.
     const workerState = swarmState().agents.find((entry) => entry.id === worker.agent && entry.role === 'worker')?.state;
     if (workerState !== 'invited' && workerState !== 'active') return null;
-    return { type: 'worker', agent: worker.agent, task: worker.task.slice(0, 512 * 1024), runId: worker.runId };
+    // Rows written before worker models existed carry no model; rows with a malformed one
+    // are repaired to the default rather than refused, so a bad slug can never strand a run.
+    return {
+      type: 'worker',
+      agent: worker.agent,
+      task: worker.task.slice(0, 512 * 1024),
+      model: isModelSlug(worker.model) ? worker.model : null,
+      runId: worker.runId
+    };
   }
   if (
     version >= 4 &&

--- a/src/main/mcp/tools-core.ts
+++ b/src/main/mcp/tools-core.ts
@@ -1058,6 +1058,13 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
                 .optional()
                 .describe(
                   'ChatGPT model slug for this worker\'s chat, e.g. a cheaper high-reasoning model while the prime runs on a limited one. Omitted means the account default.'
+                ),
+              reasoning_effort: z
+                .string()
+                .max(20)
+                .optional()
+                .describe(
+                  'Reasoning level for this worker\'s chat: none, minimal, low, medium, high, xhigh, max, ultra. Omitted inherits the default. Never changes the model.'
                 )
             }).strict()
           )
@@ -1173,7 +1180,7 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
                 type: 'text' as const,
                 text:
                   (becamePrime ? `This conversation is now the prime agent of run ${runId}. ` : '') +
-                  `${created.length} worker(s) matched: ${created.map((info) => `${info.id} (${info.label}, ${info.state}${info.model ? `, model ${info.model}` : ''})`).join(', ')}. ` +
+                  `${created.length} worker(s) matched: ${created.map((info) => `${info.id} (${info.label}, ${info.state}${info.model ? `, model ${info.model}` : ''}${info.reasoningEffort ? `, reasoning ${info.reasoningEffort}` : ''})`).join(', ')}. ` +
                   (invited.length > 0 ? 'New worker chats are opening with their briefs already in them. ' : '') +
                   (sleeping.length > 0
                     ? `${sleeping.map((worker) => worker.id).join(', ')} already finished that earlier piece and is sleeping in its existing chat; wake it with action=message instead of spawning a duplicate. `
@@ -1189,7 +1196,7 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
               run_id: runId,
               self: PRIME_ID,
               became_prime: becamePrime,
-              workers: created.map((info) => ({ id: info.id, label: info.label, state: info.state, model: info.model }))
+              workers: created.map((info) => ({ id: info.id, label: info.label, state: info.state, model: info.model, reasoning_effort: info.reasoningEffort }))
             }
           };
         }
@@ -1361,6 +1368,7 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
                     (info) =>
                       `${info.id}  ${info.role}  ${shown(info)}  waiting ${info.pending}  ${info.label}` +
                       (info.model ? `  model ${info.model}` : '') +
+                      (info.reasoningEffort ? `  reasoning ${info.reasoningEffort}` : '') +
                       (recordings.has(info.id) ? `\n    recording: ${recordings.get(info.id)}` : '') +
                       (info.result
                         ? `\n    ${info.state === 'failed' ? 'failure' : info.state === 'finished' ? 'result' : 'latest result'}: ${info.result.slice(0, 300)}`
@@ -1401,6 +1409,7 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
               role: info.role,
               label: info.label,
               model: info.model,
+              reasoning_effort: info.reasoningEffort,
               state: info.state,
               revivable: info.revivable,
               waiting: info.pending,

--- a/src/main/mcp/tools-core.ts
+++ b/src/main/mcp/tools-core.ts
@@ -1051,6 +1051,13 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
                 .max(4000)
                 .describe(
                   'This worker\'s job: objective, relevant files, constraints and expected handoff.'
+                ),
+              model: z
+                .string()
+                .max(80)
+                .optional()
+                .describe(
+                  'ChatGPT model slug for this worker\'s chat, e.g. a cheaper high-reasoning model while the prime runs on a limited one. Omitted means the account default.'
                 )
             }).strict()
           )
@@ -1166,7 +1173,7 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
                 type: 'text' as const,
                 text:
                   (becamePrime ? `This conversation is now the prime agent of run ${runId}. ` : '') +
-                  `${created.length} worker(s) matched: ${created.map((info) => `${info.id} (${info.label}, ${info.state})`).join(', ')}. ` +
+                  `${created.length} worker(s) matched: ${created.map((info) => `${info.id} (${info.label}, ${info.state}${info.model ? `, model ${info.model}` : ''})`).join(', ')}. ` +
                   (invited.length > 0 ? 'New worker chats are opening with their briefs already in them. ' : '') +
                   (sleeping.length > 0
                     ? `${sleeping.map((worker) => worker.id).join(', ')} already finished that earlier piece and is sleeping in its existing chat; wake it with action=message instead of spawning a duplicate. `
@@ -1182,7 +1189,7 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
               run_id: runId,
               self: PRIME_ID,
               became_prime: becamePrime,
-              workers: created.map((info) => ({ id: info.id, label: info.label, state: info.state }))
+              workers: created.map((info) => ({ id: info.id, label: info.label, state: info.state, model: info.model }))
             }
           };
         }
@@ -1353,6 +1360,7 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
                   .map(
                     (info) =>
                       `${info.id}  ${info.role}  ${shown(info)}  waiting ${info.pending}  ${info.label}` +
+                      (info.model ? `  model ${info.model}` : '') +
                       (recordings.has(info.id) ? `\n    recording: ${recordings.get(info.id)}` : '') +
                       (info.result
                         ? `\n    ${info.state === 'failed' ? 'failure' : info.state === 'finished' ? 'result' : 'latest result'}: ${info.result.slice(0, 300)}`
@@ -1392,6 +1400,7 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
               id: info.id,
               role: info.role,
               label: info.label,
+              model: info.model,
               state: info.state,
               revivable: info.revivable,
               waiting: info.pending,

--- a/src/shared/session.ts
+++ b/src/shared/session.ts
@@ -563,6 +563,14 @@ export interface AgentInfo {
   role: AgentRole;
   label: string;
   task: string;
+  /**
+   * ChatGPT model slug this worker's chat was opened with, or null for the account default.
+   *
+   * Chosen by the prime at spawn, never by the worker: the model is fixed by the fresh-chat
+   * URL the tab opens with, so a worker keeps it for the life of its conversation, including
+   * across sleep/wake reuse. Null for the prime, which runs in the user's own chat.
+   */
+  model: string | null;
   state: AgentState;
   createdAt: number;
   /**

--- a/src/shared/session.ts
+++ b/src/shared/session.ts
@@ -558,11 +558,42 @@ export type AgentState =
   | 'finished'
   | 'failed';
 
+/**
+ * Canonical reasoning levels for a worker's chat, shared with the Hermes runtime
+ * vocabulary (hermes_constants.VALID_REASONING_EFFORTS plus "none").
+ *
+ * "none" is a real level — reasoning disabled — and is distinct from null, which means
+ * inherit the account default. This is the single vocabulary authority; the broker, the
+ * bridge restore and the extension all check membership against this list.
+ */
+export const REASONING_EFFORTS = [
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra'
+] as const;
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
+export function isReasoningEffort(value: unknown): value is ReasoningEffort {
+  return typeof value === 'string' && (REASONING_EFFORTS as readonly string[]).includes(value);
+}
+
 export interface AgentInfo {
   id: string;
   role: AgentRole;
   label: string;
   task: string;
+  /**
+   * Requested reasoning level for this worker's chat, or null to inherit the default.
+   *
+   * Canonical vocabulary shared with the Hermes runtime (VALID_REASONING_EFFORTS plus
+   * "none"). "none" is a real level — reasoning disabled — distinct from null. Stored
+   * where the worker's model is stored and matched, snapshotted and restored the same way.
+   */
+  reasoningEffort: ReasoningEffort | null;
   /**
    * ChatGPT model slug this worker's chat was opened with, or null for the account default.
    *

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -374,6 +374,54 @@ describe('worker models', () => {
     restoreSwarm(tampered);
     expect(swarmState().agents.find((agent) => agent.id === 'worker-1')?.model).toBeNull();
   });
+
+  it('stores reasoning_effort without touching the model', () => {
+    const result = spawn({
+      workers: [{ label: 'High Reasoning', task: 'deep work', reasoning_effort: 'high' }],
+      caller: prime
+    });
+    expect(result.created[0]).toMatchObject({ id: 'worker-1', model: null, reasoningEffort: 'high' });
+    expect(pendingWorkerSpawns()).toEqual([
+      expect.objectContaining({ id: 'worker-1', model: null, reasoningEffort: 'high' })
+    ]);
+  });
+
+  it('rejects an unknown reasoning_effort with zero workers created', () => {
+    expect(() => spawn({ workers: [{ task: 'work', reasoning_effort: 'banana' }], caller: prime })).toThrow(
+      /reasoning_effort must be one of/i
+    );
+    expect(swarmRunning()).toBe(false);
+    expect(swarmState().agents).toEqual([]);
+  });
+
+  it('canonicalizes the level spelling but stores the canonical form', () => {
+    const result = spawn({ workers: [{ task: 'work', reasoning_effort: ' High ' }], caller: prime });
+    expect(result.created[0]?.reasoningEffort).toBe('high');
+  });
+
+  it('folds repeats only when model and reasoning both match', () => {
+    spawn({ workers: [{ label: 'W', task: 'same', reasoning_effort: 'high' }], caller: prime });
+    const repeat = spawn({ workers: [{ label: 'W', task: 'same', reasoning_effort: 'high' }], caller: prime });
+    expect(repeat.created.map((agent) => agent.id)).toEqual(['worker-1']);
+    const changed = spawn({ workers: [{ label: 'W', task: 'same', reasoning_effort: 'low' }], caller: prime });
+    expect(changed.created.map((agent) => agent.id)).toEqual(['worker-2']);
+    expect(changed.created[0]?.reasoningEffort).toBe('low');
+  });
+
+  it('round-trips reasoning_effort through a snapshot restore and repairs a malformed one', () => {
+    spawn({ workers: [{ label: 'W', task: 'task', reasoning_effort: 'high' }], caller: prime });
+    const saved = snapshotSwarm()!;
+    resetAgentsForTests();
+    restoreSwarm(saved);
+    expect(swarmState().agents.find((agent) => agent.id === 'worker-1')?.reasoningEffort).toBe('high');
+
+    const tampered = snapshotSwarm()!;
+    // @ts-expect-error a malformed level smuggled past the type system, as disk can hold
+    tampered.agents.find((entry) => entry.info.id === 'worker-1')!.info.reasoningEffort = 'banana';
+    resetAgentsForTests();
+    restoreSwarm(tampered);
+    expect(swarmState().agents.find((agent) => agent.id === 'worker-1')?.reasoningEffort).toBeNull();
+  });
 });
 
 describe('star topology', () => {
@@ -1985,7 +2033,7 @@ describe('restart', () => {
 
     expect(swarmState().running).toBe(true);
     expect(snapshotSwarm()?.agents.map((entry) => entry.info.id)).toEqual(['prime', 'worker-1']);
-    expect(pendingWorkerSpawns()).toEqual([{ id: 'worker-1', model: null, task: 'inspect topology' }]);
+    expect(pendingWorkerSpawns()).toEqual([{ id: 'worker-1', model: null, reasoningEffort: null, task: 'inspect topology' }]);
     expect(ordinary.at(-1)?.agents.map((entry) => entry.info.id)).toEqual(['prime', 'worker-1']);
   });
 

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -314,6 +314,68 @@ describe('spawning a run', () => {
   });
 });
 
+describe('worker models', () => {
+  it('stores the requested model on the worker and hands it to the browser request', () => {
+    const handed: Array<{ id: string; model: string | null }> = [];
+    onSpawnRequest((workers) => handed.push(...workers));
+    const result = spawn({
+      workers: [
+        { label: 'Cheap', task: 'bulk work', model: 'cheap-high-reasoning' },
+        { label: 'Default', task: 'other work' }
+      ],
+      caller: prime
+    });
+    expect(result.created.map((agent) => [agent.id, agent.model])).toEqual([
+      ['worker-1', 'cheap-high-reasoning'],
+      ['worker-2', null]
+    ]);
+    expect(handed).toEqual([
+      expect.objectContaining({ id: 'worker-1', model: 'cheap-high-reasoning' }),
+      expect.objectContaining({ id: 'worker-2', model: null })
+    ]);
+    expect(pendingWorkerSpawns()).toEqual([
+      expect.objectContaining({ id: 'worker-1', model: 'cheap-high-reasoning' }),
+      expect.objectContaining({ id: 'worker-2', model: null })
+    ]);
+  });
+
+  it('treats a blank model as the account default', () => {
+    const result = spawn({ workers: [{ task: 'plain work', model: '   ' }], caller: prime });
+    expect(result.created[0]?.model).toBeNull();
+  });
+
+  it('rejects a malformed model with zero workers created', () => {
+    expect(() =>
+      spawn({ workers: [{ task: 'fine' }, { task: 'bad', model: 'not a slug!' }], caller: prime })
+    ).toThrow(/model.*slug/i);
+    expect(swarmRunning()).toBe(false);
+    expect(swarmState().agents).toEqual([]);
+  });
+
+  it('folds an exact repeat but treats a different model as new work', () => {
+    spawn({ workers: [{ label: 'W', task: 'same task', model: 'model-a' }], caller: prime });
+    const repeat = spawn({ workers: [{ label: 'W', task: 'same task', model: 'model-a' }], caller: prime });
+    expect(repeat.created.map((agent) => agent.id)).toEqual(['worker-1']);
+    const changed = spawn({ workers: [{ label: 'W', task: 'same task', model: 'model-b' }], caller: prime });
+    expect(changed.created.map((agent) => agent.id)).toEqual(['worker-2']);
+    expect(changed.created[0]?.model).toBe('model-b');
+  });
+
+  it('round-trips the model through a snapshot restore and repairs a malformed one', () => {
+    spawn({ workers: [{ label: 'W', task: 'task', model: 'model-a' }], caller: prime });
+    const saved = snapshotSwarm()!;
+    resetAgentsForTests();
+    restoreSwarm(saved);
+    expect(swarmState().agents.find((agent) => agent.id === 'worker-1')?.model).toBe('model-a');
+
+    const tampered = snapshotSwarm()!;
+    tampered.agents.find((entry) => entry.info.id === 'worker-1')!.info.model = 'not a slug!';
+    resetAgentsForTests();
+    restoreSwarm(tampered);
+    expect(swarmState().agents.find((agent) => agent.id === 'worker-1')?.model).toBeNull();
+  });
+});
+
 describe('star topology', () => {
   it('allows worker → prime and prime → worker', () => {
     startSwarm(1);
@@ -1923,7 +1985,7 @@ describe('restart', () => {
 
     expect(swarmState().running).toBe(true);
     expect(snapshotSwarm()?.agents.map((entry) => entry.info.id)).toEqual(['prime', 'worker-1']);
-    expect(pendingWorkerSpawns()).toEqual([{ id: 'worker-1', task: 'inspect topology' }]);
+    expect(pendingWorkerSpawns()).toEqual([{ id: 'worker-1', model: null, task: 'inspect topology' }]);
     expect(ordinary.at(-1)?.agents.map((entry) => entry.info.id)).toEqual(['prime', 'worker-1']);
   });
 

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -3698,6 +3698,18 @@ describe('delivering a bootstrap', () => {
     expect(opened[0]).toContain('model=cheap-high-reasoning');
   });
 
+  it('opens a reasoning-only worker with no model param, so the level never selects a model', async () => {
+    await pair();
+    spawn({
+      workers: [{ label: 'High Reasoning', task: 'deep work', reasoning_effort: 'high' }],
+      caller: { conversationId: PRIME_CHAT }
+    });
+    await waitForOpened(1);
+    expect(opened).toEqual([commandUrl(pendingCommands()[0]!.id, null, 'high')]);
+    expect(opened[0]).toContain('reasoning_effort=high');
+    expect(opened[0]).not.toContain('model=');
+  });
+
   it('keeps a dropped worker transport durable until the failed broker state is durable', async () => {
     await pair();
     spawn({ workers: [{ task: 'overflow crash-order worker' }], caller: { conversationId: PRIME_CHAT } });
@@ -3828,7 +3840,7 @@ ${SAMPLE_BRIEF}` }
     const stored = await captureFrom(HOME);
 
     expect(stored.body.stored).toBe(true);
-    expect(stored.body.placement).toEqual({ id: stored.body.commandId, model: null });
+    expect(stored.body.placement).toEqual({ id: stored.body.commandId, model: null, reasoningEffort: null });
     // The whole point: this app did not ask the operating system where its own chat should go.
     expect(opened).toEqual([]);
     expect(pendingCommands()).toEqual([

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -3685,6 +3685,19 @@ describe('delivering a bootstrap', () => {
     expect(swarmState().running).toBe(false);
   });
 
+  it('opens a worker chat with the requested model in its URL', async () => {
+    await pair();
+    spawn({
+      workers: [{ label: 'Cheap', task: 'bulk work', model: 'cheap-high-reasoning' }],
+      caller: { conversationId: PRIME_CHAT }
+    });
+    await waitForOpened(1);
+    // The marker carries the bridge command id, not the worker id: the worker binds to its
+    // chat later, by the extension's report. What matters here is the model riding along.
+    expect(opened).toEqual([commandUrl(pendingCommands()[0]!.id, 'cheap-high-reasoning')]);
+    expect(opened[0]).toContain('model=cheap-high-reasoning');
+  });
+
   it('keeps a dropped worker transport durable until the failed broker state is durable', async () => {
     await pair();
     spawn({ workers: [{ task: 'overflow crash-order worker' }], caller: { conversationId: PRIME_CHAT } });
@@ -3815,7 +3828,7 @@ ${SAMPLE_BRIEF}` }
     const stored = await captureFrom(HOME);
 
     expect(stored.body.stored).toBe(true);
-    expect(stored.body.placement).toEqual({ id: stored.body.commandId });
+    expect(stored.body.placement).toEqual({ id: stored.body.commandId, model: null });
     // The whole point: this app did not ask the operating system where its own chat should go.
     expect(opened).toEqual([]);
     expect(pendingCommands()).toEqual([

--- a/test/resume.test.ts
+++ b/test/resume.test.ts
@@ -240,7 +240,7 @@ describe('the whole move, when it works', () => {
     const stored = await capture(continuation);
     expect(pendingCommands()).toHaveLength(1);
     // Handed to A's browser, not to the OS — and exactly one chat either way.
-    expect(stored.body.placement).toEqual({ id: pendingCommands()[0]!.id });
+    expect(stored.body.placement).toEqual({ id: pendingCommands()[0]!.id, model: null });
     expect(opened).toHaveLength(0);
   });
 });

--- a/test/resume.test.ts
+++ b/test/resume.test.ts
@@ -240,7 +240,7 @@ describe('the whole move, when it works', () => {
     const stored = await capture(continuation);
     expect(pendingCommands()).toHaveLength(1);
     // Handed to A's browser, not to the OS — and exactly one chat either way.
-    expect(stored.body.placement).toEqual({ id: pendingCommands()[0]!.id, model: null });
+    expect(stored.body.placement).toEqual({ id: pendingCommands()[0]!.id, model: null, reasoningEffort: null });
     expect(opened).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Follow-up to #N.

Root cause: agents spawn plans workers as (label, task) only, so a prime can neither hold back its expensive model nor declare a reasoning level. High-reasoning intent therefore lands on Pro SKUs by default.

Smallest change (implementation + surface + tests + docs, together):
- `src/shared/session.ts` — canonical reasoning vocabulary + `AgentInfo.reasoningEffort` / `model`.
- `src/main/agents.ts` — strict pre-mutation validation of both fields (bad input fails the spawn with zero workers), stored on the worker record, part of the repeat-spawn match, snapshotted and restored.
- `src/main/bridge.ts` — both fields ride the worker's fresh-chat open URL (`?model=` / `?reasoning_effort=`) on the OS-open and extension-placement paths, and the durable command spec.
- `extension/background.js` — placement path appends both, re-validated locally.
- `src/main/mcp/tools-core.ts` — schema, spawn receipts and status show both; `docs/tool-surface.md` documents them.

Validation: `tsc` clean; full vitest gate green except the ripgrep-PATH env test, which also fails on clean v2.0.5 on this machine (Homebrew rg shadows the bundled one — unrelated); packaged arm64 build installed and smoke-checked (bridge listening, no errors). New tests: high-only worker pins no model (URL carries no `model=` param), model+reasoning together, neither pinned, `"banana"` rejected with zero workers, restore round-trip + repair, repeat-folding respects both fields.

One open question: whether chatgpt.com applies `?model=` / `?reasoning_effort=` on fresh chats. Either way the app degrades to defaults, and the opened URL carries both for inspection.
