### PR TITLE
feat: add expandable details to activity tool rows

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -4834,12 +4834,33 @@
     return true;
   }
 
-  function streamRow(entry) {
+  /** The same bounded, app-owned metadata drives both disclosure text and repaint identity. */
+  function streamToolDetails(entry) {
+    const tool = typeof entry.tool === 'string' ? entry.tool.slice(0, 160) : 'tool';
+    const outcome = entry.outcome === 'ok' ? 'completed' : entry.outcome === 'error' ? 'failed'
+      : entry.outcome === 'rejected' ? 'refused' : 'unknown';
+    const duration = typeof entry.durationMs === 'number' && Number.isFinite(entry.durationMs) && entry.durationMs >= 0
+      ? ` · ${Math.round(entry.durationMs)} ms` : '';
+    const lines = [{ kind: 'meta', text: `${tool} · ${outcome}${duration}` }];
+    const changes = Array.isArray(entry.changes) ? entry.changes : [];
+    for (const change of changes.slice(0, 12)) {
+      if (!change || typeof change.path !== 'string') continue;
+      const counts = [];
+      if (Number.isFinite(change.added) && change.added >= 0) counts.push(`+${change.added}`);
+      if (Number.isFinite(change.removed) && change.removed >= 0) counts.push(`−${change.removed}`);
+      const path = change.path.length > 1024 ? `${change.path.slice(0, 1023)}…` : change.path;
+      lines.push({ kind: 'change', text: path + (counts.length ? `  ${change.approximate === true ? '≈ ' : ''}${counts.join(' ')}` : '') });
+    }
+    if (changes.length > 12) lines.push({ kind: 'more', text: `${changes.length - 12} more changed files` });
+    return lines;
+  }
+
+  function streamRow(entry, expandedTools) {
     // A reload row that names its turn arrives on the ordinary feed as 'progress' and is
     // painted here among the turn's tool calls. It keeps the repair look — the ↻ and the time —
     // because what it says is what the app did to this tab, not what ChatGPT said.
     if (browserRepairRow(entry) && entry.kind !== 'repair') entry = { ...entry, kind: 'repair' };
-    const row = document.createElement('div');
+    const row = document.createElement(entry.kind === 'tool_call' ? 'summary' : 'div');
     row.className = `clf-stream-row clf-stream-${entry.kind}`;
     row.dataset.clfSeq = String(entry.seq);
 
@@ -4897,7 +4918,24 @@
       when.textContent = clockText(entry.time);
       row.append(when);
     }
-    return row;
+    if (entry.kind !== 'tool_call') return row;
+
+    // Native details supplies mouse/keyboard disclosure semantics. Only metadata already
+    // present on /activity is rendered; raw arguments/results remain in the local store.
+    const disclosure = document.createElement('details');
+    disclosure.className = 'clf-stream-tool-disclosure';
+    disclosure.dataset.clfCall = entry.callId || `seq:${entry.seq}`;
+    disclosure.open = Boolean(expandedTools && expandedTools.has(disclosure.dataset.clfCall));
+    const panel = document.createElement('div');
+    panel.className = 'clf-stream-tool-panel';
+    for (const detail of streamToolDetails(entry)) {
+      const line = document.createElement('div');
+      line.className = `clf-stream-tool-${detail.kind}`;
+      line.textContent = detail.text;
+      panel.append(line);
+    }
+    disclosure.append(row, panel);
+    return disclosure;
   }
 
   /** The app's own reload/reopen notices on this chat, keyed by the seq each one holds. */
@@ -5321,13 +5359,24 @@
             entry.summary && entry.summary.title ? entry.summary.title : '',
             entry.summary && entry.summary.detail ? entry.summary.detail : '',
             entry.summary ? displayMetric(entry.summary) : '',
-            entry.agent || ''
+            entry.agent || '',
+            entry.kind === 'tool_call' ? JSON.stringify(streamToolDetails(entry)) : ''
           ].join(':')
         )
         .join('|');
       if (root.dataset.clfSignature !== signature) {
         root.dataset.clfSignature = signature;
-        root.replaceChildren(...activityRows.map(streamRow));
+        // Expansion belongs to this exact rendered conversation/turn, not a global cache.
+        // Removed calls and resetConversation() discard it with their DOM roots.
+        const disclosures = [...root.querySelectorAll('details.clf-stream-tool-disclosure')];
+        const expanded = new Set(disclosures.filter((node) => node.open).map((node) => node.dataset.clfCall));
+        const focused = disclosures.find((node) => node.querySelector('summary') === document.activeElement)?.dataset.clfCall;
+        root.replaceChildren(...activityRows.map((entry) => streamRow(entry, expanded)));
+        if (focused) {
+          const replacement = [...root.querySelectorAll('details.clf-stream-tool-disclosure')]
+            .find((node) => node.dataset.clfCall === focused);
+          replacement?.querySelector('summary')?.focus({ preventScroll: true });
+        }
       }
       root.dataset.clfStrongKeys = JSON.stringify([...strongStreamIdentityKeys(rendered)]);
       // Hide only the native activity that these exact rows replace. The assistant answer and

--- a/extension/overlay.css
+++ b/extension/overlay.css
@@ -831,6 +831,48 @@
   opacity: 0.7;
 }
 
+/* Native disclosures keep tool rows usable with a keyboard without a second UI state store. */
+.clf-stream-tool-disclosure > summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+.clf-stream-tool-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+
+.clf-stream-tool-disclosure > summary::after {
+  content: '';
+  width: 0.35rem;
+  height: 0.35rem;
+  margin: 0.1rem 0.45rem 0.1rem 0.75rem;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(-45deg);
+  flex-shrink: 0;
+}
+
+.clf-stream-tool-disclosure[open] > summary::after {
+  transform: rotate(45deg);
+}
+
+.clf-stream-tool-disclosure > summary:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
+}
+
+.clf-stream-tool-panel {
+  padding: 0.3rem 0 0.5rem 1.45rem;
+  font-size: 0.78rem;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+  opacity: 0.8;
+}
+
+.clf-stream-tool-change {
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+
 .clf-stream-tool_call:hover {
   background: transparent;
   opacity: 0.9;

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -2496,6 +2496,140 @@ describe('the app-owned chronological stream', () => {
     }
   });
 
+  it('exposes bounded metadata through native, keyboard-operable tool disclosures', async () => {
+    const withDetails = () => {
+      const payload = activity();
+      Object.assign(payload.data.stream.find((entry) => entry.seq === 4)!, {
+        changes: [{ path: 'src/third.ts', added: 2, removed: 1 }],
+        args: 'private-argument-sentinel', result: 'private-result-sentinel'
+      });
+      return payload;
+    };
+    live = await harness(undefined, { activity: withDetails });
+    renderingOn();
+    const section = assistantTurn(live.document, turnId, []);
+    await bindFiberRequest(section, 'wfr-app-stream');
+    live.hook.renderStreams();
+    const details = overwriteRows(section, 'details.clf-stream-tool-disclosure') as HTMLDetailsElement[];
+    expect(details).toHaveLength(2);
+    const disclosure = details.find((node) => node.textContent?.includes('Read third.ts'))!;
+    const summary = disclosure.querySelector('summary')!;
+    expect(summary.classList.contains('clf-stream-tool_call')).toBe(true);
+    expect(disclosure.open).toBe(false);
+    summary.click();
+    expect(disclosure.open).toBe(true);
+    expect(disclosure.querySelector('.clf-stream-tool-panel')?.textContent).toContain('read_file · completed · 3 ms');
+    expect(disclosure.textContent).toContain('src/third.ts  +2 −1');
+    expect(disclosure.textContent).not.toContain('private-argument-sentinel');
+    expect(disclosure.textContent).not.toContain('private-result-sentinel');
+    summary.click();
+    expect(disclosure.open).toBe(false);
+  });
+
+  it('keeps only the same calls expanded when activity rows are repainted', async () => {
+    live = await harness(undefined, { activity });
+    renderingOn();
+    const section = assistantTurn(live.document, turnId, []);
+    await bindFiberRequest(section, 'wfr-app-stream');
+    live.hook.renderStreams();
+    const first = overwriteRows(section, 'details.clf-stream-tool-disclosure') as HTMLDetailsElement[];
+    expect(first).toHaveLength(2);
+    first[0]!.querySelector('summary')!.click();
+    first[0]!.querySelector('summary')!.focus();
+    live.hook.setShowTimes(true);
+    live.hook.renderStreams();
+    const second = overwriteRows(section, 'details.clf-stream-tool-disclosure') as HTMLDetailsElement[];
+    expect(second[0]).not.toBe(first[0]);
+    expect(second.map((node) => node.open)).toEqual([true, false]);
+    expect(live.document.activeElement).toBe(second[0]!.querySelector('summary'));
+    expect(second[0]!.dataset.clfCall).toBe(first[0]!.dataset.clfCall);
+  });
+
+  it('refreshes details when the authoritative activity tail is replaced', async () => {
+    let revision = 0;
+    const withDetails = () => {
+      const payload = activity();
+      Object.assign(payload.data, { resetActivity: true });
+      Object.assign(payload.data.stream.find((entry) => entry.seq === 4)!, {
+        durationMs: revision ? 8 : 3,
+        changes: [{ path: revision ? 'src/revised.ts' : 'src/third.ts', added: revision, removed: 0 }]
+      });
+      return payload;
+    };
+    live = await harness(undefined, { activity: withDetails });
+    renderingOn();
+    const section = assistantTurn(live.document, turnId, []);
+    await bindFiberRequest(section, 'wfr-app-stream');
+    live.hook.renderStreams();
+    const before = overwriteRows(section, 'details').find((node) => node.textContent?.includes('Read third.ts')) as HTMLDetailsElement;
+    expect(before).toBeDefined();
+    before.querySelector('summary')!.click();
+    revision++;
+    await live.hook.pullActivity();
+    live.hook.renderStreams();
+    const after = overwriteRows(section, 'details').find((node) => node.textContent?.includes('Read third.ts')) as HTMLDetailsElement;
+    expect(after.open).toBe(true);
+    expect(after.textContent).toContain('8 ms');
+    expect(after.textContent).toContain('src/revised.ts');
+    expect(after.textContent).not.toContain('src/third.ts');
+  });
+
+  it('bounds changed paths, escapes markup and does not invent a successful outcome', async () => {
+    const withDetails = () => {
+      const payload = activity();
+      Object.assign(payload.data.stream.find((entry) => entry.seq === 4)!, {
+        outcome: undefined, durationMs: null,
+        changes: Array.from({ length: 14 }, (_, index) => ({
+          path: index === 0 ? '<img src=x onerror=alert(1)>' : `src/file-${index}.ts`,
+          added: index === 0 ? -1 : index, removed: 0, approximate: true
+        }))
+      });
+      return payload;
+    };
+    live = await harness(undefined, { activity: withDetails });
+    renderingOn();
+    const section = assistantTurn(live.document, turnId, []);
+    await bindFiberRequest(section, 'wfr-app-stream');
+    live.hook.renderStreams();
+    const panel = overwriteRows(section, '.clf-stream-tool-panel').find((node) => node.textContent?.includes('unknown'))!;
+    expect(panel).toBeDefined();
+    expect(panel.querySelectorAll('.clf-stream-tool-change')).toHaveLength(12);
+    expect(panel.textContent).toContain('2 more changed files');
+    expect(panel.textContent).toContain('<img src=x onerror=alert(1)>');
+    expect(panel.querySelector('img')).toBeNull();
+    expect(panel.textContent).not.toContain('0 ms');
+    expect(panel.textContent).not.toContain('+-1');
+    expect(panel.textContent).toContain('≈');
+  });
+
+  it('does not carry expansion into a different conversation with reused call ids', async () => {
+    live = await harness(undefined, { activity });
+    renderingOn();
+    const section = assistantTurn(live.document, turnId, []);
+    await bindFiberRequest(section, 'wfr-app-stream');
+    live.hook.renderStreams();
+    const original = overwriteRows(section, 'details')[0] as HTMLDetailsElement;
+    expect(original).toBeDefined();
+    original.querySelector('summary')!.click();
+    live.dom.reconfigure({ url: 'https://chatgpt.com/c/bbbbbbbb-cccc-dddd-eeee-ffffffffffff' });
+    live.hook.observe();
+    await settle();
+    live.document.querySelector('#thread')!.replaceChildren();
+    const replacement = assistantTurn(live.document, turnId, []);
+    live.hook.observe();
+    await settle();
+    await bindFiberTurns([{ section: replacement, turn: {
+      turnId, conversationId: 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff',
+      calls: [{ messageId: 'fiber-wfr-app-stream', tool: 'read_file', order: 0, answered: true, requestId: 'wfr-app-stream' }]
+    } }]);
+    await live.hook.pullActivity();
+    live.hook.renderStreams();
+    const disclosures = overwriteRows(replacement, 'details') as HTMLDetailsElement[];
+    expect(disclosures).toHaveLength(2);
+    expect(disclosures.every((node) => !node.open)).toBe(true);
+    expect(original.isConnected).toBe(false);
+  });
+
   /**
    * A reload of an open turn is part of that turn's story. The app names the turn on the row,
    * and the page paints it where it happened, among the turn's tool calls, with the repair look
@@ -2534,6 +2668,8 @@ describe('the app-owned chronological stream', () => {
     ]);
     const reload = overwriteRows(section, '.clf-stream-repair');
     expect(reload).toHaveLength(1);
+    expect(reload[0]!.tagName).toBe('DIV');
+    expect(reload[0]!.closest('details')).toBeNull();
     expect(reload[0]!.querySelector('.clf-stream-icon')?.textContent).toBe('↻');
     expect(reload[0]!.querySelector('.clf-when')?.textContent ?? '').not.toBe('');
     // In the turn, so not also hung between turns.


### PR DESCRIPTION
Closes #73.

## What changes

App-owned tool rows currently replace the native activity display with non-interactive text. This makes each tool-call row a native `details`/`summary` disclosure showing the tool name, recorded outcome, duration when known, and up to 12 changed paths with available line counts.

There is no new route, model-facing schema, or persistent expansion store. Only metadata already available on `/activity` is rendered with `textContent`; raw tool arguments/results and file contents are not exposed. Missing outcomes remain unknown, and missing durations are not displayed as zero.

Expansion is recovered from the current stream root when that root is repainted, keyed by the exact call. Keyboard focus stays on the same summary without scrolling. An authoritative replacement tail refreshes the details, while conversation navigation discards the old state. Existing reload/repair rows remain ordinary notices.

The rendering change is +54/-5 in `extension/content.js`, plus focused CSS and regression tests. It is rebased on current `f9d0e26`, not a replay of the old rendering implementation.

## Validation

- Five new behavior tests fail against the original implementation and pass after the change.
- Complete content-script and extension suites: **442/442 passed**.
- Full `npm run verify` passed on a clean Linux x64 / Node 22 checkout, including the privacy gate, typecheck, complete test suite and isolated shutdown tests.
- `npm run build` and `git diff --check` passed.
- Chromium smoke using the actual row-rendering functions and `overlay.css`: Tab/Enter/Space/click work; a long path causes no horizontal overflow at 380px or 1280px; repair rows remain outside disclosures.
- [Full verification job and logs](https://github.com/hhh2210/chat-on-steroids/actions/runs/33950751429/job/101264925737).

The browser smoke is a synthetic component page, not a logged-in ChatGPT Web E2E claim. The PR contains only the three implementation/test files, with no temporary fork validation workflow or generated output.