### PR TITLE
Expose per-worker model and reasoning on the agents schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ The app and the `extension/` companion are versioned together. **Reload the
 extension after updating the app**. If their bridge protocols are incompatible,
 the app refuses the extension and asks you to reload the matching copy.
 
+## Unreleased
+
+### Fixed
+- **A prime can choose each worker's model and reasoning level again.** The broker has accepted
+  per-worker `model` and `reasoning_effort` for some time — validating both before creating
+  anything, failing the whole spawn on an unrecognised value, carrying them on the worker's
+  fresh-chat URL, and reporting them in spawn receipts and status — and `docs/tool-surface.md`
+  documented them as available. The `agents` input schema never exposed them: its `workers`
+  object is `.strict()` and declared only `label` and `task`, so a spawn naming a model was
+  rejected outright rather than honoured, and the task description told the caller the opposite,
+  that model and reasoning were fixed in app settings. Both fields are now on the schema, with
+  `reasoning_effort` declared as the canonical vocabulary so a caller can discover it instead of
+  guessing. Omitting them is unchanged: the default from app settings, or the account default.
+
 ## [2.0.6] — 2026-09-06
 
 **I am exhausted.**

--- a/docs/tool-surface.md
+++ b/docs/tool-surface.md
@@ -111,9 +111,11 @@ Available while multi-agent mode is enabled. It has exactly four actions:
   on a limited model can spawn workers on a cheaper one. Omitted means the account default;
   a slug ChatGPT does not recognise opens with the default too. The model is fixed for the
   life of that conversation, including across sleep/wake reuse. Each worker also takes an
-  optional `reasoning_effort`: none, minimal, low, medium, high, xhigh, max or ultra, forwarded
-  on the open URL independently of `model` — a level never selects or changes the model, and
-  omitting both inherits the normal worker defaults.
+  optional `reasoning_effort`: pro, none, minimal, low, medium, high, xhigh, max or ultra,
+  forwarded on the open URL independently of `model` — a level never selects or changes the
+  model, and omitting either inherits the default set in app settings, or the account default
+  when no setting is chosen. The vocabulary is the one in `shared/session.ts`; `pro` is the
+  ChatGPT browser Power tier and is listed here because a worker is a real browser chat.
 - `message` sends one message or an all-or-nothing batch. Messaging a sleeping worker is what
   wakes it, in the chat it already has.
 - `status` reports the run and workers, including who is asleep and how many worker slots are free.

--- a/src/main/mcp/tools-core.ts
+++ b/src/main/mcp/tools-core.ts
@@ -34,6 +34,7 @@ import { SandboxError, isNativeWindowsPath, resolvePath, strayVirtualPath } from
 import { currentWorkspace } from '../workspace.js';
 import type { Capabilities, Root } from '../../shared/types.js';
 import type { FileChange } from '../../shared/session.js';
+import { REASONING_EFFORTS } from '../../shared/session.js';
 import { DEFAULT_EXCLUDES, MAX_CONTENT_FILE_BYTES, globToRegExp, search, searchOneFile } from '../search.js';
 import {
   ApplyPatchError,
@@ -1080,7 +1081,20 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
                 .min(1)
                 .max(4000)
                 .describe(
-                  'This worker\'s job: objective, relevant files, constraints and expected handoff. Model and reasoning are predefined by the user in app settings.'
+                  'This worker\'s job: objective, relevant files, constraints and expected handoff.'
+                ),
+              model: z
+                .string()
+                .max(80)
+                .optional()
+                .describe(
+                  'ChatGPT model slug for this worker only, e.g. to keep an expensive model for yourself. Omit for the default set in app settings.'
+                ),
+              reasoning_effort: z
+                .enum(REASONING_EFFORTS)
+                .optional()
+                .describe(
+                  'How much reasoning this worker uses. Independent of model: it never selects or changes one. Omit for the default set in app settings.'
                 )
             }).strict()
           )

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -169,6 +169,7 @@ async function call(surface: SurfaceId, method: string, params: unknown = {}): P
 const core = (method: string, params: unknown = {}): Promise<any> => call('core', method, params);
 const desktop = (method: string, params: unknown = {}): Promise<any> => call('desktop', method, params);
 
+const { REASONING_EFFORTS } = await import('../src/shared/session.js');
 const PROTOCOL_2026 = '2026-07-28';
 const META_VERSION = 'io.modelcontextprotocol/protocolVersion';
 const META_CAPABILITIES = 'io.modelcontextprotocol/clientCapabilities';
@@ -630,6 +631,39 @@ describe('surface boundaries', () => {
     // And an ordinary read from a worker's chat carries nothing at all.
     const call1 = await core('tools/call', { name: 'read', arguments: { paths: ['/workspace/src/app.ts'] } });
     expect(failed(call1)).toBe(false);
+  });
+
+  /**
+   * The prime has to be able to say which model each worker gets — issue #67.
+   *
+   * The broker has accepted per-worker `model` and `reasoning_effort` for a while, validates
+   * both before creating anything, and has tests for the rejection path. What it did not have
+   * was any way for a caller to send them: the `workers` object is `.strict()`, so a spawn
+   * naming a model was rejected outright rather than honoured. This asserts the surface, since
+   * that gate is the one seam the broker's own tests cannot see.
+   */
+  it('lets a spawn choose a model and reasoning level per worker', async () => {
+    everything();
+    const agentsTool = toolList(await core('tools/list')).find((tool) => tool.name === 'agents')!;
+    const worker = agentsTool.inputSchema.properties.workers.items;
+
+    expect(Object.keys(worker.properties).sort()).toEqual(['label', 'model', 'reasoning_effort', 'task']);
+    // Only `task` is required: omitting both keeps exactly the previous behaviour, which is
+    // the account default, or whatever the user chose in settings.
+    expect(worker.required).toEqual(['task']);
+    expect(worker.additionalProperties).toBe(false);
+
+    // Declared as an enum so the caller can discover the vocabulary instead of guessing at it
+    // and having the spawn fail. `pro` belongs here: a worker is a real ChatGPT browser chat.
+    expect(worker.properties.reasoning_effort.enum).toEqual([...REASONING_EFFORTS]);
+    expect(worker.properties.model.type).toBe('string');
+
+    // The task description used to tell the model the opposite — that model and reasoning were
+    // fixed in app settings. A caller that believes that will never pass either field.
+    expect(worker.properties.task.description).not.toMatch(/predefined by the user/i);
+    for (const field of ['model', 'reasoning_effort']) {
+      expect(worker.properties[field].description, field).toMatch(/app settings/i);
+    }
   });
 
   it('removes the agents tool entirely once multi-agent is switched off', async () => {


### PR DESCRIPTION
Fixes #67.

Almost all of this already exists on `main`. What is missing is the only part a caller can see.

### What is already there

`planSpawn` in `src/main/agents.ts` reads `worker.model` and `worker.reasoning_effort` **per
worker**, falling back to the app-settings default when they are absent:

```ts
const model = normalizeModel(index, worker.model === undefined ? getConfig().multiAgent.defaultModel : worker.model);
const reasoningEffort = normalizeReasoningEffort(index, worker.reasoning_effort === undefined ? getConfig().multiAgent.defaultReasoning : worker.reasoning_effort);
```

`normalizeModel` and `normalizeReasoningEffort` throw an `AgentError` naming the worker index
before anything is created — so an unrecognised value fails the whole spawn with zero workers,
which is exactly what the issue asked for and is already covered by tests
(`rejects an unknown reasoning_effort with zero workers created`, and the model equivalent). Both
values ride the worker's fresh-chat URL and appear in spawn receipts and `status`.
`docs/tool-surface.md` documents both fields as available.

### What was wrong

The `workers` object in the `agents` input schema is `.strict()` and declared `label` and `task`
only. So a spawn naming a model was **rejected by the schema** rather than honoured — and the
`task` description told the caller the opposite:

> *"Model and reasoning are predefined by the user in app settings."*

Documentation, implementation and tests all said this feature existed. The surface said it did
not, and the surface is what the model reads.

### The change

Both fields are declared on the schema, and that sentence is removed from `task`.

`reasoning_effort` is an `enum` over `REASONING_EFFORTS` rather than a free string, so a caller
can discover the levels instead of guessing at one and having its spawn fail. That constant is
already described in `shared/session.ts` as the single vocabulary authority the broker, the
bridge restore and the extension all check against — using it here means the surface cannot drift
from what is accepted. `model` stays a bounded free slug, validated where it always was.

Omitting either field is unchanged in every respect: the default the user chose in settings, or
the account default when they chose none. Nothing in the broker moved.

The documented level list gains `pro`, which the broker has always accepted and the docs did not
mention — a worker is a real ChatGPT browser chat, so the browser Power tier belongs in its
vocabulary.

### Verification

`npm run typecheck` clean. 2922 passing. The two failures left are environmental and reproduce
identically on a pristine `main` checkout here: PowerShell execution policy blocking `.ps1`, and
a locale that formats decimals with a comma.

The new test asserts the *surface* rather than the broker, since that gate is the one seam the
broker's own tests cannot see — required fields, `additionalProperties: false`, the enum matching
the shared vocabulary, and that the task description no longer contradicts it. It fails against
the previous schema with `expected [ 'label', 'task' ] to deeply equal [ 'label', 'model', … ]`.

### On #68

@JeshuaCastro's PR #68 proposed this feature end to end and now conflicts with `main`. Much of
what it described — the spec fields, the URL transport, the receipts, the strict pre-mutation
validation — is on `main` already, so if this lands, what remains of #68 is worth checking
against it rather than rebasing wholesale.
