### PR TITLE
Give the macOS app a coherent ad-hoc seal so it will launch

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -34,6 +34,9 @@ extraResources:
 
 npmRebuild: false
 
+# macOS only; a no-op on every other platform. See the hook and the mac.identity note below.
+afterPack: scripts/afterpack-macos-adhoc-seal.mjs
+
 asarUnpack:
   - '**/node_modules/node-pty/**'
   - '**/node_modules/sharp/**'
@@ -90,6 +93,12 @@ mac:
   # v2.0.2 intentionally ships unsigned/unnotarized macOS artifacts. Make that policy
   # deterministic instead of depending on whatever identities or Apple env vars happen to be
   # present on a hosted runner. Remove these two lines when real signing credentials are wired.
+  #
+  # Unsigned still has to mean *coherent*. Every arm64 Mach-O is ad-hoc signed by the linker
+  # whether anyone asks or not, so skipping bundle signing shipped an app whose executables
+  # claimed a resource seal the bundle did not have; macOS calls that damaged and refuses to
+  # launch it (issue #66). afterPack re-seals ad-hoc — no Authority, no TeamIdentifier, still
+  # nothing Gatekeeper will vouch for — and verifies the result.
   identity: null
   notarize: false
   artifactName: Chat-On-Steroids-macOS-${arch}.${ext}

--- a/scripts/afterpack-macos-adhoc-seal.mjs
+++ b/scripts/afterpack-macos-adhoc-seal.mjs
@@ -1,0 +1,76 @@
+/**
+ * Gives the packaged macOS app a valid ad-hoc seal, and refuses to ship one that is not valid.
+ *
+ * ## The bug this exists for
+ *
+ * Issue #66: the 2.0.5 arm64 DMG launched to "the application is damaged" on macOS 27, with
+ * Gatekeeper assessment already disabled — so this was a structural failure, not a policy one:
+ *
+ *     codesign --verify --deep --strict "Chat On Steroids.app"
+ *     -> code has no resources but signature indicates they must be present
+ *     codesign -dvv -> flags=0x20002(adhoc,linker-signed), Sealed Resources=none
+ *
+ * `linker-signed` is the giveaway. Every arm64 Mach-O gets an ad-hoc signature from the linker
+ * whether anyone asks or not — it is not optional on Apple Silicon. `identity: null` tells
+ * electron-builder to skip bundle signing, so the app shipped as a *bundle* carrying signed
+ * Mach-Os and no `_CodeSignature/CodeResources`. macOS reads the signature on the executable,
+ * looks for the resource seal it implies, finds none, and calls the bundle damaged. There was
+ * never an x64-only version of this problem, which is why it appeared with Apple Silicon.
+ *
+ * ## Why ad-hoc rather than Developer ID
+ *
+ * The release policy is deliberately unsigned and unnotarized, and this does not change that.
+ * An ad-hoc seal carries no Authority and no TeamIdentifier — `codesign -dvv` still reports
+ * `Signature=adhoc`, and Gatekeeper still will not vouch for it. What it adds is the resource
+ * envelope the executable's own signature already claims exists. The bundle stops contradicting
+ * itself; it does not become trusted. Users still clear quarantine as before.
+ *
+ * ## Why it verifies afterwards
+ *
+ * The real defect was that nothing checked. The bundle audit asserted the *absence* of a seal, so
+ * the broken state was the state the build required, and two releases shipped it. Signing without
+ * verifying would leave the same hole one layer along, so a failed verify fails the build.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+/** Runs a command and returns its combined output, throwing with that output on failure. */
+function run(command, args) {
+  try {
+    return execFileSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (error) {
+    const detail = `${error.stdout ?? ''}${error.stderr ?? ''}`.trim();
+    throw new Error(`${command} ${args.join(' ')} failed: ${detail || error.message}`);
+  }
+}
+
+export default async function sealMacOsBundle(context) {
+  if (context.electronPlatformName !== 'darwin') return;
+
+  const appName = `${context.packager.appInfo.productFilename}.app`;
+  const app = path.join(context.appOutDir, appName);
+  if (!existsSync(app)) throw new Error(`afterPack could not find ${app} to seal`);
+
+  // --deep is the wrong tool for verification and the right one here: an Electron bundle nests
+  // frameworks and helper apps that each need their own signature, and signing only the outer
+  // bundle would leave the same self-contradiction one level down. Apple discourages --deep for
+  // *distribution* signing, where each nested component wants its own identity and entitlements;
+  // for a uniform ad-hoc seal with no entitlements there is nothing to distinguish.
+  run('codesign', ['--force', '--deep', '--sign', '-', app]);
+
+  // The check the two broken releases did not have. --strict so a seal that merely exists is not
+  // mistaken for a seal that is coherent, and --deep so a nested framework cannot be the one
+  // thing that is wrong, which is exactly how issue #66 presented.
+  run('codesign', ['--verify', '--deep', '--strict', '--verbose=2', app]);
+
+  const shown = run('codesign', ['--display', '--verbose=4', app]);
+  // Fail loudly if this ever starts producing a trust-bearing signature. The release notes say
+  // unsigned, and an afterPack hook silently turning that into something Gatekeeper vouches for
+  // would be a policy change smuggled in as a build step.
+  if (/^Authority=/m.test(shown) || !/^Signature=adhoc\s*$/m.test(shown)) {
+    throw new Error(`${app} was sealed with something other than an ad-hoc signature:\n${shown}`);
+  }
+
+  process.stdout.write(`Sealed ${appName} ad-hoc and verified its resource envelope.\n`);
+}

--- a/scripts/macos-audit-utils.mjs
+++ b/scripts/macos-audit-utils.mjs
@@ -94,12 +94,24 @@ export function assertCompatibleMacOSDeploymentTargets(file, otoolOutput, declar
  * arm64 Mach-O executables can carry an ad-hoc LC_CODE_SIGNATURE even when the application has
  * never been signed by a Developer ID. `codesign --display` may therefore succeed for a bundle
  * whose publisher identity is still untrusted. A trust-bearing signature instead exposes an
- * Authority chain and/or a real TeamIdentifier. Whole-bundle signing also creates CodeResources;
- * identity:null must not produce that resource envelope at all.
+ * Authority chain and/or a real TeamIdentifier.
+ *
+ * The resource envelope is now required rather than forbidden, which is the opposite of what this
+ * asserted before. That inversion was issue #66: arm64 Mach-Os are ad-hoc signed by the linker
+ * whether anyone asks or not, so a bundle without CodeResources is one whose executables claim a
+ * resource seal the bundle does not have. macOS reads that contradiction as damage and refuses to
+ * launch, with Gatekeeper assessment disabled and no crash report to show for it. Demanding the
+ * absence of a seal made the broken artifact the compliant one, and two releases shipped it.
+ *
+ * Coherent and untrusted are different axes. Only the second is the policy, and it is still
+ * enforced below.
  */
 export function assertNoTrustBearingMacCodeSignature(file, codesignResult, hasCodeResources = false) {
-  if (hasCodeResources) {
-    throw new Error(`${file} unexpectedly has a bundle CodeResources signature envelope`);
+  if (!hasCodeResources) {
+    throw new Error(
+      `${file} has no bundle CodeResources envelope; macOS reads an ad-hoc linker-signed bundle ` +
+        'without one as damaged. The afterPack ad-hoc seal should have created it.'
+    );
   }
 
   const output = `${codesignResult.stdout ?? ''}\n${codesignResult.stderr ?? ''}`;

--- a/scripts/smoke-macos-bundle.mjs
+++ b/scripts/smoke-macos-bundle.mjs
@@ -158,11 +158,16 @@ if (launchedMachOCount < 6) {
   throw new Error(`Only found ${launchedMachOCount} launchable Mach-O files in ${app}; executable-mode audit is unexpectedly shallow`);
 }
 
-// The release notes promise no publisher/Developer-ID signature. `codesign --verify --deep` is the
-// wrong predicate here: a signed outer bundle with one broken nested signature would fail verify
-// and look "unsigned". Conversely, Apple-Silicon executables can carry ad-hoc LC_CODE_SIGNATURE
-// commands even when there is no publisher identity. Inspect the displayed identity semantics and
-// the whole-bundle CodeResources envelope instead of treating every successful display as trusted.
+// The release notes promise no publisher/Developer-ID signature, and Apple-Silicon executables
+// carry ad-hoc LC_CODE_SIGNATURE commands whether or not anyone signed them, so a successful
+// `codesign --display` proves nothing about trust on its own. Inspect the displayed identity
+// semantics instead.
+//
+// The CodeResources envelope is now passed as a requirement rather than a prohibition. Its
+// absence is what made issue #66 — executables claiming a resource seal the bundle did not have,
+// which macOS treats as damage — and demanding that absence here is why two releases shipped it.
+// The afterPack hook creates the seal and runs the real --verify --deep --strict against the app
+// it just sealed, where a failure can still stop the build before an artifact exists.
 const signature = run('codesign', ['--display', '--verbose=4', app], { allowFailure: true });
 assertNoTrustBearingMacCodeSignature(
   app,

--- a/test/packaging.test.ts
+++ b/test/packaging.test.ts
@@ -516,37 +516,54 @@ Load command 11
   });
 
   it('allows Apple-Silicon ad-hoc signatures but rejects publisher-bearing macOS signatures', () => {
-    expect(() => assertNoTrustBearingMacCodeSignature('unsigned.app', {
-      status: 1,
-      stdout: '',
-      stderr: 'code object is not signed at all'
-    })).not.toThrow();
+    // The sealed ad-hoc bundle, which is what ships: no Authority, no TeamIdentifier, and the
+    // resource envelope its own executables imply.
     expect(() => assertNoTrustBearingMacCodeSignature('adhoc.app', {
       status: 0,
       stdout: '',
       stderr: 'Identifier=com.example\nSignature=adhoc\nTeamIdentifier=not set\n'
-    })).not.toThrow();
+    }, true)).not.toThrow();
 
     expect(() => assertNoTrustBearingMacCodeSignature('developer-id.app', {
       status: 0,
       stdout: '',
       stderr: 'Signature size=9000\nAuthority=Developer ID Application: Example Corp (TEAM123456)\nTeamIdentifier=TEAM123456\n'
-    })).toThrow(/trust-bearing code signature/);
+    }, true)).toThrow(/trust-bearing code signature/);
     expect(() => assertNoTrustBearingMacCodeSignature('unknown-success.app', {
       status: 0,
       stdout: '',
       stderr: 'Identifier=com.example\n'
-    })).toThrow(/trust-bearing code signature/);
+    }, true)).toThrow(/trust-bearing code signature/);
     expect(() => assertNoTrustBearingMacCodeSignature('inspection-failed.app', {
       status: null,
       stdout: '',
       stderr: 'codesign was terminated unexpectedly'
-    })).toThrow(/inspection failed unexpectedly/);
-    expect(() => assertNoTrustBearingMacCodeSignature('enveloped.app', {
+    }, true)).toThrow(/inspection failed unexpectedly/);
+  });
+
+  /**
+   * Issue #66: the shape that shipped twice and would not launch.
+   *
+   * arm64 Mach-Os are ad-hoc signed by the linker whether anyone asks or not, so a bundle with no
+   * CodeResources is one whose executables claim a resource seal the bundle does not have. macOS
+   * reads that contradiction as damage — with Gatekeeper assessment already disabled, and no
+   * crash report to show for it. This assertion used to *demand* that state, which is why two
+   * releases shipped it and nothing caught them.
+   */
+  it('rejects a bundle whose executables are signed but which has no resource seal', () => {
+    expect(() => assertNoTrustBearingMacCodeSignature('linker-signed.app', {
+      status: 0,
+      stdout: '',
+      stderr: 'Identifier=com.example\nSignature=adhoc\nTeamIdentifier=not set\n'
+    }, false)).toThrow(/no bundle CodeResources envelope/);
+
+    // "Never signed at all" earns the same refusal. The seal is what macOS needs, and a packaged
+    // arm64 app cannot reach that state anyway — the linker signs it regardless.
+    expect(() => assertNoTrustBearingMacCodeSignature('unsigned.app', {
       status: 1,
       stdout: '',
       stderr: 'code object is not signed at all'
-    }, true)).toThrow(/CodeResources signature envelope/);
+    }, false)).toThrow(/no bundle CodeResources envelope/);
   });
 
   it('fails release-existence preflight closed on API errors instead of spending packaging runners', async () => {


### PR DESCRIPTION
Fixes #66 — the arm64 DMG opens to "the application is damaged" and never launches.

## The diagnosis

Gatekeeper assessment was already disabled on the reporting machine, so this was structural rather
than policy:

```
codesign --verify --deep --strict "Chat On Steroids.app"
-> code has no resources but signature indicates they must be present
codesign -dvv -> flags=0x20002(adhoc,linker-signed), Sealed Resources=none
```

`linker-signed` is the whole story. **Every arm64 Mach-O gets an ad-hoc signature from the linker
whether anyone asks or not** — it isn't optional on Apple Silicon. `identity: null` skips *bundle*
signing, so the app shipped as a bundle full of signed executables with no
`_CodeSignature/CodeResources`. macOS reads the signature on the executable, looks for the resource
seal it implies, finds none, and calls the bundle damaged.

## The fix

An `afterPack` hook re-seals the bundle ad-hoc and then verifies it.

**This does not weaken the unsigned policy.** An ad-hoc seal carries no `Authority` and no
`TeamIdentifier`; `codesign -dvv` still reports `Signature=adhoc`, and Gatekeeper still won't vouch
for it. It adds only the envelope the executables already claim exists — the bundle stops
contradicting itself. The hook fails the build if it ever produces something trust-bearing, so it
can't quietly turn into a signing change.

## Why it shipped twice

This is the part worth a look, because it wasn't really a packaging bug — it was an assertion:

```js
if (hasCodeResources) {
  throw new Error(`${file} unexpectedly has a bundle CodeResources signature envelope`);
}
```

The bundle audit **threw when the seal existed**, so the broken artifact was the compliant one and
nothing could ever catch it. That's now inverted — the seal is required — and the test grew a case
for the exact shape that shipped: ad-hoc executables, no resource envelope.

Trust and coherence are different axes. Only the first is the release policy, and it's still
enforced.

## What I could not check

I'm on Windows; `codesign` doesn't exist here. The hook is written from the report's diagnosis,
which is unusually complete, and the `--verify --deep --strict` step is deliberately *inside* the
build so a bad seal fails there rather than reaching a user.

@lavalava45 offered to test a candidate DMG on the affected machine — that's the check this wants
before it goes into a release, and it's the one thing I can't do from here.

`tsc` clean, suite green. (`exec-hints.test.ts` fails on my machine from PowerShell's execution
policy blocking `.ps1` files; it fails identically on a clean checkout of `main`.)
