### PR TITLE
Respect the Windows swapped-button setting for desktop clicks

### DIFF
--- a/src/main/computer/helper.ts
+++ b/src/main/computer/helper.ts
@@ -56,6 +56,8 @@ public static class Clf {
   const uint MOUSEEVENTF_RIGHTDOWN = 0x0008, MOUSEEVENTF_RIGHTUP = 0x0010;
   const uint MOUSEEVENTF_MIDDLEDOWN = 0x0020, MOUSEEVENTF_MIDDLEUP = 0x0040;
   const uint MOUSEEVENTF_WHEEL = 0x0800, MOUSEEVENTF_HWHEEL = 0x1000;
+  // Nonzero when the user has swapped the primary and secondary mouse buttons. See ButtonFlags.
+  const int SM_SWAPBUTTON = 23;
   const uint KEYEVENTF_KEYUP = 0x0002, KEYEVENTF_UNICODE = 0x0004;
 
   [DllImport("user32.dll", SetLastError = true)]
@@ -110,11 +112,38 @@ public static class Clf {
     Send(new INPUT[] { Mouse(MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK, nx, ny, 0) });
   }
 
+  /**
+   * The caller's "left" means the primary button, not the physical one on the left.
+   *
+   * SendInput's flags name physical buttons, and Windows applies the left-handed swap
+   * (SM_SWAPBUTTON) when it turns a physical press into the message an application receives. So
+   * on a swapped mouse MOUSEEVENTF_LEFTDOWN arrives as the *secondary* click, and a default click
+   * opens a context menu instead of activating what it was aimed at -- issue #76. Inverting the
+   * pair here cancels the system's inversion, so a caller asking for "left" always gets whatever
+   * that user's Windows treats as primary.
+   *
+   * Measured on Windows 11 rather than inferred, by injecting into a window the probe owned:
+   * with the swap on, sending LEFTDOWN produced WM_RBUTTONDOWN and sending RIGHTDOWN produced
+   * WM_LBUTTONDOWN.
+   *
+   * Read per call rather than cached: it is a checkbox in Mouse properties and can change while
+   * the app runs, and a stale answer is the same wrong-button bug with a longer fuse. Only the
+   * primary and secondary swap -- middle and the wheel are untouched.
+   *
+   * (No backticks in this comment: the whole script is a String.raw template literal.)
+   */
   static void ButtonFlags(string button, out uint down, out uint up) {
+    bool swapped = GetSystemMetrics(SM_SWAPBUTTON) != 0;
     switch (button) {
-      case "right": down = MOUSEEVENTF_RIGHTDOWN; up = MOUSEEVENTF_RIGHTUP; break;
+      case "right":
+        down = swapped ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_RIGHTDOWN;
+        up = swapped ? MOUSEEVENTF_LEFTUP : MOUSEEVENTF_RIGHTUP;
+        break;
       case "middle": case "wheel": down = MOUSEEVENTF_MIDDLEDOWN; up = MOUSEEVENTF_MIDDLEUP; break;
-      default: down = MOUSEEVENTF_LEFTDOWN; up = MOUSEEVENTF_LEFTUP; break;
+      default:
+        down = swapped ? MOUSEEVENTF_RIGHTDOWN : MOUSEEVENTF_LEFTDOWN;
+        up = swapped ? MOUSEEVENTF_RIGHTUP : MOUSEEVENTF_LEFTUP;
+        break;
     }
   }
 

--- a/test/computer-swapped-buttons.test.ts
+++ b/test/computer-swapped-buttons.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { HELPER_SCRIPT } from '../src/main/computer/helper.js';
+
+/**
+ * Issue #76: a left-handed mouse turned every default click into a right-click.
+ *
+ * SendInput's flags name *physical* buttons, and Windows applies the `SM_SWAPBUTTON` swap when it
+ * turns a physical press into the message an application receives. So on a swapped mouse the app's
+ * `left` — which callers mean as "the primary button" — arrived as the secondary click, opening
+ * context menus instead of activating things.
+ *
+ * Measured on Windows 11 before the fix, by injecting into a window the probe owned so no real UI
+ * was clicked, with the setting restored afterwards:
+ *
+ *     swap on, MOUSEEVENTF_LEFTDOWN  sent -> WM_RBUTTONDOWN   (the bug)
+ *     swap on, MOUSEEVENTF_RIGHTDOWN sent -> WM_LBUTTONDOWN   (the fix)
+ *
+ * The mapping lives inside the embedded C#, so it cannot be called from here; what this pins is
+ * the source contract. Deliberately asserted as whole down/up pairs rather than as "the file
+ * mentions SM_SWAPBUTTON", because the ways this regresses are partial: swapping the down flag and
+ * not the up, fixing `left` and forgetting `right`, or dropping the runtime read for a constant.
+ */
+describe('a swapped-button mouse still gets a primary click (issue #76)', () => {
+  const buttonFlags = (() => {
+    const start = HELPER_SCRIPT.indexOf('static void ButtonFlags');
+    expect(start, 'ButtonFlags should still exist in the helper').toBeGreaterThan(-1);
+    return HELPER_SCRIPT.slice(start, HELPER_SCRIPT.indexOf('public static void Click', start));
+  })();
+
+  it('decides from the live system setting rather than a build-time constant', () => {
+    // The user can flip this checkbox while the app runs, so a cached answer is the same
+    // wrong-button bug with a longer fuse.
+    expect(buttonFlags).toMatch(/GetSystemMetrics\(SM_SWAPBUTTON\)/);
+  });
+
+  it('sends the right-hand flags for a primary click when the buttons are swapped', () => {
+    // Both halves of the pair, because a down without its up leaves the button stuck.
+    expect(buttonFlags).toMatch(/swapped \? MOUSEEVENTF_RIGHTDOWN : MOUSEEVENTF_LEFTDOWN/);
+    expect(buttonFlags).toMatch(/swapped \? MOUSEEVENTF_RIGHTUP : MOUSEEVENTF_LEFTUP/);
+  });
+
+  it('sends the left-hand flags for a secondary click when the buttons are swapped', () => {
+    expect(buttonFlags).toMatch(/swapped \? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_RIGHTDOWN/);
+    expect(buttonFlags).toMatch(/swapped \? MOUSEEVENTF_LEFTUP : MOUSEEVENTF_RIGHTUP/);
+  });
+
+  it('leaves the middle button and wheel out of it', () => {
+    // Windows swaps only the primary and secondary buttons; conditioning the middle button on the
+    // setting would invent a bug the OS does not have.
+    const middle = buttonFlags.slice(buttonFlags.indexOf('case "middle"'));
+    expect(middle.slice(0, middle.indexOf('break'))).not.toMatch(/swapped/);
+  });
+
+  it('declares SM_SWAPBUTTON as the documented index', () => {
+    expect(HELPER_SCRIPT).toMatch(/const int SM_SWAPBUTTON = 23;/);
+  });
+
+  it('routes every physical click through the one place that knows about the swap', () => {
+    // click, double_click and drag all reach the pointer through ButtonFlags, and so does the
+    // click_ref fallback when a control has no InvokePattern — it calls Clf::Click. A caller that
+    // built its own flags instead would silently stop being covered by this fix.
+    //
+    // Asserted as "these callers delegate" rather than by counting flag mentions across the file:
+    // the first version of this test counted them, and the count moved the moment the fix's own
+    // comment mentioned a flag by name. A test that a comment can break is measuring the wrong
+    // thing.
+    for (const caller of ['public static void Click', 'public static void Drag']) {
+      const start = HELPER_SCRIPT.indexOf(caller);
+      expect(start, `${caller} should still exist`).toBeGreaterThan(-1);
+      const body = HELPER_SCRIPT.slice(start, start + 600);
+      expect(body, `${caller} should ask ButtonFlags rather than choosing flags itself`)
+        .toMatch(/ButtonFlags\(button, out down, out up\)/);
+    }
+    // And the click_ref fallback goes through Click, so it inherits the same decision.
+    expect(HELPER_SCRIPT).toMatch(/\[Clf\]::Click\(/);
+  });
+});


### PR DESCRIPTION
Fixes #76.

On a mouse set up for left-handed use, every default click became a right-click — so the agent
opened context menus instead of activating what it was aimed at.

## Why

SendInput's flags name **physical** buttons, and Windows applies the `SM_SWAPBUTTON` swap when it
turns a physical press into the message an application receives. So `MOUSEEVENTF_LEFTDOWN` — which
callers mean as "the primary button" — lands as the *secondary* click on a swapped mouse.

## Measured, not reasoned about

This inverts clicking for exactly the users it's meant to help, so getting the direction wrong
would make their situation worse than the bug. I checked on Windows 11 with a probe that injected
into a window it owned itself, so no real UI was clicked, and restored the setting in a `finally`:

```
swap on, MOUSEEVENTF_LEFTDOWN  sent  ->  WM_RBUTTONDOWN   (the bug)
swap on, MOUSEEVENTF_RIGHTDOWN sent  ->  WM_LBUTTONDOWN   (the fix)
```

## The change

One place. `ButtonFlags` is the only spot the physical flags are chosen, and `Click` and `Drag`
both go through it — as does the `click_ref` fallback, which calls `Clf::Click` when a control has
no `InvokePattern`. So inverting the pair there covers every path the issue names: coordinate
`click`, `double_click`, `drag`, and that fallback.

Two deliberate details:

- **Read per call, not cached.** It's a checkbox in Mouse properties that can be flipped while the
  app is running, and a cached answer is the same wrong-button bug with a longer fuse.
- **Middle and wheel untouched.** Windows swaps only the primary and secondary buttons;
  conditioning the middle button on the setting would invent a bug the OS doesn't have.

## Test

The mapping lives inside the embedded C# and can't be called from a unit test, so the test pins the
source contract — as whole down/up pairs, because the ways this regresses are partial: swapping the
down flag but not the up, fixing one button and forgetting the other, or replacing the runtime read
with a constant. **Four of its six assertions fail against the code as it was.**

`tsc` clean, full suite green. (`exec-hints.test.ts` has one failure on my machine from the
PowerShell execution policy blocking `.ps1` files — it fails identically on a clean checkout of
`main`, and is unrelated to this change.)
