### PR TITLE
Create the Compact & Resume successor inside its source Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ The app and the `extension/` companion are versioned together. **Reload the
 extension after updating the app**. If their bridge protocols are incompatible,
 the app refuses the extension and asks you to reload the matching copy.
 
+## Unreleased
+
+### Fixed
+- **Compact & Resume no longer drops the replacement chat outside its Project.** Starting a
+  handoff from a conversation inside a ChatGPT Project created the successor at the site root,
+  so the work continued outside the Project it belonged to. A Project is expressed only in the
+  address — `/g/<project>/c/<id>` — and a chat created from anywhere else is not in it, so the
+  successor's URL was the entire mechanism, and all three places that build one were hardcoded
+  to the root: the extension's window-bound placement, its background-window placement and the
+  app's own OS fallback. The Project is now read from the polling page's own address, written
+  onto the continuation so a restart or a closed tab cannot lose it, and used by all three.
+
+  Two things this deliberately does not do. It does not carry the slug it sees: a Project chat's
+  path has the Project's display name appended to its id, so only the `g-p-<id>` head is stored
+  and emitted, and renaming a Project cannot invalidate a stored address. And it never guesses —
+  a value that is not exactly that shape, including one from a record written before this
+  existed, opens at the root exactly as before rather than at an address assembled from it.
+
 ## [2.0.6] — 2026-09-06
 
 **I am exhausted.**

--- a/extension/background.js
+++ b/extension/background.js
@@ -2236,6 +2236,27 @@ function conversationFromUrl(value) {
   }
 }
 
+/**
+ * The ChatGPT Project a URL belongs to, or null.
+ *
+ * Mirrors chatgpt-dom.js::projectFromPath and src/main/session/continuation.ts's
+ * normalizeProjectId: only `g-p-` plus 32 hex digits counts. A Project chat's path appends the
+ * Project's display name to that id, so the name is stripped here rather than carried into an
+ * address that a rename would invalidate. Custom GPTs are also served from `/g/`, and their
+ * slugs do not have this shape, so they are correctly not Projects.
+ */
+function projectFromUrl(value) {
+  try {
+    const url = new URL(String(value || ''));
+    if (url.protocol !== 'https:' || (url.hostname !== 'chatgpt.com' && url.hostname !== 'chat.openai.com')) return null;
+    if (url.pathname.length > 512) return null;
+    const match = /^\/g\/(g-p-[0-9a-f]{32})(?:-[^/]*)?\//i.exec(url.pathname);
+    return match ? match[1].toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}
+
 function isChatGptUrl(value) {
   try {
     const url = new URL(String(value || ''));
@@ -2583,7 +2604,7 @@ const HANDLERS = {
     });
     return ownsDocument(source) ? result : { ok: false, error: 'stale_document' };
   },
-  async activity(message, _sender, source) {
+  async activity(message, sender, source) {
     await load();
     if (!ownsDocument(source)) return { ok: false, error: 'stale_document' };
     await noteTabConversation(source, message.conversationId);
@@ -2591,9 +2612,15 @@ const HANDLERS = {
     // Goal drafts are conversation-scoped in the app but browser writes are tab-scoped. Tell
     // the app which tab is polling so two tabs showing the same chat cannot both receive and
     // submit one ready Goal draft.
+    // Which Project this chat is being viewed in, read from the polling document's own
+    // address. Only the browser can see this, and the app needs it before a Compact & Resume
+    // opens the successor -- see issue #84. Always sent, including as empty for a chat at the
+    // root, so that moving a chat out of a Project is reported as clearly as moving it in.
+    const project = projectFromUrl(sender && sender.tab ? sender.tab.url : null) || '';
     const query =
       `?conversationId=${encodeURIComponent(message.conversationId)}` +
       `&since=${Number(message.since) || 0}` +
+      `&project=${encodeURIComponent(project)}` +
       `&goalClient=${encodeURIComponent(String(source.tab))}`;
     const result = await call(`/activity${query}`);
     if (ownsDocument(source) && result.ok && result.data && await acceptBrowserRevival(result.data.revival)) {
@@ -3150,6 +3177,26 @@ function deferredRevivalUrl(entry) {
  * locally either — when no redeem arrives the app opens it the old way, which is the only
  * recovery that still works if this window is closing.
  */
+/**
+ * Where a fresh chat has to be created so it lands in the right Project.
+ *
+ * `/g/<id>/project` is the Project's own page; a chat started from it belongs to that Project,
+ * which no query parameter can express. The app names the Project on the offer because it is
+ * the side that remembers one across a restart; `observed` is the tab this successor is being
+ * placed beside, used only when the offer carries nothing -- an older app, or a path that never
+ * had a continuation to record it on. Neither being usable means the site root, as before.
+ */
+function successorChatBase(offered, observed) {
+  const project = normalizedProjectId(offered) || projectFromUrl(observed);
+  return project ? `https://chatgpt.com/g/${project}/project` : 'https://chatgpt.com/';
+}
+
+/** Accepts only the Project routing identity itself; a display name is never part of it. */
+function normalizedProjectId(value) {
+  const candidate = String(value || '').trim().toLowerCase();
+  return /^g-p-[0-9a-f]{32}$/.test(candidate) ? candidate : null;
+}
+
 async function placeSuccessorChat(raw, tabId) {
   const id = commandMarkerId(raw && raw.id);
   if (id && raw.background === true) {
@@ -3159,7 +3206,7 @@ async function placeSuccessorChat(raw, tabId) {
     const query = [marker];
     if (model) query.push(`model=${encodeURIComponent(model)}`);
     if (effort) query.push(`reasoning_effort=${encodeURIComponent(effort)}`);
-    const created = await createChatTab(`https://chatgpt.com/?${query.join('&')}#${marker}`, true);
+    const created = await createChatTab(`${successorChatBase(raw.project, null)}?${query.join('&')}#${marker}`, true);
     if (Number.isInteger(created?.id)) {
       await chrome.tabs.update(created.id, { autoDiscardable: false });
       discardProtectedTabs[String(created.id)] = true;
@@ -3185,7 +3232,11 @@ async function placeSuccessorChat(raw, tabId) {
   const query = [marker];
   if (model) query.push(`model=${encodeURIComponent(model)}`);
   if (reasoningEffort) query.push(`reasoning_effort=${encodeURIComponent(reasoningEffort)}`);
-  const create = { url: `https://chatgpt.com/?${query.join('&')}#${marker}`, windowId: home.windowId, active: true };
+  const create = {
+    url: `${successorChatBase(raw && raw.project, home.url)}?${query.join('&')}#${marker}`,
+    windowId: home.windowId,
+    active: true
+  };
   // Directly after the chat it continues, so a handoff reads as one piece of work instead of a
   // tab appended to the far end of a long strip.
   if (typeof home.index === 'number') create.index = home.index + 1;

--- a/extension/chatgpt-dom.js
+++ b/extension/chatgpt-dom.js
@@ -291,6 +291,34 @@ var CLF_DOM = (() => {
     }, null);
   }
 
+  /**
+   * The Project a ChatGPT path belongs to, reduced to the identity ChatGPT itself routes by.
+   *
+   * A Project chat is served from `/g/<slug>/c/<id>`, and that slug is not the Project's
+   * identity: ChatGPT appends the Project's current display name to it, so the same Project
+   * reads as `g-p-<hex>-homelab-development` on a chat and as plain `g-p-<hex>` on the Project
+   * page itself. Carrying the chat's slug over to a Project URL verbatim therefore builds an
+   * address for a name that can be renamed out from under it. Only the `g-p-<hex>` head is
+   * stable, and it is what `/g/<id>/project` is addressed by.
+   *
+   * Strict on purpose. Anything that is not exactly this shape returns null, and every caller
+   * treats null as "open at the site root", which is what this app did everywhere before. A
+   * Project whose id is shaped differently therefore keeps today's behaviour rather than being
+   * sent to an address guessed from a pattern that was never observed.
+   *
+   * Length is bounded before the match: a path is attacker-influenced only in the sense that
+   * the user can visit anything, but an unbounded backtrackable pattern over a long path is a
+   * cost nobody needs to pay on every navigation.
+   */
+  function projectFromPath(pathname) {
+    return safe(() => {
+      const path = String(pathname || '');
+      if (path.length > 512) return null;
+      const match = /^\/g\/(g-p-[0-9a-f]{32})(?:-[^/]*)?\//i.exec(path);
+      return match ? match[1].toLowerCase() : null;
+    }, null);
+  }
+
   /** The conversation this tab is on, or null for a chat that has not been sent yet. */
   function conversationId() {
     return safe(() => conversationFromPath(location.pathname), null);
@@ -2013,6 +2041,7 @@ var CLF_DOM = (() => {
     },
     conversationId,
     conversationFromPath,
+    projectFromPath,
     conversationTitle,
     turns,
     presentationTurns,

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -156,6 +156,7 @@ import {
   supersededSourceConversations,
   dispatchContinuationDestinationSendNow,
   dispatchContinuationSourceSendNow,
+  normalizeProjectId,
   openContinuationNow,
   releaseContinuationDestinationSendNow,
   repairPrimeFromResumeShadow,
@@ -1186,7 +1187,7 @@ async function fileCompactionTicket(sessionId: string, id: string, automatic = f
   if (isChatBlocked(id)) throw new Error('chat_blocked');
   if (automatic && !automaticCompactionAllowed(await getSession(sessionId))) throw new Error('automatic_compaction_disabled');
   const existing = continuationForSession(sessionId);
-  const opened = existing ?? await openContinuationNow(sessionId, id, automatic);
+  const opened = existing ?? await openContinuationNow(sessionId, id, automatic, observedProject(id));
   rememberToken(sessionId, opened.token);
   changed();
   return { opened, started: !existing };
@@ -1782,6 +1783,9 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
     const since = Number(url.searchParams.get('since') ?? 0);
     const goalClient = (url.searchParams.get('goalClient') ?? '').slice(0, 100);
     if (!id) return json(res, 400, { error: 'bad_conversation_id' }, origin);
+    // Where this chat is being viewed, straight from the page's own address. Older extensions
+    // send nothing, which leaves whatever was already observed alone rather than clearing it.
+    if (url.searchParams.has('project')) noteConversationProject(id, url.searchParams.get('project'));
     const retiredWorker = retiredWorkerForConversation(id);
     const superseded = await conversationWasSuperseded(id);
     /**
@@ -2508,7 +2512,7 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
 
     let opened;
     try {
-      opened = await openContinuationNow(sessionId, id);
+      opened = await openContinuationNow(sessionId, id, false, observedProject(id));
     } catch (err) {
       logWarn(`bridge: could not durably open Compact & Resume for ${sessionId} — ${err instanceof Error ? err.message : String(err)}`);
       return json(res, 503, { error: 'continuation_not_durable', retryable: true, sessionId }, origin);
@@ -4596,13 +4600,53 @@ export function setBrowserOpener(open: ((url: string) => Promise<void>) | null):
   openInBrowser = open;
 }
 
+/**
+ * The Project each live chat is being viewed in, as last reported by its own page.
+ *
+ * Only the browser can see this: a Project is part of chat A's address, and nothing in the
+ * app's own record of a session says which Project it is filed under. The page reports it on
+ * the poll it already makes, and it is read once, when a continuation opens, and copied onto
+ * that continuation -- which is what survives a restart. This map is deliberately not durable:
+ * it is a cache of what a live page said a moment ago, and a page that is gone cannot be
+ * trusted to still describe where its chat lives.
+ *
+ * Bounded, because entries are only ever added by a chat being polled.
+ */
+const projectByConversation = new Map<string, string>();
+const MAX_OBSERVED_PROJECTS = 256;
+
+function noteConversationProject(conversationId: string, raw: string | null): void {
+  const project = normalizeProjectId(raw);
+  if (!project) {
+    // An explicit "not in a Project" is information too: a chat moved out of one must stop
+    // being remembered as in it. Only a malformed value is ignored rather than believed.
+    if (raw === null || raw === '') projectByConversation.delete(conversationId);
+    return;
+  }
+  if (!projectByConversation.has(conversationId) && projectByConversation.size >= MAX_OBSERVED_PROJECTS) {
+    const oldest = projectByConversation.keys().next();
+    if (!oldest.done) projectByConversation.delete(oldest.value);
+  }
+  projectByConversation.set(conversationId, project);
+}
+
+/** The Project a fresh chat opened for this conversation should be created in. */
+function observedProject(conversationId: string | null): string | null {
+  return conversationId ? projectByConversation.get(conversationId) ?? null : null;
+}
+
 /** The one place this app writes a ChatGPT conversation URL. */
 export function chatUrl(conversationId: string): string {
   return `https://chatgpt.com/c/${encodeURIComponent(conversationId)}`;
 }
 
 /** Where the app opens a fresh worker/resume chat. The marker is an id, not a credential. */
-export function commandUrl(id: string, model?: string | null, reasoningEffort?: ReasoningEffort | null): string {
+export function commandUrl(
+  id: string,
+  model?: string | null,
+  reasoningEffort?: ReasoningEffort | null,
+  project?: string | null
+): string {
   // Both a query and a fragment: ChatGPT is a single-page app that rewrites its own URL
   // during boot, and which of the two survives has changed between builds. The content
   // script accepts either, and redeeming still requires the extension's bearer token —
@@ -4613,11 +4657,19 @@ export function commandUrl(id: string, model?: string | null, reasoningEffort?: 
   // declared creation intent, forwarded independently: it never selects or changes the
   // model, and whether ChatGPT applies it is proven by the chat's own picker state, not
   // by this URL.
+  //
+  // A chat created inside a Project has to be started from that Project's own page, because
+  // the address is the only thing that says which Project a new conversation belongs to --
+  // issue #84. `/g/<id>/project` is that page. The id is normalized first, so a display name
+  // that happens to be in a stored value can never reach the path, and anything unrecognised
+  // falls back to the root exactly as before rather than to an address nobody has seen.
   const marker = `clf=${encodeURIComponent(id)}`;
   const params = [marker];
   if (model) params.push(`model=${encodeURIComponent(model)}`);
   if (reasoningEffort) params.push(`reasoning_effort=${encodeURIComponent(reasoningEffort)}`);
-  return `https://chatgpt.com/?${params.join('&')}#${marker}`;
+  const inProject = normalizeProjectId(project);
+  const base = inProject ? `https://chatgpt.com/g/${inProject}/project` : 'https://chatgpt.com/';
+  return `${base}?${params.join('&')}#${marker}`;
 }
 
 /**
@@ -4704,7 +4756,7 @@ export const BROWSER_PLACEMENT_MS = 20_000;
 let placementCollector: string | null = null;
 
 /** The one fresh chat currently offered to its home page, and the fallback that outlives it. */
-let placementOffer: { id: string; conversationId: string | null; model: string | null; reasoningEffort: ReasoningEffort | null } | null = null;
+let placementOffer: { id: string; conversationId: string | null; model: string | null; reasoningEffort: ReasoningEffort | null; project: string | null } | null = null;
 let placementTimer: NodeJS.Timeout | null = null;
 
 /** Drops the standing offer and its fallback. Called by every path that ends a command. */
@@ -4730,7 +4782,11 @@ function offerPlacement(command: Command): boolean {
     id: command.id,
     conversationId: backgroundWorker ? null : home,
     model: command.spec.type === 'worker' ? command.spec.model : null,
-    reasoningEffort: command.spec.type === 'worker' ? command.spec.reasoningEffort : null
+    reasoningEffort: command.spec.type === 'worker' ? command.spec.reasoningEffort : null,
+    // Named by the app so both placement paths agree. The extension can read the Project off
+    // the tab it is placing beside, but only for a chat it can still see; a background worker
+    // has no such tab, and the OS fallback below has none either.
+    project: commandProject(command)
   };
   placementTimer = setTimeout(() => {
     placementTimer = null;
@@ -4756,7 +4812,7 @@ function offerPlacement(command: Command): boolean {
  * a second one. If that page fails to act, the fallback above is what recovers it, not a
  * repeated offer.
  */
-function pendingBrowserPlacement(conversationId: string | null): { id: string; model: string | null; reasoningEffort: ReasoningEffort | null; background?: true } | null {
+function pendingBrowserPlacement(conversationId: string | null): { id: string; model: string | null; reasoningEffort: ReasoningEffort | null; project?: string; background?: true } | null {
   const offer = placementOffer;
   if (!offer || offer.conversationId !== conversationId) return null;
   if (!commands.some((entry) => entry.id === offer.id && entry.owner === null)) {
@@ -4764,7 +4820,13 @@ function pendingBrowserPlacement(conversationId: string | null): { id: string; m
     return null;
   }
   placementOffer = null;
-  return { id: offer.id, model: offer.model, reasoningEffort: offer.reasoningEffort, ...(offer.conversationId === null ? { background: true as const } : {}) };
+  return {
+    id: offer.id,
+    model: offer.model,
+    reasoningEffort: offer.reasoningEffort,
+    ...(offer.project ? { project: offer.project } : {}),
+    ...(offer.conversationId === null ? { background: true as const } : {})
+  };
 }
 
 // -------------------------------------------------------- exact browser recovery
@@ -4947,7 +5009,7 @@ async function considerAutomaticCompaction(conversationId: string, sessionId: st
     // Re-read after the awaits: the turn may have ended, or a page may have filed by hand.
     if (!chatIsWorking(conversationId) || continuationForSession(sessionId) || goalFencedChat(conversationId) ||
         !automaticCompactionAllowed(await getSession(sessionId))) return;
-    const opened = await openContinuationNow(sessionId, conversationId, true);
+    const opened = await openContinuationNow(sessionId, conversationId, true, observedProject(conversationId));
     rememberToken(sessionId, opened.token);
     changed();
     logInfo(
@@ -6651,6 +6713,19 @@ async function deliverOne(): Promise<void> {
  * running. It is also the fallback for an offer nobody collected, which is why it is reachable
  * from the placement timer as well as from delivery.
  */
+/**
+ * The Project a command's fresh chat belongs in, or null for the site root.
+ *
+ * Read from the continuation rather than from the live observation, because this is the path
+ * taken when the browser did not place the chat -- the tab is gone, or this process restarted
+ * and the map is empty. The continuation is what was written down at open time and is the only
+ * thing here that survives either.
+ */
+function commandProject(command: Command): string | null {
+  if (command.spec.type !== 'resume') return null;
+  return continuationByToken(command.spec.token)?.project ?? null;
+}
+
 async function openFreshChatInBrowser(command: Command): Promise<void> {
   if (!openInBrowser) {
     drop(command, 'this app has no way to open a browser window');
@@ -6664,7 +6739,7 @@ async function openFreshChatInBrowser(command: Command): Promise<void> {
     await openInBrowser(
       command.spec.type === 'worker'
         ? commandUrl(command.id, command.spec.model, command.spec.reasoningEffort)
-        : commandUrl(command.id)
+        : commandUrl(command.id, null, null, commandProject(command))
     );
   } catch (err) {
     // One command is one browser-open attempt. A rejected opener can never produce an ACK,

--- a/src/main/session/continuation.ts
+++ b/src/main/session/continuation.ts
@@ -145,6 +145,25 @@ export interface ContinuationDestinationCheckpoint extends ContinuationSendCheck
 export const sendUnattempted = (checkpoint: ContinuationSendCheckpoint): boolean =>
   checkpoint.state === 'not-attempted' || checkpoint.state === 'attempted-unresolved';
 
+/**
+ * The ChatGPT Project a successor chat must be created in, reduced to its routing identity.
+ *
+ * Mirrors chatgpt-dom.js::projectFromPath, which is the browser-side half of the same rule --
+ * the extension is plain JS and cannot import this. Both accept only `g-p-` followed by 32 hex
+ * digits, because that is the form ChatGPT addresses a Project page by. A Project chat's own
+ * path carries the display name appended to that id, and a renamed Project changes it, so the
+ * name is never part of what is stored or built.
+ *
+ * Anything else is null, and null everywhere means "open at the site root" -- exactly what this
+ * app did before Projects were carried at all. An unrecognised shape therefore degrades to the
+ * previous behaviour rather than to a guessed address.
+ */
+export function normalizeProjectId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const candidate = value.trim().toLowerCase();
+  return /^g-p-[0-9a-f]{32}$/.test(candidate) ? candidate : null;
+}
+
 interface Continuation {
   token: string;
   sessionId: string;
@@ -175,6 +194,14 @@ interface Continuation {
   claimedBy: string | null;
   /** Chat B while the durable commit is in flight; persisted for restart recovery. */
   to: string | null;
+  /**
+   * The Project chat A belongs to, so chat B is created in it too. Null for a chat at the root.
+   *
+   * Held here rather than only in the browser because the app opens the replacement itself
+   * whenever the extension does not -- an OS fallback, or a recovery after this process
+   * restarted -- and by then the tab that knew the Project may be gone.
+   */
+  project: string | null;
   sourceSend: ContinuationSendCheckpoint;
   destinationSend: ContinuationDestinationCheckpoint;
   error: string | null;
@@ -198,6 +225,8 @@ interface ContinuationRecord {
   automatic?: boolean;
   /** Absent in records written before automatic handovers had a deadline. */
   askedAt?: number | null;
+  /** Absent in records written before Project affinity was carried; null means the site root. */
+  project?: string | null;
   state: ContinuationState;
   summary: string;
   handoffId: string | null;
@@ -225,6 +254,7 @@ function durableRecord(entry: Continuation): ContinuationRecord {
     openedAt: entry.openedAt,
     automatic: entry.automatic,
     askedAt: entry.askedAt,
+    project: entry.project,
     state: entry.state,
     summary: entry.summary.slice(0, 512 * 1024),
     handoffId: entry.handoffId,
@@ -344,6 +374,8 @@ export interface ContinuationView {
   automatic: boolean;
   /** When the brief request first went on its way, or null while it has not. */
   askedAt: number | null;
+  /** The Project the replacement chat belongs in, or null for the site root. */
+  project: string | null;
   sourceSend: ContinuationSendCheckpoint;
   destinationSend: ContinuationDestinationCheckpoint;
 }
@@ -359,6 +391,7 @@ const view = (entry: Continuation): ContinuationView => ({
   openedAt: entry.openedAt,
   automatic: entry.automatic,
   askedAt: entry.askedAt,
+  project: entry.project,
   sourceSend: { ...entry.sourceSend },
   destinationSend: { ...entry.destinationSend }
 });
@@ -622,11 +655,12 @@ export async function repairPrimeFromResumeShadow(conversationId: string): Promi
  * one already running. That is deliberate — the previous design let each press become its
  * own handoff and its own fresh tab.
  */
-function makeContinuation(sessionId: string, fromConversationId: string, automatic: boolean): Continuation {
+function makeContinuation(sessionId: string, fromConversationId: string, automatic: boolean, project: string | null): Continuation {
   return {
     token: randomBytes(16).toString('base64url'),
     sessionId,
     from: fromConversationId,
+    project,
     openedAt: Date.now(),
     automatic,
     askedAt: null,
@@ -647,7 +681,8 @@ function makeContinuation(sessionId: string, fromConversationId: string, automat
 export async function openContinuationNow(
   sessionId: string,
   fromConversationId: string,
-  automatic = false
+  automatic = false,
+  project: string | null = null
 ): Promise<ContinuationView> {
   sweep();
   const existing = [...byToken.values()].find((entry) => entry.sessionId === sessionId && isOpen(entry));
@@ -658,7 +693,7 @@ export async function openContinuationNow(
   const work = (async (): Promise<ContinuationView> => {
     const again = [...byToken.values()].find((entry) => entry.sessionId === sessionId && isOpen(entry));
     if (again) return view(again);
-    const entry = makeContinuation(sessionId, fromConversationId, automatic);
+    const entry = makeContinuation(sessionId, fromConversationId, automatic, normalizeProjectId(project));
     try {
       await writeDurableNow(CONTINUATIONS_STATE, snapshotWith(entry.token, durableRecord(entry)));
     } catch (err) {
@@ -1378,6 +1413,7 @@ export async function restoreContinuations(snapshot: ContinuationSnapshot | null
       from: raw.from,
       to: typeof raw.to === 'string' && raw.to ? raw.to : null,
       openedAt: raw.openedAt,
+      project: normalizeProjectId(raw.project),
       automatic: raw.automatic === true,
       askedAt: null,
       state: raw.state,

--- a/test/project-successor.test.ts
+++ b/test/project-successor.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Compact & Resume has to create the replacement chat inside the Project the source chat is in.
+ *
+ * A ChatGPT Project is expressed only in the address. `/g/<project>/c/<id>` is a chat filed
+ * under a Project, and a conversation created from anywhere else is not in it — there is no
+ * parameter, header or later call that moves it. So the successor's URL is the whole mechanism,
+ * and issue #84 is that all three places that build one hardcoded the site root.
+ *
+ * Two details drive most of what is asserted here:
+ *
+ * The slug in a chat's path is not the Project's identity. ChatGPT appends the Project's current
+ * display name to it, so the same Project reads as `g-p-<hex>-homelab-development` on a chat and
+ * as `g-p-<hex>` on the Project's own page. Carrying the chat's slug across verbatim would build
+ * an address containing a name that a rename invalidates, so only the `g-p-<hex>` head is ever
+ * stored or emitted.
+ *
+ * And the browser is the only thing that can see it, while the app is the only thing that
+ * survives a restart. That is why the Project is observed from the page, written onto the
+ * continuation, and read back from there by the fallback that runs when no page is left.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isAsyncEncryptionAvailable: async () => true,
+    getSelectedStorageBackend: () => 'gnome_libsecret',
+    encryptStringAsync: async (value: string) => Buffer.from(value, 'utf8'),
+    decryptStringAsync: async (buffer: Buffer) => ({ result: buffer.toString('utf8'), shouldReEncrypt: false })
+  },
+  clipboard: { readText: () => '', writeText: () => undefined },
+  shell: { openExternal: async () => undefined }
+}));
+
+const { defaultConfig, initConfigPath, saveConfig } = await import('../src/main/config.js');
+const { commandUrl } = await import('../src/main/bridge.js');
+const {
+  continuationByToken,
+  normalizeProjectId,
+  openContinuationNow,
+  resetContinuationsForTests,
+  restoreContinuations,
+  snapshotContinuations
+} = await import('../src/main/session/continuation.js');
+const { createSession, initSessionStore, resetSessionStoreForTests } = await import('../src/main/session/store.js');
+const { makeTempDir, removeTempDir } = await import('./helpers.js');
+
+let dir: string;
+
+const vm = await import('node:vm');
+const { readFileSync } = await import('node:fs');
+
+const backgroundSource = readFileSync(new URL('../extension/background.js', import.meta.url), 'utf8');
+// The worker is evaluated as a classic script, where an ES import is a parse error. There is
+// none today; strip any that appears rather than failing on a change unrelated to this file,
+// and supply the binding through the context, as test/extension.test.ts does.
+const workerSource = backgroundSource.replace(/^import .*$/gm, '');
+
+
+/** The exact identifiers from a real account, so the shapes here are observed and not invented. */
+const PROJECT = 'g-p-6a93d6fe7f008191be6262248831c7d9';
+const NAMED_SLUG = 'g-p-6a93d6fe7f008191be6262248831c7d9-homelab-development';
+const CHAT_IN_PROJECT = '6a99ae79-c0e4-83eb-943b-84279bddd81c';
+const CHAT_A = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+beforeAll(async () => {
+  dir = await makeTempDir('clf-project-successor-');
+  initConfigPath(dir);
+  initSessionStore(dir);
+  await saveConfig(defaultConfig());
+});
+
+afterAll(async () => {
+  await removeTempDir(dir);
+});
+
+beforeEach(async () => {
+  resetContinuationsForTests();
+  await resetSessionStoreForTests();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('the Project identity carried between a chat and its successor', () => {
+  it('accepts only the routing id, and never the display name appended to it', () => {
+    expect(normalizeProjectId(PROJECT)).toBe(PROJECT);
+    // The form that actually appears in a Project chat's own path. Normalising it is the whole
+    // point: the app stores what `/g/<id>/project` is addressed by, not what a rename can change.
+    expect(normalizeProjectId(NAMED_SLUG)).toBeNull();
+    expect(normalizeProjectId(PROJECT.toUpperCase())).toBe(PROJECT);
+  });
+
+  it.each([
+    ['a custom GPT, which is served from /g/ but is not a Project', 'g-abc123def456'],
+    ['a path segment escape', `${PROJECT}/../../etc`],
+    ['a query smuggled into the id', `${PROJECT}?x=1`],
+    ['too few hex digits', 'g-p-6a93d6fe7f008191be6262248831c7d'],
+    ['too many hex digits', 'g-p-6a93d6fe7f008191be6262248831c7d9a'],
+    ['non-hex characters', 'g-p-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'],
+    ['an empty value', ''],
+    ['a non-string', 42]
+  ])('refuses %s', (_why, value) => {
+    expect(normalizeProjectId(value)).toBeNull();
+  });
+});
+
+describe('the URL the app opens when no page places the chat', () => {
+  it('starts a successor from the Project page so the new chat is created inside it', () => {
+    const url = commandUrl('cmd-1', null, null, PROJECT);
+    expect(url.startsWith(`https://chatgpt.com/g/${PROJECT}/project?`)).toBe(true);
+    // The marker still rides in both places, for the same reason it always did: ChatGPT
+    // rewrites its own query during boot and which of the two survives has changed between
+    // builds. Carrying a Project must not quietly cost the fragment.
+    expect(url).toContain('clf=cmd-1');
+    expect(url.endsWith('#clf=cmd-1')).toBe(true);
+  });
+
+  it('keeps opening at the site root for a chat that is in no Project', () => {
+    expect(commandUrl('cmd-2')).toBe('https://chatgpt.com/?clf=cmd-2#clf=cmd-2');
+    expect(commandUrl('cmd-2', null, null, null)).toBe('https://chatgpt.com/?clf=cmd-2#clf=cmd-2');
+  });
+
+  it('falls back to the root rather than building an address from an unusable value', () => {
+    // Degrading to exactly the old behaviour is the point. A value this app does not recognise
+    // must never become a path, because a wrong Project page is worse than no Project at all.
+    for (const bad of [NAMED_SLUG, 'g-abc123', '../evil', `${PROJECT}/x`, '']) {
+      expect(commandUrl('cmd-3', null, null, bad)).toBe('https://chatgpt.com/?clf=cmd-3#clf=cmd-3');
+    }
+  });
+
+  it('carries a Project alongside a requested model and reasoning level', () => {
+    const url = commandUrl('cmd-4', 'gpt-5.6-sol', 'high', PROJECT);
+    expect(url.startsWith(`https://chatgpt.com/g/${PROJECT}/project?`)).toBe(true);
+    expect(url).toContain('model=gpt-5.6-sol');
+    expect(url).toContain('reasoning_effort=high');
+  });
+});
+
+describe('the Project surviving a restart', () => {
+  it('writes the Project onto the continuation and restores it', async () => {
+    const session = await createSession({ title: 'Compacting inside a Project', conversationId: CHAT_A });
+    const opened = await openContinuationNow(session.id, CHAT_A, false, PROJECT);
+    expect(opened.project).toBe(PROJECT);
+
+    // The process ends here. Nothing in the app's own session record says which Project the
+    // chat is filed under, and the tab that could have said so is gone with the browser.
+    const snapshot = snapshotContinuations();
+    resetContinuationsForTests();
+    expect(continuationByToken(opened.token)).toBeNull();
+
+    await restoreContinuations(snapshot);
+    expect(continuationByToken(opened.token)?.project).toBe(PROJECT);
+    expect(commandUrl('cmd-5', null, null, continuationByToken(opened.token)?.project)).toContain(
+      `/g/${PROJECT}/project?`
+    );
+  });
+
+  it('opens a non-Project chat with no Project, before and after a restart', async () => {
+    const session = await createSession({ title: 'Compacting at the root', conversationId: CHAT_A });
+    const opened = await openContinuationNow(session.id, CHAT_A, false, null);
+    expect(opened.project).toBeNull();
+
+    const snapshot = snapshotContinuations();
+    resetContinuationsForTests();
+    await restoreContinuations(snapshot);
+    expect(continuationByToken(opened.token)?.project).toBeNull();
+  });
+
+  it('reads a record written before Project affinity existed as no Project', async () => {
+    const session = await createSession({ title: 'Older record', conversationId: CHAT_A });
+    const opened = await openContinuationNow(session.id, CHAT_A, false, PROJECT);
+    const snapshot = JSON.parse(JSON.stringify(snapshotContinuations()));
+    // Exactly what an older build wrote: the field is simply not there.
+    for (const entry of snapshot.entries) delete entry.project;
+
+    resetContinuationsForTests();
+    await restoreContinuations(snapshot);
+    // Restored and usable, just without a Project — never dropped, and never a crash.
+    expect(continuationByToken(opened.token)).not.toBeNull();
+    expect(continuationByToken(opened.token)?.project).toBeNull();
+  });
+
+  it('refuses a Project value that a tampered or corrupt record carries', async () => {
+    const session = await createSession({ title: 'Corrupt record', conversationId: CHAT_A });
+    const opened = await openContinuationNow(session.id, CHAT_A, false, PROJECT);
+    const snapshot = JSON.parse(JSON.stringify(snapshotContinuations()));
+    for (const entry of snapshot.entries) entry.project = `${PROJECT}/../../../attacker`;
+
+    resetContinuationsForTests();
+    await restoreContinuations(snapshot);
+    // The continuation is still honoured; only the unusable Project is dropped, which puts the
+    // successor back at the root instead of at an address assembled from a stored string.
+    expect(continuationByToken(opened.token)).not.toBeNull();
+    expect(continuationByToken(opened.token)?.project).toBeNull();
+  });
+
+  it('normalizes at the boundary, so a named slug never reaches a stored record', async () => {
+    const session = await createSession({ title: 'Named slug offered', conversationId: CHAT_A });
+    const opened = await openContinuationNow(session.id, CHAT_A, false, NAMED_SLUG);
+    expect(opened.project).toBeNull();
+  });
+});
+
+describe('the parsers on both sides of the bridge agree', () => {
+  it('reduces a Project chat path and the Project page path to the same identity', async () => {
+    const { readFileSync } = await import('node:fs');
+    const read = (rel: string) => readFileSync(new URL(`../${rel}`, import.meta.url), 'utf8');
+
+    // The extension is plain JS and cannot import the app's normalizer, so the rule exists in
+    // three places. What keeps them honest is that all three name the same shape; a change to
+    // one that is not made to the others shows up here rather than in a lost Project.
+    const shape = 'g-p-[0-9a-f]{32}';
+    expect(read('extension/chatgpt-dom.js')).toContain(shape);
+    expect(read('extension/background.js')).toContain(shape);
+    expect(read('src/main/session/continuation.ts')).toContain(shape);
+
+    // And the extension's placement builds the same Project page address the app does.
+    expect(read('extension/background.js')).toContain('https://chatgpt.com/g/${project}/project');
+  });
+});
+
+/**
+ * The path the reported bug actually takes.
+ *
+ * Compact & Resume names chat A's own conversation on its placement offer, so the successor is
+ * created by the extension in chat A's window — not by the OS opener. Asserted by running the
+ * real service worker and reading the tab it creates, because the whole failure was that a URL
+ * built correctly everywhere else was still built at the root here.
+ */
+describe('the chat the extension creates beside its source', () => {
+  type Created = { id: number; url?: string; pendingUrl?: string; windowId?: number; index?: number };
+  interface Probe {
+    placeSuccessorChat(raw: unknown, tabId: number | null): Promise<void>;
+    projectFromUrl(value: unknown): string | null;
+    successorChatBase(offered: unknown, observed: unknown): string;
+  }
+
+  function worker(home: Created | null) {
+    const created: Created[] = [];
+    const tabs: Created[] = home ? [home] : [];
+    const event = { addListener: () => {} };
+    const store = (saved: Record<string, unknown>) => ({
+      get: async () => ({ ...saved }),
+      set: async (value: object) => { Object.assign(saved, value); },
+      remove: async () => {}
+    });
+    const makeTab = async (options: Created) => {
+      const tab = { ...options, id: 100 + created.length };
+      created.push(tab);
+      return tab;
+    };
+    const context = vm.createContext({
+      chrome: {
+        storage: { local: store({ port: 8765, token: 'test-pairing' }), session: store({}) },
+        windows: {
+          get: async (id: number) => ({ id }),
+          // The minimized window a background worker chat is created in, with its first tab.
+          create: async ({ url }: { url: string }) => ({ id: 80, tabs: [await makeTab({ url, windowId: 80 } as Created)] }),
+          update: () => {}
+        },
+        tabs: {
+          query: async () => [...tabs],
+          get: async (id: number) => {
+            const tab = tabs.find(entry => entry.id === id);
+            if (!tab) throw new Error('no such tab');
+            return tab;
+          },
+          create: makeTab,
+          update: async () => undefined,
+          remove: async () => undefined,
+          sendMessage: async () => ({ ok: true }),
+          onCreated: event, onUpdated: event, onRemoved: event
+        },
+        runtime: { getManifest: () => ({ version: '2.0.6' }), onMessage: event, onInstalled: event, onStartup: event },
+        alarms: { onAlarm: event, create: () => {}, clear: async () => true },
+        scripting: { executeScript: async () => [], insertCSS: async () => {} }
+      },
+      fetch: async () => ({ ok: true, status: 200, json: async () => ({ ok: true }) }),
+      URL, URLSearchParams, AbortController, setTimeout, clearTimeout, TextEncoder, console,
+      browserDriverModule: { installBrowserDriverLifecycle() {}, sweepStaleDrivenGroups: async () => {} }
+    });
+    vm.runInContext(`${workerSource}
+globalThis.probe = { placeSuccessorChat, projectFromUrl, successorChatBase };`, context);
+    return { api: (context as unknown as { probe: Probe }).probe, created };
+  }
+
+  const chatInProject = `https://chatgpt.com/g/${NAMED_SLUG}/c/${CHAT_IN_PROJECT}`;
+  const offer = (extra: Record<string, unknown> = {}) => ({ id: 'cmd-9', model: null, reasoningEffort: null, ...extra });
+
+  it('creates the successor on the Project page when the source chat is in one', async () => {
+    const h = worker({ id: 7, url: chatInProject, windowId: 3, index: 1 });
+    await h.api.placeSuccessorChat(offer({ project: PROJECT }), 7);
+    expect(h.created).toHaveLength(1);
+    expect(h.created[0]!.url!.startsWith(`https://chatgpt.com/g/${PROJECT}/project?`)).toBe(true);
+    expect(h.created[0]!.url).toContain('clf=cmd-9');
+    // Still beside the chat it continues, and still in that chat's own window.
+    expect(h.created[0]!.windowId).toBe(3);
+    expect(h.created[0]!.index).toBe(2);
+  });
+
+  it('recovers the Project from the source tab when the offer names none', async () => {
+    // An app that predates the offer field, or a path with no continuation to record it on.
+    const h = worker({ id: 7, url: chatInProject, windowId: 3, index: 0 });
+    await h.api.placeSuccessorChat(offer(), 7);
+    expect(h.created[0]!.url!.startsWith(`https://chatgpt.com/g/${PROJECT}/project?`)).toBe(true);
+  });
+
+  it('trusts the app over the tab, because only the app remembers across a restart', async () => {
+    // Chat A has already been navigated away to the root in this tab; the offer is still right.
+    const h = worker({ id: 7, url: 'https://chatgpt.com/', windowId: 3, index: 0 });
+    await h.api.placeSuccessorChat(offer({ project: PROJECT }), 7);
+    expect(h.created[0]!.url!.startsWith(`https://chatgpt.com/g/${PROJECT}/project?`)).toBe(true);
+  });
+
+  it('creates a background worker chat in the Project the app named', async () => {
+    const h = worker(null);
+    await h.api.placeSuccessorChat(offer({ project: PROJECT, background: true }), null);
+    expect(h.created[0]!.url!.startsWith(`https://chatgpt.com/g/${PROJECT}/project?`)).toBe(true);
+  });
+
+  it('leaves a chat outside any Project exactly where it was created before', async () => {
+    const h = worker({ id: 7, url: `https://chatgpt.com/c/${CHAT_IN_PROJECT}`, windowId: 3, index: 0 });
+    await h.api.placeSuccessorChat(offer(), 7);
+    expect(h.created[0]!.url!.startsWith('https://chatgpt.com/?')).toBe(true);
+  });
+
+  it('refuses a named slug and an unrelated /g/ route from either source', () => {
+    // A custom GPT is served from /g/ too and is not a Project.
+    expect(h1(`https://chatgpt.com/g/g-abc123/c/${CHAT_IN_PROJECT}`)).toBeNull();
+    expect(h1(`http://chatgpt.com/g/${NAMED_SLUG}/c/x`)).toBeNull();
+    expect(h1(`https://evil.example/g/${NAMED_SLUG}/c/x`)).toBeNull();
+    expect(h1(chatInProject)).toBe(PROJECT);
+
+    const { api } = worker(null);
+    // The display-name form is refused as an offered value and falls back to what was observed.
+    expect(api.successorChatBase(NAMED_SLUG, chatInProject)).toBe(
+      `https://chatgpt.com/g/${PROJECT}/project`
+    );
+    expect(api.successorChatBase(NAMED_SLUG, null)).toBe('https://chatgpt.com/');
+  });
+
+  function h1(url: string): string | null {
+    return worker(null).api.projectFromUrl(url);
+  }
+});


### PR DESCRIPTION
Fixes #84.

A ChatGPT Project is expressed only in the address. `/g/<project>/c/<id>` is a chat filed under
one, and a conversation created from anywhere else is not in it — no parameter, header or later
call moves it there. So the successor's URL *is* the mechanism, and all three places that build
one opened at the site root:

| | |
|---|---|
| `extension/background.js` `placeSuccessorChat()` | window-bound placement — the path Compact & Resume actually takes |
| the same function's `background: true` branch | a worker chat in the minimized window |
| `src/main/bridge.ts` `commandUrl()` | the app's OS fallback, and restart recovery |

### How the Project gets from chat A to chat B

Only the browser can see it, and only the app survives a restart, so it travels between them:
the page reports it on the `/activity` poll it already makes, the app writes it onto the
continuation, and all three builders read it from there. The extension prefers the value the app
names — that is the one that outlives a tab — and falls back to reading the tab it is placing
beside. The OS fallback reads the continuation, because by the time it runs there may be no tab
at all.

### The slug is not what gets carried

This is the part worth reviewing closely. A Project chat's path has the Project's **current
display name appended to its id**:

```
chat in a Project   /g/g-p-<32 hex>-homelab-development/c/<conversation>
the Project itself  /g/g-p-<32 hex>/project
```

Copying the slug out of chat A verbatim would build an address containing a name that a rename
invalidates. Only the `g-p-<hex>` head — what `/g/<id>/project` is addressed by — is ever stored
or emitted, and normalization happens at the boundary so a display-name form cannot reach a
durable record even if something offers one.

### Nothing is guessed

Anything that is not exactly `g-p-` plus 32 hex digits opens at the root, exactly as before: a
record written by an older build, a corrupt or tampered one, a custom GPT's `/g/` slug (custom
GPTs are served from `/g/` too and are not Projects), a display-name form, a path-escape attempt.

Degrading to the previous behaviour is deliberate. A Project this app does not recognise costs
the user what they have today; an address assembled from a value it does not understand could
cost them something worse.

### Verification

25 tests in `test/project-successor.test.ts`, covering the five cases the issue asks for:
extension placement (both windows), OS fallback, restart recovery, unchanged non-Project
behaviour, and rejected route input — plus old-record and corrupt-record migration.

The placement tests drive the **real service worker** in a VM and read the tab it creates, rather
than asserting on source text. Checked the way that matters: they fail against the previous
`background.js` and pass against this one.

`npm run typecheck` clean. Full suite: 2946 passing. Two failures remain and both reproduce
identically on a pristine `main` checkout in the same environment — PowerShell execution policy
blocking `.ps1`, and a locale that formats decimals with a comma.

### One thing I could not verify from here

The route shapes are taken from a real account rather than invented, and both are in the tests as
constants. What is **not** machine-verified is the last step: that opening `/g/<id>/project?clf=…`
and sending actually files the new conversation under that Project. It is the address ChatGPT
serves the Project page from, and the bootstrap is path-agnostic — the marker is read from the
query and fragment, and `conversationFromPath()` correctly reports no conversation there, exactly
as at the root — so there is no reason it should behave differently. But it wants one real
Compact & Resume from inside a Project to confirm, and I would rather say so than imply otherwise.

If it turns out ChatGPT needs a different entry point, only `successorChatBase()` and
`commandUrl()` change; the capture, persistence and fallback behaviour are independent of it.
