### PR TITLE
fix: preserve Desktop reply provenance across helper replacement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2667,7 +2667,10 @@ reduced to a different path-based subject even when the parent is allowed. Regis
 re-checks, and macOS Screen Recording/Accessibility consent remains an independent OS boundary.
 The helper is prewarmed only when native Desktop capabilities are published; window observation is
 background-first and never focuses. Recent immutable frames bind coordinates to screenshot and
-window geometry; semantic refs bind cached elements to bounded native accessibility snapshots.
+window geometry; semantic refs bind cached elements to bounded native accessibility snapshots. Both also
+retain the producing helper generation, stamped on the transport reply before asynchronous image
+I/O. Frame/ref-based requests recheck that identity at native dispatch, including after local work
+in a batch; helper replacement never transfers an old snapshot to the new instance.
 Visible-pixel crops and window-capture fallbacks are always screen-bound even when their request or
 coordinates named a window; otherwise an occluding app's pixels could be relabelled as the covered
 window. Screen captures compare the exact active-display rectangles with ScreenCaptureKit's snapshot

--- a/src/main/computer/index.ts
+++ b/src/main/computer/index.ts
@@ -184,6 +184,7 @@ interface PendingHelperRequest {
 }
 
 interface HelperRuntime {
+  generation: number;
   child: ChildProcessWithoutNullStreams;
   stdoutBuffer: string;
   stderrTail: string;
@@ -193,6 +194,7 @@ interface HelperRuntime {
 }
 
 interface MacOSAddonRuntime {
+  generation: number;
   worker: Worker;
   pending: PendingHelperRequest | null;
   exited: boolean;
@@ -206,6 +208,38 @@ let helperQueue: Promise<void> = Promise.resolve();
 let helperGeneration = 0;
 let helperStopping = false;
 const helperRetirements = new Set<Promise<void>>();
+
+// Transport-owned metadata, never accepted from the native protocol. Capture it before
+// resolving a reply: image I/O may yield long enough for another helper to start.
+const helperReplyGeneration = new WeakMap<object, number>();
+
+function stampHelperReply(reply: Record<string, any>, generation: number): Record<string, any> {
+  helperReplyGeneration.set(reply, generation);
+  return reply;
+}
+
+function generationOfReply(reply: Record<string, any>): number {
+  const generation = helperReplyGeneration.get(reply);
+  if (generation === undefined) throw new ComputerError('Desktop reply has no transport identity.');
+  return generation;
+}
+
+function isHelperGenerationActive(generation: number): boolean {
+  if (helperStopping) return false;
+  return useMacOSDesktopAddon()
+    ? macOSAddonRuntime !== null && !macOSAddonRuntime.exited && macOSAddonRuntime.generation === generation
+    : helperRuntime !== null && helperRuntime.child.exitCode === null && helperRuntime.generation === generation;
+}
+
+type ExpectedHelper = { generation: number; code: 'STALE_FRAME' | 'STALE_REF' };
+
+function assertHelperGeneration(generation: number, expected?: ExpectedHelper): void {
+  if (expected && (generation !== expected.generation || !isHelperGenerationActive(generation))) {
+    throw new ComputerError(`${expected.code}: the desktop helper changed. Observe again before retrying.`, {
+      completedCount: 0, failedIndex: 0, completedRoutes: []
+    });
+  }
+}
 
 export function helperTimeoutMs(
   request: Record<string, unknown>,
@@ -305,6 +339,7 @@ async function startHelper(): Promise<HelperRuntime> {
       env: env as NodeJS.ProcessEnv
     });
     const runtime: HelperRuntime = {
+      generation: 0,
       child,
       stdoutBuffer: '',
       stderrTail: '',
@@ -368,7 +403,7 @@ async function startHelper(): Promise<HelperRuntime> {
             })
           );
         } else {
-          pending.resolve(reply);
+          pending.resolve(stampHelperReply(reply, runtime.generation));
         }
       }
     });
@@ -378,7 +413,7 @@ async function startHelper(): Promise<HelperRuntime> {
     child.once('spawn', () => {
       started = true;
       helperRuntime = runtime;
-      helperGeneration += 1;
+      runtime.generation = ++helperGeneration;
       resolve(runtime);
     });
     child.once('error', (error) => {
@@ -538,7 +573,7 @@ async function startMacOSAddon(): Promise<MacOSAddonRuntime> {
   const payload = locateMacOSDesktopAddon();
   macOSAddonStarting = new Promise<MacOSAddonRuntime>((resolve, reject) => {
     const worker = new Worker(MACOS_ADDON_WORKER_SOURCE, { eval: true, workerData: payload });
-    const runtime: MacOSAddonRuntime = { worker, pending: null, exited: false };
+    const runtime: MacOSAddonRuntime = { worker, pending: null, exited: false, generation: 0 };
     let started = false;
     const startupTimer = setTimeout(() => {
       if (started) return;
@@ -550,7 +585,7 @@ async function startMacOSAddon(): Promise<MacOSAddonRuntime> {
         started = true;
         clearTimeout(startupTimer);
         macOSAddonRuntime = runtime;
-        helperGeneration += 1;
+        runtime.generation = ++helperGeneration;
         resolve(runtime);
         return;
       }
@@ -585,7 +620,7 @@ async function startMacOSAddon(): Promise<MacOSAddonRuntime> {
       const record = reply as Record<string, any>;
       const failure = protocolFailure(record);
       if (failure) pending.reject(failure);
-      else pending.resolve(record);
+      else pending.resolve(stampHelperReply(record, runtime.generation));
     });
     worker.once('error', (error) => {
       if (!started) {
@@ -619,8 +654,9 @@ async function startMacOSAddon(): Promise<MacOSAddonRuntime> {
   return macOSAddonStarting;
 }
 
-async function sendMacOSAddonRequest(request: Record<string, unknown>): Promise<Record<string, any>> {
+async function sendMacOSAddonRequest(request: Record<string, unknown>, expected?: ExpectedHelper): Promise<Record<string, any>> {
   const runtime = await startMacOSAddon();
+  assertHelperGeneration(runtime.generation, expected);
   if (runtime.pending) throw new ComputerError('macOS Desktop addon received overlapping requests.');
   return new Promise<Record<string, any>>((resolve, reject) => {
     let pending: PendingHelperRequest;
@@ -686,9 +722,10 @@ export async function stopComputerHelper(): Promise<void> {
   await Promise.allSettled([...helperRetirements]);
 }
 
-async function sendHelperRequest(request: Record<string, unknown>): Promise<Record<string, any>> {
-  if (useMacOSDesktopAddon()) return sendMacOSAddonRequest(request);
+async function sendHelperRequest(request: Record<string, unknown>, expected?: ExpectedHelper): Promise<Record<string, any>> {
+  if (useMacOSDesktopAddon()) return sendMacOSAddonRequest(request, expected);
   const runtime = await startHelper();
+  assertHelperGeneration(runtime.generation, expected);
   if (runtime.pending) throw new ComputerError('Desktop helper received overlapping requests.');
 
   return new Promise<Record<string, any>>((resolve, reject) => {
@@ -711,13 +748,13 @@ async function sendHelperRequest(request: Record<string, unknown>): Promise<Reco
   });
 }
 
-function runHelper(request: Record<string, unknown>): Promise<Record<string, any>> {
+function runHelper(request: Record<string, unknown>, expected?: ExpectedHelper): Promise<Record<string, any>> {
   const queuedAt = Date.now();
   const operation = typeof request['op'] === 'string' ? request['op'] : 'unknown';
   const result = helperQueue.then(async () => {
     const startedAt = Date.now();
     try {
-      return await sendHelperRequest(request);
+      return await sendHelperRequest(request, expected);
     } finally {
       logInfo(
         `desktop timing op=${operation} helper_queue_ms=${startedAt - queuedAt} helper_ms=${Date.now() - startedAt}`
@@ -739,6 +776,7 @@ function runHelper(request: Record<string, unknown>): Promise<Record<string, any
  */
 interface Frame {
   id: number;
+  helperGeneration: number;
   region: Rect;
   scale: number;
   width: number;
@@ -792,8 +830,7 @@ const uiRefs = new Map<
  * outstanding ref is meaningless — and acting on one would click whatever now happens to
  * hold that id. Stamping the generation makes that detectable instead of silent.
  */
-function rememberUiRef(window: number, runtimeKey: string, index: number, snapshotId: number): string {
-  const generation = helperGeneration;
+function rememberUiRef(window: number, runtimeKey: string, index: number, snapshotId: number, generation: number): string {
   const ref = `g${generation}_s${snapshotId}_e${index + 1}`;
   uiRefs.set(ref, { window, runtimeKey, generation, snapshotId });
   while (uiRefs.size > 1000) {
@@ -811,10 +848,7 @@ function uiTarget(ref: string): { window: number; runtimeKey: string; snapshotId
       `UNKNOWN_UI_REF: ${ref}. Call get_window_state or find_ui again and use a ref from that reply.`
     );
   }
-  const helperAlive = useMacOSDesktopAddon()
-    ? macOSAddonRuntime !== null && !macOSAddonRuntime.exited
-    : helperRuntime !== null && helperRuntime.child.exitCode === null;
-  if (!helperAlive || target.generation !== helperGeneration) {
+  if (!isHelperGenerationActive(target.generation)) {
     throw new ComputerError(
       `STALE_REF: ${ref} was issued by a desktop helper that is no longer active, so it no longer identifies anything. Call get_window_state again and use a ref from that reply.`
     );
@@ -832,8 +866,12 @@ function rememberFrame(frame: Frame): void {
   }
 }
 
+function qualifiedFrame(frame: Frame | null, generation = helperGeneration): Frame | null {
+  return frame && frame.helperGeneration === generation && isHelperGenerationActive(generation) ? frame : null;
+}
+
 function frameById(id: number | undefined): Frame | null {
-  return id === undefined ? null : (frames.get(id) ?? null);
+  return qualifiedFrame(id === undefined ? null : (frames.get(id) ?? null));
 }
 
 export async function listWindows(): Promise<{ windows: WindowInfo[]; screen: Rect }> {
@@ -884,6 +922,8 @@ async function findUiLocked(
     maxResults: Math.min(100, Math.max(1, Math.floor(opts.maxResults ?? 30)))
   };
   const reply = suppliedReply ?? (await runHelper(request));
+  const replyGeneration = generationOfReply(reply);
+  frame = qualifiedFrame(frame, replyGeneration);
   const raw = Array.isArray(reply['elements']) ? (reply['elements'] as Array<Record<string, any>>) : [];
   const snapshotId = Number(reply['snapshotId']);
   if (!Number.isInteger(snapshotId) || snapshotId < 1) {
@@ -930,7 +970,7 @@ async function findUiLocked(
     const runtimeKey = String(item['runtimeKey'] ?? '');
     return {
       ref: runtimeKey
-        ? rememberUiRef(windowId, runtimeKey, index, snapshotId)
+        ? rememberUiRef(windowId, runtimeKey, index, snapshotId, replyGeneration)
         : `unavailable-${snapshotId}-${index + 1}`,
       name: String(item['name'] ?? ''),
       role: String(item['role'] ?? ''),
@@ -1122,6 +1162,7 @@ async function screenshotFromReply(
   }
   const frame: Frame = {
     id: nextFrameId++,
+    helperGeneration: generationOfReply(reply),
     region,
     scale,
     width: size.width,
@@ -1169,9 +1210,13 @@ async function screenshotLocked(
   }
 
   let cropRegion: Rect | undefined;
+  let expected: ExpectedHelper | undefined;
   if (opts.crop) {
-    const frame = cropFrame === undefined ? lastFrame : cropFrame;
+    const source = cropFrame === undefined ? lastFrame : cropFrame;
+    const frame = qualifiedFrame(source);
+    if (source && !frame) throw new ComputerError('STALE_FRAME: take a new screenshot before cropping.');
     if (!frame) throw new ComputerError('Take a screenshot first — crop coordinates refer to the most recent frame.');
+    expected = { generation: frame.helperGeneration, code: 'STALE_FRAME' };
     const crop = {
       x: Math.floor(opts.crop.x),
       y: Math.floor(opts.crop.y),
@@ -1221,7 +1266,7 @@ async function screenshotLocked(
       ...(cropRegion === undefined ? {} : { region: cropRegion }),
       ...(opts.window === undefined ? {} : { id: opts.window }),
       ...(opts.full === true ? { full: true } : {})
-    });
+    }, expected);
     // A crop is a fresh capture of visible display pixels, even when its coordinates came
     // from a window-bound frame. Keeping the source window id here would let pixels from an
     // occluding app authorize later input against the covered window. Publish the crop as
@@ -1278,7 +1323,7 @@ export async function actAndCapture(
   } = {}
 ): Promise<ActionResult & { screenshot: Screenshot | null; verification: VerificationResult | null }> {
   return exclusive(async () => {
-    const before = opts.frameId === undefined ? lastFrame : frameById(opts.frameId);
+    const before = opts.frameId === undefined ? qualifiedFrame(lastFrame) : frameById(opts.frameId);
     // capture.crop is expressed in pixels of the screenshot the caller saw, exactly like a
     // coordinate action. Another chat/agent can replace the app-global lastFrame between that
     // screenshot and this call, so using whichever frame happens to be current would crop an
@@ -1426,8 +1471,9 @@ async function actLocked(
     );
   }
   const frame =
-    requestedFrame ?? lastFrame ?? {
+    requestedFrame ?? qualifiedFrame(lastFrame) ?? {
       id: 0,
+      helperGeneration: 0,
       region: { x: 0, y: 0, width: 1, height: 1 },
       scale: 1,
       width: 1,
@@ -1547,6 +1593,11 @@ async function actLocked(
   const clipboard: string[] = [];
   const routes: ActionResult['routes'] = [];
   let completedCount = 0;
+  // Validation above is synchronous; pin its helper through every queued native segment,
+  // including a segment reached after a local wait or clipboard operation.
+  const expected: ExpectedHelper | undefined = needsFrame || uiTargets.size > 0
+    ? { generation: helperGeneration, code: uiTargets.size > 0 ? 'STALE_REF' : 'STALE_FRAME' }
+    : undefined;
   let batch: ReturnType<typeof mapOne>[] = [];
   let batchIndices: number[] = [];
   let reply: Record<string, any> | null = null;
@@ -1573,7 +1624,7 @@ async function actLocked(
               }
             }
           : {})
-      });
+      }, expected);
       helperUsed = true;
       const helperRoutes = Array.isArray(reply['routes']) ? reply['routes'].map(String) : [];
       for (let index = 0; index < sending.length; index++) {
@@ -1658,7 +1709,7 @@ async function actLocked(
   if (!Number.isFinite(sx) || !Number.isFinite(sy)) {
     throw new ComputerError('The desktop helper returned an invalid pointer position.');
   }
-  const current = requestedFrame ?? lastFrame;
+  const current = qualifiedFrame(requestedFrame ?? lastFrame, generationOfReply(reply));
   const image = current
     ? {
         x: Math.round((sx - current.region.x) * current.scale),

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -8,6 +8,7 @@
  */
 
 import http from 'node:http';
+import { once } from 'node:events';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { APP_VERSION, BRIDGE_PROTOCOL } from '../src/main/version.js';
 import { foldProgress, type SessionEvent } from '../src/shared/session.js';
@@ -7918,8 +7919,9 @@ describe('shutting the listener down', () => {
     const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
     const payload = Buffer.from(JSON.stringify({ conversationId: 'cafe0009-0000-4000-8000-000000000009', events: [] }), 'utf8');
 
+    let req!: http.ClientRequest;
     const answered = new Promise<number>((resolve, reject) => {
-      const req = http.request(
+      req = http.request(
         `${base}/events`,
         {
           method: 'POST',
@@ -7927,6 +7929,7 @@ describe('shutting the listener down', () => {
           headers: {
             origin: EXTENSION_ORIGIN,
             authorization: `Bearer ${token}`,
+            expect: '100-continue',
             'content-type': 'application/json',
             'x-extension-protocol': String(BRIDGE_PROTOCOL),
             'content-length': String(payload.length)
@@ -7938,23 +7941,26 @@ describe('shutting the listener down', () => {
         }
       );
       req.on('error', reject);
-      // Headers and half the body only: the handler is now parked inside readBody.
-      req.write(payload.subarray(0, payload.length - 1));
-      setTimeout(() => req.end(payload.subarray(payload.length - 1)), 150);
     });
 
-    // Give the server time to accept the connection and start reading.
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    // HTTP 100 Continue proves the server accepted the request. Withhold the last byte
+    // ourselves; timer subtraction (150 - 50 ms) is not proof that shutdown drained it.
+    const accepted = once(req, 'continue');
+    req.write(payload.subarray(0, payload.length - 1));
+    await accepted;
     const started = Date.now();
-    await stopBridge();
-    const elapsed = Date.now() - started;
-
-    expect(await answered).toBe(200);
-    agent.destroy();
-    // The drain is real — it waited for the request — but it ends with the request, not with
-    // the force timer 15s later.
-    expect(elapsed).toBeGreaterThanOrEqual(100);
-    expect(elapsed).toBeLessThan(3_000);
+    let stopped = false;
+    const stopping = stopBridge().then(() => { stopped = true; });
+    try {
+      await vi.waitFor(() => expect(bridgePort()).toBeNull());
+      expect(stopped).toBe(false);
+      req.end(payload.subarray(payload.length - 1));
+      expect(await answered).toBe(200);
+      await stopping;
+      expect(Date.now() - started).toBeLessThan(3_000);
+    } finally {
+      agent.destroy();
+    }
 
     const restarted = await startBridge();
     expect(restarted).not.toBeNull();

--- a/test/computer-generation.test.ts
+++ b/test/computer-generation.test.ts
@@ -1,0 +1,193 @@
+import { promises as fs } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fake = vi.hoisted(() => {
+  type Listener = { fn: (...args: any[]) => void; once: boolean };
+  class Emitter {
+    private listeners = new Map<string, Listener[]>();
+    on(event: string, fn: (...args: any[]) => void) {
+      this.listeners.set(event, [...(this.listeners.get(event) ?? []), { fn, once: false }]);
+      return this;
+    }
+    once(event: string, fn: (...args: any[]) => void) {
+      this.listeners.set(event, [...(this.listeners.get(event) ?? []), { fn, once: true }]);
+      return this;
+    }
+    emit(event: string, ...args: any[]) {
+      const listeners = this.listeners.get(event) ?? [];
+      this.listeners.set(event, listeners.filter((entry) => !entry.once));
+      for (const listener of listeners) listener.fn(...args);
+    }
+  }
+  const requests: Array<Record<string, any>> = [];
+  const children: Array<Transport> = [];
+  class Transport extends Emitter {
+    readonly pid = 9000 + children.length;
+    exitCode: number | null = null;
+    readonly stdout = new Emitter();
+    readonly stderr = new Emitter();
+    readonly stdin = {
+      write: (line: string, _encoding: string, callback: (error: null) => void) => {
+        callback(null);
+        this.answer(JSON.parse(line), false);
+        return true;
+      },
+      end: () => this.close()
+    };
+    constructor(readonly addon = true) {
+      super();
+      children.push(this);
+      queueMicrotask(() => addon ? this.emit('message', { type: 'ready' }) : this.emit('spawn'));
+    }
+    postMessage({ request }: { request: Record<string, any> }) {
+      this.answer(request, true);
+    }
+    close() {
+      this.exitCode = 0;
+      this.emit(this.addon ? 'exit' : 'close', 0);
+    }
+    async terminate() { this.close(); return 0; }
+    private answer(request: Record<string, any>, addon: boolean) {
+      requests.push(request);
+      const rect = { x: 0, y: 0, width: 100, height: 100 };
+      const window = { id: 77, title: 'Example', process: 'Example', ...rect, state: 'foreground' };
+      if (request.file) {
+        process.getBuiltinModule('node:fs').writeFileSync(request.file, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+      }
+      const reply = {
+        ok: true, window: request.op === 'find_ui' ? 77 : window, windows: [window], screen: rect,
+        region: rect, image: { width: 100, height: 100 }, windowGeometry: rect,
+        displays: [rect], captureMode: 'window', focused: true,
+        snapshotId: 41,
+        elements: [{ runtimeKey: 'button', name: 'Example', role: 'Button', enabled: true,
+          offscreen: false, bounds: { x: 10, y: 10, width: 20, height: 20 } }],
+        cursor: { x: 20, y: 20 },
+        routes: (request.actions ?? []).map(() => 'uia')
+      };
+      queueMicrotask(() => addon
+        ? this.emit('message', { type: 'reply', reply })
+        : this.stdout.emit('data', Buffer.from(`${JSON.stringify(reply)}\n`)));
+    }
+  }
+  return { requests, children, Transport, spawn: () => new Transport(false) };
+});
+
+vi.mock('node:child_process', () => ({ spawn: fake.spawn }));
+vi.mock('node:worker_threads', () => ({ Worker: fake.Transport }));
+vi.mock('node:fs', async (original) => ({
+  ...await original<typeof import('node:fs')>(), existsSync: () => true
+}));
+vi.mock('../src/main/env.js', () => ({
+  ensureUsablePath: vi.fn(), normalizeEnvironment: (env: NodeJS.ProcessEnv) => ({ ...env }),
+  setEnvValue: (env: NodeJS.ProcessEnv, key: string, value: string) => { env[key] = value; }
+}));
+vi.mock('../src/main/exec.js', () => ({
+  findWindowsPowerShell: () => 'powershell.exe',
+  terminateProcessTree: async (pid: number) => { fake.children.find((child) => child.pid === pid)?.close(); }
+}));
+vi.mock('../src/main/logger.js', () => ({ logInfo: vi.fn(), logWarn: vi.fn() }));
+
+// Both production transports exercise the same lifecycle contract without native input,
+// OS permissions or a display server. Only native replies and process/worker exits are mocked.
+describe.each(['stdio', 'addon'] as const)('Desktop reply provenance (%s)', (transport) => {
+  const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  let computer: typeof import('../src/main/computer/index.js');
+  beforeEach(async () => {
+    vi.resetModules();
+    fake.children.length = 0;
+    fake.requests.length = 0;
+    Object.defineProperty(process, 'platform', { ...platform, value: transport === 'addon' ? 'darwin' : 'linux' });
+    vi.stubEnv('COS_MACOS_DESKTOP_HELPER', '');
+    computer = await import('../src/main/computer/index.js');
+  });
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    if (computer) await computer.stopComputerHelper();
+    vi.unstubAllEnvs();
+    Object.defineProperty(process, 'platform', platform);
+  });
+  const replace = async () => {
+    fake.children.at(-1)!.close();
+    await computer.listWindows();
+  };
+
+  it('keeps older frames and refs usable while the same helper remains active', async () => {
+    const first = await computer.screenshot({ window: 77 });
+    await computer.screenshot({ window: 77 });
+    const ui = await computer.findUi({ window: 77 });
+    expect(ui.elements[0]?.imageCenter).toEqual({ x: 20, y: 20 });
+    await expect(computer.act([{ type: 'move', x: 10, y: 10 }], { frameId: first.frameId })).resolves.toBeTruthy();
+    await expect(computer.act([{ type: 'click_ref', ref: ui.elements[0]!.ref }])).resolves.toBeTruthy();
+    expect(fake.children).toHaveLength(1);
+  });
+
+  it('retires a frame immediately on helper exit without starting a replacement', async () => {
+    const shot = await computer.screenshot({ window: 77 });
+    fake.children[0]!.close();
+    const sent = fake.requests.length;
+    await expect(computer.act([{ type: 'move', x: 10, y: 10 }], { frameId: shot.frameId })).rejects.toThrow(/STALE_FRAME/);
+    expect(fake.requests).toHaveLength(sent);
+    expect(fake.children).toHaveLength(1);
+  });
+
+  it('does not bind new UI bounds or pointer reports to an earlier helper frame', async () => {
+    await computer.screenshot({ window: 77 });
+    await replace();
+    expect((await computer.findUi({ window: 77 })).elements[0]).toMatchObject({ imageBounds: null, imageCenter: null });
+    expect((await computer.act([{ type: 'type', text: 'example' }])).cursor).toMatchObject({ image: null, frameId: null });
+  });
+
+  it('refuses crops expressed in an earlier helper frame', async () => {
+    const shot = await computer.screenshot({ window: 77 });
+    await replace();
+    const sent = fake.requests.length;
+    await expect(computer.screenshot({ crop: { x: 0, y: 0, width: 10, height: 10 } })).rejects.toThrow(/STALE_FRAME/);
+    await expect(computer.actAndCapture([], {
+      frameId: shot.frameId, capture: { crop: { x: 0, y: 0, width: 10, height: 10 } }
+    })).rejects.toThrow(/STALE_FRAME/);
+    expect(fake.requests).toHaveLength(sent);
+  });
+
+  it('keeps an original reply identity across asynchronous image materialization', async () => {
+    const stat = fs.stat.bind(fs) as (...args: any[]) => Promise<any>;
+    const boundary = vi.spyOn(fs, 'stat').mockImplementationOnce(async (...args: any[]) => {
+      await replace();
+      return stat(...args);
+    });
+    const state = await computer.getWindowState({ window: 77 });
+    boundary.mockRestore();
+    expect(fake.children).toHaveLength(2);
+    expect(state.screenshot).not.toBeNull();
+    const sent = fake.requests.length;
+    await expect(computer.act([{ type: 'click_ref', ref: state.elements[0]!.ref }])).rejects.toThrow(/STALE_REF/);
+    await expect(computer.act([{ type: 'move', x: 10, y: 10 }], { frameId: state.screenshot!.frameId })).rejects.toThrow(/STALE_FRAME/);
+    expect(fake.requests).toHaveLength(sent);
+    const fresh = await computer.getWindowState({ window: 77 });
+    expect(fresh.elements[0]!.ref).not.toBe(state.elements[0]!.ref);
+    await expect(computer.act([{ type: 'click_ref', ref: fresh.elements[0]!.ref }])).resolves.toBeTruthy();
+  });
+
+  it.each(['frame', 'ref'] as const)('rechecks %s provenance at dispatch after local work', async (kind) => {
+    const state = await computer.getWindowState({ window: 77 });
+    vi.useFakeTimers();
+    const work = computer.act([
+      { type: 'wait', ms: 100 },
+      ...(kind === 'frame'
+        ? [{ type: 'move' as const, x: 10, y: 10 }]
+        : [{ type: 'click_ref' as const, ref: state.elements[0]!.ref }])
+    ], { frameId: state.screenshot!.frameId });
+    const rejected = expect(work).rejects.toMatchObject({
+      completedCount: 1, failedIndex: 1, completedRoutes: ['local'],
+      message: expect.stringMatching(kind === 'frame' ? /STALE_FRAME/ : /STALE_REF/)
+    });
+    void rejected.catch(() => {}); // A red baseline may settle before the clock is advanced.
+    // Advance the controlled scheduler up to (but not through) the local wait.
+    await vi.advanceTimersByTimeAsync(0);
+    await replace();
+    const sent = fake.requests.length;
+    await vi.advanceTimersByTimeAsync(100);
+    await rejected;
+    expect(fake.requests).toHaveLength(sent);
+  });
+});


### PR DESCRIPTION
Follow-up to #28; refs #29.

## Root cause

Desktop observations outlive the native request that produced them. A combined snapshot may finish reading its image after the helper has already been replaced; reading the global generation at that later point gives the observation the wrong provenance. Frame-dependent work also needs its helper identity rechecked when a queued native segment actually dispatches, rather than only before a local wait or clipboard step.

## Change

Keep the existing generation as the single lifetime identity:

- Bind successful replies to their producing runtime at both transport boundaries using a private WeakMap, not a new native protocol field.
- Carry that provenance into frames and semantic refs, and use one active-generation predicate when qualifying coordinates, crops, refs and pointer projections.
- Recheck the expected generation immediately before native dispatch. A refusal before dispatch reports zero native side effects, preserving the existing partial-batch evidence for any preceding local work.

The implementation change is confined to `src/main/computer/index.ts` (+75/-24), with a new behavioral suite and four lines of architecture guidance. No Swift, native input, display topology, permissions, model-facing schemas or packaging changes. This deliberately does not bring in the larger post-#28 hardening/refactor bundle.

## Validation

Exact head: `07d4196814512228bd5d42ae857783ee26fa5e58`, one commit on `f9d0e26`.

- New behavioral suite runs the actual JS stdio and Worker transport paths with mocked native endpoints: 12 failures / 2 passes on the original implementation, 14/14 after the fix. It covers same-helper reuse, retirement, async image materialization, crops, pointer projection and dispatch after a controlled local wait.
- Full `npm run verify` on Linux x64 / Node 22: 2,138 passed, 98 host-skipped; isolated shutdown suite 2/2. Privacy gate and typecheck passed.
- `npm run build` and `git diff --check` passed.
- [Verification job and logs](https://github.com/hhh2210/chat-on-steroids/actions/runs/33950751429/job/101264925827).

These tests are not a live macOS UI/TCC or packaged-app acceptance run; those were not performed for this change. The contribution branch contains only the three listed files, not the temporary fork validation workflow.