### PR TITLE
Keep folder access editable after setup

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -238,6 +238,7 @@
                     <button class="btn btn-solid" id="wizAddFolder" type="button">
                       <svg class="ico" viewBox="0 0 24 24"><use href="#i-folder" /></svg>Choose folder
                     </button>
+                    <button class="btn" id="wizManageFolders" type="button">Manage folders</button>
                     <span class="chosen" id="wizFolders">None yet</span>
                   </div>
                 </div>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -1477,6 +1477,11 @@ $('readOnlyBtn').addEventListener('click', () => {
 
 $('addFolder').addEventListener('click', () => void addFolder());
 $('wizAddFolder').addEventListener('click', () => void addFolder());
+$('wizManageFolders').addEventListener('click', () => {
+  showTab('home');
+  $('foldersCard').scrollIntoView({ block: 'nearest' });
+  $('addFolder').focus({ preventScroll: true });
+});
 
 // Dropping a file anywhere on an Electron window otherwise navigates the whole window to
 // it. Only the Folders card accepts drops, and everything else swallows them.

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1177,6 +1177,8 @@ main {
   padding: 14px 0;
 }
 
+/* Folder access remains editable after onboarding has finished. */
+.wizard.is-tidy .step.is-done[data-step='folder'] .step-body > .step-actions,
 .wizard.is-tidy .step.is-done[data-step='chatgpt'] .step-body > .step-actions {
   display: flex;
 }

--- a/test/renderer-state.test.ts
+++ b/test/renderer-state.test.ts
@@ -582,6 +582,33 @@ it('guides rootless setup from the capabilities that actually need a filesystem 
   expect(connect.disabled).toBe(false);
 });
 
+it('keeps folder access discoverable after setup and navigates without granting access', async () => {
+  const addRoot = vi.fn();
+  const mounted = await mountChat({ hasApiKey: true }, [], { addRoot });
+  const connected = structuredClone(mounted.state);
+  connected.status.state = 'connected';
+  connected.status.lastRequestAt = Date.now();
+  connected.bridge.present = true;
+  mounted.push(connected);
+  const doc = mounted.window.document;
+  const styles = doc.createElement('style');
+  styles.textContent = await fs.readFile(path.join(process.cwd(), 'src/renderer/styles.css'), 'utf8');
+  doc.head.append(styles);
+  doc.querySelector<HTMLButtonElement>('[data-tab="setup"]')!.click();
+
+  expect(doc.getElementById('wizard')!.classList.contains('is-tidy')).toBe(true);
+  const manage = doc.getElementById('wizManageFolders')!;
+  expect(mounted.window.getComputedStyle(manage.parentElement!).display).not.toBe('none');
+  expect(doc.getElementById('wizFolders')!.textContent).toBe('/repo');
+  manage.click();
+
+  expect(doc.querySelector('.panel.is-active')?.getAttribute('data-panel')).toBe('home');
+  expect(doc.activeElement).toBe(doc.getElementById('addFolder'));
+  expect(doc.getElementById('rootList')!.textContent).toContain('/repo');
+  expect(addRoot).not.toHaveBeenCalled();
+  expect(mounted.calls).toEqual([]);
+});
+
 it('requires a live browser only when a browser-backed feature is actually enabled', async () => {
   const mounted = await mountChat({
     hasApiKey: true,


### PR DESCRIPTION
## What changed

After setup completes, the wizard hides the folder actions and shared-folder summary. Returning users see a checked “Pick a folder to share” heading but no way to change access from that page.

Keep the folder actions visible in the collapsed wizard and add **Manage folders**, which opens the existing Home → Folders card and focuses Add. Folder approval still uses the existing picker; navigation itself does not grant access or restart a connector.

Scope: **8 production lines and 27 regression-test lines added**, across four files. No backend, permission-enforcement or native changes.

## Validation

- [x] Added a regression for completed-setup visibility, navigation/focus and no implicit authorization.
- [x] `npm run typecheck`, `npm run build` and `git diff --check` passed.
- [x] Verified the built renderer in a Chromium browser with placeholder state and mocked IPC: both folder actions remain visible; Manage folders reaches Home; Choose folder calls the existing picker API.
- [x] `npm run verify` passes locally. The local full run reported PTY cleanup and bundled-ripgrep failures; renderer test runs were interrupted during dependency loading. No passing local unit/full-suite result is claimed.
- [x] No generated artifacts, unrelated changes or private data included.

The running packaged app was left untouched; this is renderer verification, not a new packaged-app acceptance run.