### PR TITLE
fix: reduce Chrome background throttling on Windows

### DIFF
--- a/src/main/browser.ts
+++ b/src/main/browser.ts
@@ -153,7 +153,15 @@ export async function openInPreferredBrowser(
   for (const browser of preferredBrowserCandidates(platform, env, options.home)) {
     if (!usable(browser)) continue;
     try {
-      await launch(browser, [url], path.dirname(browser));
+      const args =
+        platform === 'win32'
+          ? [
+              '--disable-renderer-backgrounding',
+              '--disable-background-timer-throttling',
+              url
+            ]
+          : [url];
+      await launch(browser, args, path.dirname(browser));
       return browser;
     } catch (error) {
       lastError = error;

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -103,6 +103,36 @@ describe('browser-backed ChatGPT commands', () => {
     expect(attempts).toEqual([first, second]);
   });
 
+  it('keeps ChatGPT orchestration tabs active when launching Chrome on Windows', async () => {
+    const chrome = 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe';
+    const calls: Array<{ command: string; args: readonly string[]; cwd: string }> = [];
+    const url = 'https://chatgpt.com/?clf=worker-marker';
+
+    const opened = await openInPreferredBrowser(url, {
+      platform: 'win32',
+      env: { ProgramFiles: 'C:\\Program Files' },
+      usable: (candidate) => candidate === chrome,
+      launch: async (command, args, cwd) => {
+        calls.push({ command, args, cwd });
+        return { pid: 789 };
+      }
+    });
+
+    expect(opened).toBe(chrome);
+    expect(calls).toEqual([
+      {
+        command: chrome,
+        args: [
+          '--disable-renderer-backgrounding',
+          '--disable-background-timer-throttling',
+          url
+        ],
+        cwd: 'C:\\Program Files\\Google\\Chrome\\Application'
+      }
+    ]);
+    expect(calls[0]?.args).not.toContain('--disable-backgrounding-occluded-windows');
+  });
+
   it('passes only the orchestration URL to a Linux browser, never the AppImage sandbox fallback', async () => {
     const flatpakChrome = '/var/lib/flatpak/exports/bin/com.google.Chrome';
     const calls: Array<{ command: string; args: readonly string[]; cwd: string }> = [];


### PR DESCRIPTION
﻿## What changed

Closes #69.

`openInPreferredBrowser()` currently sends only the orchestration URL to Chrome. On Windows, if that call is what creates the Chrome browser process, the process still uses Chrome's normal renderer backgrounding and background timer throttling. In an affected setup this showed up as a long-running ChatGPT orchestration tab becoming much less responsive after being left in the background, even though `chatgpt.com` was already in Chrome's Memory Saver keep-active exception list.

This keeps the change narrow: Windows browser-backed launches now prepend:

```text
--disable-renderer-backgrounding
--disable-background-timer-throttling
```

macOS and Linux launch behavior is unchanged.

Chromium documents these switches as preventing renderer backgrounding and disabling timer-task throttling for background pages:
https://chromium.googlesource.com/chromium/src/+/lkgr/content/public/common/content_switches.cc

I intentionally did **not** include `--disable-backgrounding-occluded-windows`; Chromium marks that switch as testing-oriented.

### Scope / limitation

Chrome command-line switches are browser-process startup settings. If Chrome is already running without these switches, a later `chrome.exe <flags> <url>` invocation may hand the URL to the existing instance, so this cannot retroactively change that process. The mitigation applies when Chat On Steroids is the launch that creates the Chrome instance.

Keeping background renderers/timers active can also increase CPU usage and battery drain, which is why the change is Windows-scoped and limited to the orchestration browser-launch path.

## Validation

- [x] Added or updated a deterministic regression test where behavior changed.
- [ ] `npm run verify` passes. On this Windows host the full parallel run ended with three unrelated/flaky failures described below; every failed case passed when rerun individually.
- [ ] Packaging/runtime smoke was run when the change can differ after bundling. N/A here: this is a launch-argv branch with no packaging-specific path; the launch contract is covered directly by `browser.test.ts`.
- [x] No unrelated formatting, generated output, local debugging notes, or private data is included.
- [x] Screenshots, logs and examples use placeholders instead of real usernames, paths, chat text, IDs or credentials.
- [x] Security-sensitive details are being handled privately instead of disclosed here.

Focused checks:

- `npx vitest run test/browser.test.ts` — 11/11 passed.
- `npm run typecheck` — passed.
- `npm run verify:privacy` — passed in a fresh upstream clone.
- Red/green regression was verified: the new Windows launch-argument test fails against the old URL-only behavior and passes with this change.

Full-suite note on Windows:

- A clean upstream baseline already reproduced an Electron install/extraction race during parallel Vitest execution.
- The fresh-clone `npm run verify` later ended with the same Electron/tunnel install class of failure plus two timing-sensitive tests in `bridge.test.ts` and `content-script.test.ts`.
- After `npm rebuild electron`, `test/tunnel.test.ts` passed (30 passed, 1 skipped), the exact failed bridge test passed individually, and the exact failed content-script test passed individually.

So the changed browser test, typecheck, privacy gate, and every full-run failure all pass in isolated reruns; I am leaving the full `npm run verify` checkbox unchecked rather than representing the flaky parallel Windows run as green.
