### PR TITLE
fix: open fresh worker tabs in background

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -2634,7 +2634,11 @@ async function placeSuccessorChat(raw, tabId) {
   // Both a query and a fragment, matching the app's commandUrl(): ChatGPT rewrites its own URL
   // during boot and which of the two survives has changed between builds.
   const marker = `clf=${encodeURIComponent(id)}`;
-  const create = { url: `https://chatgpt.com/?${marker}#${marker}`, windowId: home.windowId, active: true };
+  const create = {
+    url: `https://chatgpt.com/?${marker}#${marker}`,
+    windowId: home.windowId,
+    active: !(raw && raw.background === true)
+  };
   // Directly after the chat it continues, so a handoff reads as one piece of work instead of a
   // tab appended to the far end of a long strip.
   if (typeof home.index === 'number') create.index = home.index + 1;

--- a/src/main/agents.ts
+++ b/src/main/agents.ts
@@ -365,7 +365,7 @@ const MAX_DORMANT_RUNS = 16;
  */
 let livenessFloor = 0;
 
-let spawnRequest: ((workers: WorkerSpawn[]) => void) | null = null;
+let spawnRequest: ((workers: WorkerSpawn[], placementHome: string | null) => void) | null = null;
 const listeners = new Set<() => void>();
 const endListeners = new Set<(reason: string, retired: RetiredChat[]) => void>();
 let persist: (() => void) | null = null;
@@ -571,11 +571,11 @@ export function pendingWorkerSpawns(): WorkerSpawn[] {
  * Registration replays whatever is already owed: startup restores the run before the bridge
  * exists, so the restore itself has nobody to ask for a tab.
  */
-export function onSpawnRequest(handler: (workers: WorkerSpawn[]) => void): () => void {
+export function onSpawnRequest(handler: (workers: WorkerSpawn[], placementHome: string | null) => void): () => void {
   spawnRequest = handler;
   const owed = pendingWorkerSpawns();
   if (owed.length > 0) {
-    handler(owed);
+    handler(owed, null);
     logInfo(`multi-agent: ${owed.length} worker chat(s) still owed a tab`);
   }
   return () => {
@@ -1173,7 +1173,7 @@ export function stageSpawn(input: SpawnInput): StagedSpawn {
  * planned first, that exact revision is made durable, and only then are browser tabs requested.
  * A retry after a failed disk barrier is safe because already-running workers are ignored.
  */
-export function requestWorkerBootstraps(ids: readonly string[]): number {
+export function requestWorkerBootstraps(ids: readonly string[], placementHome: string | null = null): number {
   if (!run || ids.length === 0) return 0;
   const wanted = new Set(ids);
   const owed = [...run.agents.values()]
@@ -1186,7 +1186,7 @@ export function requestWorkerBootstraps(ids: readonly string[]): number {
     )
     .map((agent) => ({ id: agent.info.id, task: agent.info.task }));
   if (owed.length === 0) return 0;
-  if (spawnRequest) spawnRequest(owed);
+  if (spawnRequest) spawnRequest(owed, placementHome);
   else logWarn('multi-agent: no browser extension is paired, so worker chats cannot be opened automatically');
   return owed.length;
 }
@@ -3945,7 +3945,7 @@ export function restoreSwarm(snapshot: SwarmSnapshot | null): void {
   // this is replayed by onSpawnRequest the moment it registers.
   const stranded = pendingWorkerSpawns();
   if (stranded.length > 0 && spawnRequest) {
-    spawnRequest(stranded);
+    spawnRequest(stranded, null);
     logInfo(`multi-agent: re-requested ${stranded.length} worker chat(s) that were unbound at the restart`);
   }
   const activeAgents = run ? [...run.agents.values()] : [];

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -414,6 +414,8 @@ interface Command {
    * Memory only: a command restored from a previous run has no page waiting for it.
    */
   owner: string | null;
+  /** Fresh worker publication may be placed by the prime page that just requested it. Memory only. */
+  placementHome: string | null;
 }
 
 type CommandPhase = 'queued' | 'leased';
@@ -3508,8 +3510,8 @@ async function startBridgeOnce(epoch: number): Promise<number | null> {
       // a still-live lease can sit forever with no timer to end it.
       rearmRetainedCommandDeadlines();
       dropSpawnRequestListener?.();
-      dropSpawnRequestListener = onSpawnRequest((workers) => {
-        for (const worker of workers) queueWorkerBootstrap(worker.id, worker.task);
+      dropSpawnRequestListener = onSpawnRequest((workers, placementHome) => {
+        for (const worker of workers) queueWorkerBootstrap(worker.id, worker.task, placementHome);
       });
       // The same replay contract for waking a worker that already has a chat. A run restored
       // from disk can hold a worker left in `waking` by a crash mid-revival; registering here
@@ -3874,10 +3876,11 @@ async function finalizeCommand(command: Command, receipt: CommandReceipt): Promi
   return true;
 }
 
-function queue(spec: CommandSpec): Command {
+function queue(spec: CommandSpec, placementHome: string | null = null): Command {
   const key = commandKey(spec);
   const existing = commands.find((command) => commandKey(command.spec) === key);
   if (existing) {
+    if (spec.type === 'worker' && placementHome) existing.placementHome = placementHome;
     // The same bootstrap arriving twice — a restart re-requesting a worker whose chat was
     // never bound, or the user pressing Compact & Resume again — is one job, not two tabs.
     const superseded = JSON.stringify(existing.spec) !== JSON.stringify(spec);
@@ -3912,7 +3915,8 @@ function queue(spec: CommandSpec): Command {
     retriedAt: null,
     timer: null,
     lastError: null,
-    owner: null
+    owner: null,
+    placementHome
   };
   commands.push(command);
   if (commands.length > MAX_COMMANDS) {
@@ -4146,13 +4150,17 @@ async function cancelAutomaticResumesNow(): Promise<number> {
  * stored: the chat this opens is bound to the slot by the extension's report, and the
  * recovery key exists only if the user asks the app for one after that has failed.
  */
-export function queueWorkerBootstrap(agent: string, task: string): BridgeCommand | null {
+export function queueWorkerBootstrap(
+  agent: string,
+  task: string,
+  placementHome: string | null = null
+): BridgeCommand | null {
   const runId = currentRunId();
   // A worker bootstrap is authority for one concrete broker incarnation. There is no safe
   // meaning for one outside a run, and manufacturing an unscoped command here is exactly how
   // stale durable work later becomes somebody else's `worker-1`.
   if (!runId) return null;
-  const command = queue({ type: 'worker', agent, task, runId });
+  const command = queue({ type: 'worker', agent, task, runId }, placementHome);
   // Start the clock at broker admission, exactly as a revival does. A bootstrap that never
   // reaches a page is the case that has no other clock at all.
   armDeadline(command);
@@ -4373,7 +4381,7 @@ export const BROWSER_PLACEMENT_MS = 20_000;
 let placementCollector: string | null = null;
 
 /** The one fresh chat currently offered to its home page, and the fallback that outlives it. */
-let placementOffer: { id: string; conversationId: string } | null = null;
+let placementOffer: { id: string; conversationId: string; background: boolean } | null = null;
 let placementTimer: NodeJS.Timeout | null = null;
 
 /** Drops the standing offer and its fallback. Called by every path that ends a command. */
@@ -4391,10 +4399,14 @@ function clearPlacementOffer(): void {
  * opener exactly as before, because there is genuinely nothing better to know about them.
  */
 function offerPlacement(command: Command): boolean {
-  const home = commandHomeConversation(command.spec);
-  if (!home || home !== placementCollector) return false;
+  const home = command.spec.type === 'worker' ? command.placementHome : commandHomeConversation(command.spec);
+  if (!home) return false;
+  // A resume is placeable only while its source page's capture request is in flight. A worker
+  // gets a one-shot home only from the fresh spawn publication callback; restored worker
+  // commands deliberately have placementHome=null and fall through to the OS opener.
+  if (command.spec.type !== 'worker' && home !== placementCollector) return false;
   clearPlacementOffer();
-  placementOffer = { id: command.id, conversationId: home };
+  placementOffer = { id: command.id, conversationId: home, background: command.spec.type === 'worker' };
   placementTimer = setTimeout(() => {
     placementTimer = null;
     placementOffer = null;
@@ -4415,7 +4427,7 @@ function offerPlacement(command: Command): boolean {
  * a second one. If that page fails to act, the fallback above is what recovers it, not a
  * repeated offer.
  */
-function pendingBrowserPlacement(conversationId: string): { id: string } | null {
+function pendingBrowserPlacement(conversationId: string): { id: string; background?: true } | null {
   const offer = placementOffer;
   if (!offer || offer.conversationId !== conversationId) return null;
   if (!commands.some((entry) => entry.id === offer.id && entry.owner === null)) {
@@ -4423,7 +4435,7 @@ function pendingBrowserPlacement(conversationId: string): { id: string } | null 
     return null;
   }
   placementOffer = null;
-  return { id: offer.id };
+  return offer.background ? { id: offer.id, background: true } : { id: offer.id };
 }
 
 // -------------------------------------------------------- exact browser recovery
@@ -6847,7 +6859,8 @@ function planCommandRestore(
       retriedAt: null,
       timer: null,
       lastError: typeof raw.lastError === 'string' ? raw.lastError : null,
-      owner: leased && typeof raw.owner === 'string' ? raw.owner.slice(0, 64) : null
+      owner: leased && typeof raw.owner === 'string' ? raw.owner.slice(0, 64) : null,
+      placementHome: null
     });
     restored += 1;
   }

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -4380,7 +4380,7 @@ export const BROWSER_PLACEMENT_MS = 20_000;
  */
 let placementCollector: string | null = null;
 
-/** The one fresh chat currently offered to its home page, and the fallback that outlives it. */
+/** The one fresh chat currently offered to its home page. Resume placement owns its own fallback timer. */
 let placementOffer: { id: string; conversationId: string; background: boolean } | null = null;
 let placementTimer: NodeJS.Timeout | null = null;
 
@@ -4407,6 +4407,14 @@ function offerPlacement(command: Command): boolean {
   if (command.spec.type !== 'worker' && home !== placementCollector) return false;
   clearPlacementOffer();
   placementOffer = { id: command.id, conversationId: home, background: command.spec.type === 'worker' };
+  // A worker already has one short redeem deadline whose only retry is the OS opener. Do not
+  // create a second timer for the same fallback here: if Prime never collects/opens this offer,
+  // that worker deadline remains the single owner of the one permitted reopen. Resume commands
+  // do not have that worker retry path, so their placement still needs its own bounded fallback.
+  if (command.spec.type === 'worker') {
+    logInfo(`bridge: offering ${specKey(command.spec)} to ${home}'s own browser window`);
+    return true;
+  }
   placementTimer = setTimeout(() => {
     placementTimer = null;
     placementOffer = null;
@@ -6298,6 +6306,10 @@ function expire(command: Command): void {
  * its chance to place this one.
  */
 async function reopenWorkerChat(command: Command): Promise<void> {
+  // The worker deadline is now taking ownership of the one fallback open. Retire any still-live
+  // home-page offer first so a late /activity poll cannot create another tab beside Prime after
+  // the OS reopen has already begun.
+  if (placementOffer?.id === command.id) clearPlacementOffer();
   if (!(await persistCommandLease(command, null, Date.now()))) {
     if (commands.includes(command)) {
       drop(command, 'the chat this app opened did not report back in time');

--- a/src/main/mcp/tools-core.ts
+++ b/src/main/mcp/tools-core.ts
@@ -1127,10 +1127,11 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
           // And the identity behind it is the exact kind: a generic connector row would let
           // an uninvolved chat that happened to call something else in the same window
           // become the prime of this run.
+          const caller = await callerNow(startedAt, { exact: true });
           const staged = stageSpawn({
             workers: input.workers,
             context: input.context ?? null,
-            caller: await callerNow(startedAt, { exact: true })
+            caller
           });
           let accepted = false;
           try {
@@ -1156,7 +1157,7 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
           const { created, becamePrime, runId } = staged;
           // Browser tabs are a publication side effect, never part of planning. They become
           // visible only after the exact broker revision above is durable.
-          requestWorkerBootstraps(created.map((worker) => worker.id));
+          requestWorkerBootstraps(created.map((worker) => worker.id), caller.conversationId ?? null);
           await adoptAgent(PRIME_ID);
           const invited = created.filter((worker) => worker.state === 'invited');
           const sleeping = created.filter((worker) => worker.state === 'sleeping' && worker.revivable);

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -3814,6 +3814,43 @@ describe('which browser opens the replacement chat', () => {
     expect(opened).toEqual([]);
   });
 
+  it('uses the worker redeem deadline as the only OS fallback when its prime never collects placement', async () => {
+    vi.useFakeTimers();
+    try {
+      await pair();
+      await request('POST', '/events', {
+        body: {
+          conversationId: HOME,
+          events: [{ kind: 'user_message', time: Date.now(), text: 'spawn a worker', messageId: 'm-worker-fallback' }]
+        }
+      });
+      const staged = spawn(
+        { workers: [{ task: 'audit the single worker fallback path' }], caller: { conversationId: HOME } },
+        { deferDelivery: true }
+      );
+      requestWorkerBootstraps(staged.created.map((worker) => worker.id), HOME);
+
+      await vi.waitFor(() => expect(pendingCommands()).toHaveLength(1));
+      const [command] = pendingCommands();
+      expect(command?.what).toContain('worker:worker-1');
+      expect(opened).toEqual([]);
+
+      // Prime never polls /activity, so the worker's existing redeem deadline owns the one
+      // fallback open. A separate placement timer would race it and open the same marker twice.
+      await vi.advanceTimersByTimeAsync(WORKER_REDEEM_MS + 1_000);
+      await vi.waitFor(() => expect(opened.length).toBeGreaterThan(0));
+      expect(opened).toEqual([commandUrl(command!.id)]);
+
+      // Once fallback takes over, a late Prime poll cannot still consume the old placement and
+      // create another tab beside itself.
+      const lateFeed = await request('GET', `/activity?conversationId=${HOME}`);
+      expect(lateFeed.body.placement).toBeNull();
+      expect(opened).toEqual([commandUrl(command!.id)]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   /** The real capture path: A's page files the ticket and then hands over its brief. */
   async function captureFrom(conversationId: string): Promise<Reply> {
     await request('POST', '/events', {

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -3790,6 +3790,30 @@ describe('delivering a bootstrap', () => {
 describe('which browser opens the replacement chat', () => {
   const HOME = 'c0c0c0c0-1111-4222-8333-000000000b01';
 
+  it('offers a fresh worker to the prime page in the background instead of opening it through the OS', async () => {
+    await pair();
+    await request('POST', '/events', {
+      body: {
+        conversationId: HOME,
+        events: [{ kind: 'user_message', time: Date.now(), text: 'spawn a worker', messageId: 'm-worker-home' }]
+      }
+    });
+    const staged = spawn(
+      { workers: [{ task: 'audit the background tab path' }], caller: { conversationId: HOME } },
+      { deferDelivery: true }
+    );
+    requestWorkerBootstraps(staged.created.map((worker) => worker.id), HOME);
+
+    await vi.waitFor(() => expect(pendingCommands()).toHaveLength(1));
+    const [command] = pendingCommands();
+    expect(command?.what).toContain('worker:worker-1');
+    expect(opened).toEqual([]);
+
+    const feed = await request('GET', `/activity?conversationId=${HOME}`);
+    expect(feed.body.placement).toEqual({ id: command?.id, background: true });
+    expect(opened).toEqual([]);
+  });
+
   /** The real capture path: A's page files the ticket and then hands over its brief. */
   async function captureFrom(conversationId: string): Promise<Reply> {
     await request('POST', '/events', {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1217,6 +1217,39 @@ describe('worker settings authority', () => {
     expect(worker.windowsUpdate).not.toHaveBeenCalled();
   });
 
+  it('opens a worker placement as a background tab without focusing its window', async () => {
+    const fetch = vi.fn(async (input: string) => {
+      const url = new URL(input);
+      if (url.pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
+      if (url.pathname === '/activity') {
+        return response(200, {
+          ok: true,
+          placement: { id: 'cmd-worker', background: true }
+        });
+      }
+      return response(404, {});
+    });
+    const worker = loadWorker({
+      local: new FakeStorageArea(paired),
+      session: new FakeStorageArea(),
+      fetch,
+      tabsGet: async () => ({ id: 47, windowId: 9, index: 4 }) as never
+    });
+    await worker.registerTab(47);
+    await worker.send({ type: 'bind', conversationId: CHAT }, 47);
+
+    await worker.send({ type: 'activity', conversationId: CHAT, since: 0 }, 47);
+
+    expect(worker.tabsCreate).toHaveBeenCalledTimes(1);
+    expect(worker.tabsCreate).toHaveBeenCalledWith({
+      url: 'https://chatgpt.com/?clf=cmd-worker#clf=cmd-worker',
+      windowId: 9,
+      index: 5,
+      active: false
+    });
+    expect(worker.windowsUpdate).not.toHaveBeenCalled();
+  });
+
   it('leaves a compaction reply that places nothing to the app’s own opener', async () => {
     const fetch = vi.fn(async (input: string, init: Record<string, unknown> = {}) => {
       const url = new URL(input);


### PR DESCRIPTION
## What changed

Fresh multi-agent worker tabs no longer need to be opened through the OS browser launcher when they are spawned by a live prime conversation.

The root cause was that `agents action=spawn` published a worker bootstrap straight to the app's browser opener. On Windows, handing `chrome.exe` a URL can activate the receiving Chrome tab/window and pull the user's foreground work away.

This change reuses the existing one-shot browser placement path for fresh MCP worker spawns:

- the accepted spawn carries the proven prime conversation only as an in-memory placement hint;
- the prime page's extension receives that one-shot placement and creates the worker beside Prime;
- worker placement is marked `background`, so the extension uses `chrome.tabs.create(... active: false)` and does not focus the window;
- Compact & Resume keeps its existing active-tab semantics;
- restored/stranded worker commands do not persist the placement hint, so restart/no-page recovery still falls straight through to the existing OS opener.

Closes #71.

## Validation

- [x] Added deterministic bridge regression coverage for fresh worker placement vs. OS open.
- [x] Added deterministic extension coverage proving worker placement uses `active: false` and does not call window focus.
- [x] Existing Compact & Resume placement test still asserts `active: true`.
- [x] `test/bridge.test.ts`: 230/230 passed.
- [x] `test/extension.test.ts`: 94/94 passed.
- [x] `test/agents.test.ts`: 125/125 passed.
- [x] `test/mcp.test.ts`: 169/169 passed.
- [x] `npm run verify` passed in a clean clone of upstream `main`: 75 test files passed + 1 skipped (2201 passed / 23 skipped), followed by `test/mcp-shutdown.test.ts` 2/2 passed.
- [x] No unrelated formatting, generated output, local debugging notes, or private data is included.
- [x] Screenshots/logs/examples contain no personal paths or credentials.
- [x] No security-sensitive behavior is disclosed.