### PR TITLE
Add a settings field for your own connector instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ The app and the `extension/` companion are versioned together. **Reload the
 extension after updating the app**. If their bridge protocols are incompatible,
 the app refuses the extension and asks you to reload the matching copy.
 
+## Unreleased
+
+### Added
+- **Your own instructions for the connectors.** A settings field whose text is appended to what
+  the Core and Desktop MCP servers tell ChatGPT about themselves, so a standing preference — run
+  the tests before claiming a change works, prefer this package manager, never force-push — does
+  not have to be repeated in every chat. It is stored in settings, so an app update no longer
+  overwrites it; editing `app.asar` was previously the only way to add anything at all.
+
+  It is appended last and under a heading naming the user as its author. Both are deliberate:
+  everything above it is what the app can actually promise about its own tools, and a preference
+  must not silently redefine one — and the model should be able to tell a standing instruction
+  from the person apart from the connector's description of itself, because those carry different
+  authority. Empty adds nothing, not even the heading. Changing it asks for the same reconnect a
+  tool change does, since ChatGPT reads connector instructions once, when it loads the tools.
+
 ## [2.0.6] — 2026-09-06
 
 **I am exhausted.**

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -238,6 +238,16 @@ const capabilitiesSchema = z
   )
   .transform((caps) => ({ ...DEFAULT_CAPABILITIES, ...caps }) as Capabilities);
 
+/**
+ * The user's own MCP instructions.
+ *
+ * Empty by default, and deliberately so: the connector instructions are how the app explains
+ * its own tools, and inventing text on the user's behalf there would put words the app cannot
+ * honour in front of the model.
+ */
+export const MAX_MCP_INSTRUCTIONS_CHARS = 4000;
+const DEFAULT_MCP = { instructions: '' } as const;
+
 const configSchema = z.object({
   // A config written by hand — or by a build before `/skills` was reserved — must not be
   // able to claim a reserved virtual root. Renamed rather than rejected: a single bad root
@@ -383,6 +393,21 @@ const configSchema = z.object({
     })
     .optional()
     .default({ ...DEFAULT_GOAL, backend: 'chatgpt', loopBackend: 'chatgpt', impulseMinutes: 0, includeToolCalls: false, helperModel: 'gpt-5.6-sol', helperReasoning: 'high' })
+    ,
+  mcp: z
+    .object({
+      // Repaired rather than rejected, like the Goal prompts above: this is free text a person
+      // typed, and one over-long or malformed field must not send the whole config — every
+      // root, every permission — through conservative recovery.
+      instructions: z
+        .string()
+        .optional()
+        .default(DEFAULT_MCP.instructions)
+        .transform((value) => value.slice(0, MAX_MCP_INSTRUCTIONS_CHARS).trim())
+        .catch(DEFAULT_MCP.instructions)
+    })
+    .optional()
+    .default({ ...DEFAULT_MCP })
 });
 
 /**
@@ -408,7 +433,8 @@ export function defaultConfig(platform: NodeJS.Platform = process.platform, rele
     sessions: { ...DEFAULT_SESSIONS },
     compaction: { ...DEFAULT_COMPACTION },
     multiAgent: { ...FIRST_LAUNCH_MULTI_AGENT },
-    goal: { ...DEFAULT_GOAL }
+    goal: { ...DEFAULT_GOAL },
+    mcp: { ...DEFAULT_MCP }
   };
 }
 

--- a/src/main/mcp/instructions.ts
+++ b/src/main/mcp/instructions.ts
@@ -11,7 +11,7 @@
  */
 
 import { LAUNCHES_WINDOWS_POWERSHELL_5 } from '../codex/tool-specs.js';
-import { getConfig } from '../config.js';
+import { getConfig, MAX_MCP_INSTRUCTIONS_CHARS } from '../config.js';
 import { isGitRepository } from '../toolchain.js';
 import type { ToolContext } from './kernel.js';
 import { surfaceDefinition, type SurfaceId } from './surfaces.js';
@@ -22,6 +22,23 @@ export function serverInstructions(
   platform: NodeJS.Platform = process.platform
 ): string {
   return surface === 'desktop' ? desktopInstructions(ctx, platform) : coreInstructions(ctx, platform);
+}
+
+/**
+ * The user's own additions, appended to whichever connector is being described.
+ *
+ * Last, and fenced under a heading that says whose words these are. Both matter. Last, because
+ * everything above is what the app can actually promise about its own tools, and a preference
+ * must not quietly redefine one of them. Attributed, because the model should be able to tell a
+ * standing instruction from this user apart from the connector's description of itself -- they
+ * carry different authority, and running them together hides that.
+ *
+ * Empty is the normal case and adds nothing at all, not even the heading.
+ */
+function userInstructions(): string[] {
+  const text = getConfig().mcp.instructions.trim();
+  if (!text) return [];
+  return ['', "The user's own standing instructions for this connector:", text.slice(0, MAX_MCP_INSTRUCTIONS_CHARS)];
 }
 
 function coreInstructions(ctx: ToolContext, platform: NodeJS.Platform): string {
@@ -155,6 +172,8 @@ function coreInstructions(ctx: ToolContext, platform: NodeJS.Platform): string {
     );
   }
 
+  lines.push(...userInstructions());
+
   return lines.join('\n');
 }
 
@@ -202,6 +221,8 @@ function desktopInstructions(ctx: ToolContext, platform: NodeJS.Platform): strin
     `Files, patches and commands live in a separate connector, "${surfaceDefinition('core').connectorName}".`,
     'This one cannot read or change files. If a task needs that and it is not available here, say so.'
   );
+
+  lines.push(...userInstructions());
 
   return lines.join('\n');
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -39,6 +39,7 @@ export interface SettingsPatch {
   compaction: Config['compaction'];
   multiAgent: Config['multiAgent'];
   goal: Config['goal'];
+  mcp: Config['mcp'];
 }
 
 /** One page of the OpenRouter catalogue, as the model picker asks for it. */

--- a/src/renderer/chat.ts
+++ b/src/renderer/chat.ts
@@ -2155,6 +2155,7 @@ export function chatSettingsPatch(current: Config): {
   compaction: Config['compaction'];
   multiAgent: Config['multiAgent'];
   goal: Config['goal'];
+  mcp: Config['mcp'];
 } {
   const number = (id: string, fallback: number, min: number, max: number): number => {
     const raw = Number($<HTMLInputElement>(id).value);
@@ -2202,7 +2203,9 @@ export function chatSettingsPatch(current: Config): {
         DEFAULT_GOAL_OBJECTIVE_SYSTEM_PROMPT,
       loopPrompt:
         $<HTMLTextAreaElement>('goalLoopPrompt').value.trim() || DEFAULT_GOAL_LOOP_SYSTEM_PROMPT
-    }
+    },
+    // Empty is a real choice here, not a value to repair: it means "add nothing of mine".
+    mcp: { instructions: $<HTMLTextAreaElement>('mcpInstructions').value.trim() }
   };
 }
 
@@ -2332,6 +2335,7 @@ function applyGoal(state: AppState, previous?: Config): void {
   goalModel = config.goal.model;
   applyChatValue($<HTMLSelectElement>('goalReasoning'), config.goal.reasoning, previous?.goal.reasoning);
   applyChatValue($<HTMLTextAreaElement>('goalPrompt'), config.goal.prompt, previous?.goal.prompt);
+  applyChatValue($<HTMLTextAreaElement>('mcpInstructions'), config.mcp?.instructions ?? '', previous?.mcp?.instructions);
   applyChatValue(
     $<HTMLTextAreaElement>('goalObjectivePrompt'),
     config.goal.objectivePrompt,
@@ -2474,7 +2478,8 @@ const CHAT_INPUTS = [
   'goalReasoning',
   'goalPrompt',
   'goalObjectivePrompt',
-  'goalLoopPrompt'
+  'goalLoopPrompt',
+  'mcpInstructions'
 ];
 
 /** Writes app state into this panel's controls. Called from the renderer's apply(). */

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -592,6 +592,15 @@
                   <div class="setting"><span class="setting-text"><b>When ChatGPT is wrapping up</b><em>Automatic follow-ups use your Loop instructions and selected Loop source.</em></span><select id="finishAction"><option value="notify">Notify me · Write or Generate Goal</option><option value="goal">Generate and inject Goal</option></select></div>
                   <div class="setting"><span class="setting-text"><b>Requested notice</b><em>A request to the model, not a guaranteed countdown.</em></span><select id="finishLeadMinutes"><option value="3">3 minutes</option><option value="5">5 minutes</option></select></div>
                   </div>
+                <h2 class="settings-section-title">Connector instructions</h2>
+                <div class="pane">
+                  <div class="field">
+                    <label for="mcpInstructions">Your own instructions</label>
+                    <textarea id="mcpInstructions" rows="6" maxlength="4000" spellcheck="false" placeholder="e.g. Always run the test suite before saying a change works."></textarea>
+                    <p class="hint">Added to the end of what each connector tells ChatGPT about itself, marked as yours. Kept across app updates. Leave empty for none.</p>
+                  </div>
+                  <p class="muted">ChatGPT reads connector instructions once, when it loads the tools, so a change reaches an existing conversation only after the connector is loaded again.</p>
+                </div>
                 <h2 class="settings-section-title">ChatGPT models</h2>
                 <div class="pane">
                   <div class="setting"><span class="setting-text"><b>Available ChatGPT models</b><em id="chatModelStatus">Read model choices from your account.</em></span><button class="btn" id="refreshChatModels" type="button">Refresh</button></div>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -472,6 +472,10 @@ async function saveSnapshot(patch: SettingsPatch, previous: AppState['config']):
   const toolSurfaceChanged =
     previous.sessions.record !== patch.sessions.record ||
     previous.multiAgent.enabled !== patch.multiAgent.enabled ||
+    // The user's own connector instructions are part of what each server advertises about
+    // itself, and ChatGPT reads that once when it loads the tools. Editing them is therefore
+    // the same kind of change as adding a tool: it needs the same reconnect to be seen.
+    (previous.mcp?.instructions ?? '') !== patch.mcp.instructions ||
     (Object.keys(patch.capabilities) as Capability[]).some((cap) => {
       const before = previous.capabilities[cap] && !(previous.readOnly && WRITE_CAPABILITIES.includes(cap));
       const after = patch.capabilities[cap] && !(patch.readOnly && WRITE_CAPABILITIES.includes(cap));
@@ -484,6 +488,7 @@ async function saveSnapshot(patch: SettingsPatch, previous: AppState['config']):
     ui: previous.ui,
     sessions: previous.sessions,
     compaction: previous.compaction,
+    mcp: previous.mcp ?? { instructions: '' },
     multiAgent: previous.multiAgent,
     goal: previous.goal
   };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -267,6 +267,12 @@ export interface MultiAgentSettings {
   recoverAgentTabs: boolean;
 }
 
+/** The user's own additions to what each MCP connector tells the model about itself. */
+export interface McpSettings {
+  /** Appended to the Core and Desktop server instructions, or empty for none. */
+  instructions: string;
+}
+
 export interface Config {
   roots: Root[];
   capabilities: Capabilities;
@@ -277,6 +283,7 @@ export interface Config {
   compaction: CompactionSettings;
   multiAgent: MultiAgentSettings;
   goal: GoalSettings;
+  mcp: McpSettings;
 }
 
 export type ConnectionState =

--- a/test/mcp-user-instructions.test.ts
+++ b/test/mcp-user-instructions.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The user's own standing instructions, appended to what each connector says about itself.
+ *
+ * Issue #85: there was no persistent way to add anything, so the only route was patching
+ * `app.asar` — which an update overwrites. This is a settings field instead.
+ *
+ * Two properties are worth defending in tests rather than in review. It goes **last**, because
+ * everything above it is what the app can actually promise about its own tools and a preference
+ * must not quietly redefine one. And it is **attributed**, so the model can tell a standing
+ * instruction from this user apart from the connector's description of itself — those carry
+ * different authority, and running them together hides that.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isAsyncEncryptionAvailable: async () => true,
+    getSelectedStorageBackend: () => 'gnome_libsecret',
+    encryptStringAsync: async (value: string) => Buffer.from(value, 'utf8'),
+    decryptStringAsync: async (buffer: Buffer) => ({ result: buffer.toString('utf8'), shouldReEncrypt: false })
+  },
+  clipboard: { readText: () => '', writeText: () => undefined },
+  shell: { openExternal: async () => undefined }
+}));
+
+const { MAX_MCP_INSTRUCTIONS_CHARS, defaultConfig, getConfig, initConfigPath, saveConfig } = await import(
+  '../src/main/config.js'
+);
+const { serverInstructions } = await import('../src/main/mcp/instructions.js');
+const { makeTempDir, removeTempDir } = await import('./helpers.js');
+const { CAPABILITIES } = await import('../src/shared/types.js');
+type Capabilities = import('../src/shared/types.js').Capabilities;
+
+let dir: string;
+
+const allCapabilities = (): Capabilities =>
+  Object.fromEntries(CAPABILITIES.map((name) => [name, true])) as Capabilities;
+
+const ctx = {
+  roots: [],
+  caps: allCapabilities(),
+  readOnly: false,
+  sessionTools: false,
+  agentTools: false
+};
+
+const HEADING = "The user's own standing instructions for this connector:";
+
+async function withInstructions(instructions: string): Promise<void> {
+  const config = getConfig();
+  await saveConfig({ ...config, mcp: { ...config.mcp, instructions } });
+}
+
+beforeAll(async () => {
+  dir = await makeTempDir('clf-mcp-instructions-');
+  initConfigPath(dir);
+  await saveConfig(defaultConfig());
+});
+
+afterAll(async () => {
+  await removeTempDir(dir);
+});
+
+beforeEach(async () => {
+  await withInstructions('');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('the user’s own connector instructions', () => {
+  it('adds nothing at all when empty, not even the heading', () => {
+    expect(defaultConfig().mcp.instructions).toBe('');
+    for (const surface of ['core', 'desktop'] as const) {
+      const text = serverInstructions(ctx, surface, 'win32');
+      expect(text, surface).not.toContain(HEADING);
+      expect(text.trimEnd(), surface).toBe(text.trimEnd());
+    }
+  });
+
+  it.each(['core', 'desktop'] as const)('appends them last on the %s connector, attributed', async (surface) => {
+    const mine = 'Always run the test suite before saying a change works.';
+    await withInstructions(mine);
+
+    const text = serverInstructions(ctx, surface, 'win32');
+    expect(text).toContain(HEADING);
+    expect(text).toContain(mine);
+    // Last: nothing the app authored may follow, or a preference would be read as overriding
+    // guidance that comes after it.
+    expect(text.trimEnd().endsWith(mine)).toBe(true);
+    // And the heading immediately precedes it, so the attribution cannot drift away.
+    expect(text.indexOf(HEADING)).toBeLessThan(text.indexOf(mine));
+  });
+
+  it('leaves everything the app says about itself intact', async () => {
+    const before = serverInstructions(ctx, 'core', 'win32');
+    await withInstructions('Prefer pnpm.');
+    const after = serverInstructions(ctx, 'core', 'win32');
+
+    // Added to, never edited: the connector's own description is unchanged character for
+    // character, and only the attributed block is new.
+    expect(after.startsWith(before)).toBe(true);
+    expect(after.slice(before.length)).toContain('Prefer pnpm.');
+  });
+
+  it('survives a reload, which is the whole point of it being a setting', async () => {
+    await withInstructions('Never force-push.');
+    initConfigPath(dir);
+    expect(getConfig().mcp.instructions).toBe('Never force-push.');
+    expect(serverInstructions(ctx, 'core', 'win32')).toContain('Never force-push.');
+  });
+
+  it('trims surrounding whitespace rather than emitting a blank block', async () => {
+    await withInstructions('   \n  \t ');
+    expect(getConfig().mcp.instructions).toBe('');
+    expect(serverInstructions(ctx, 'core', 'win32')).not.toContain(HEADING);
+  });
+
+  it('caps an over-long value instead of rejecting the whole config', async () => {
+    // Repaired, not rejected. This is free text a person typed, and one over-long field must
+    // not send every root and every permission through conservative recovery.
+    await withInstructions('x'.repeat(MAX_MCP_INSTRUCTIONS_CHARS + 500));
+    const stored = getConfig().mcp.instructions;
+    expect(stored.length).toBe(MAX_MCP_INSTRUCTIONS_CHARS);
+    // And the rest of the config is still the real one, not the conservative fallback.
+    expect(getConfig().readOnly).toBe(false);
+    expect(serverInstructions(ctx, 'core', 'win32')).toContain(stored);
+  });
+});


### PR DESCRIPTION
Fixes #85.

A settings field whose text is appended to what the Core and Desktop MCP servers tell ChatGPT
about themselves. Stored in config under `mcp.instructions`, so an app update no longer
overwrites it — patching `app.asar` was previously the only way to add anything at all.

### The two decisions worth reviewing

**It goes last.** Everything above it is what the app can actually promise about its own tools.
A preference placed before that could be read as qualifying guidance the app has to honour, so
the user's text can only ever follow it. There is a test asserting the connector's own
description is unchanged character for character and only the new block is appended.

**It is attributed**, under a heading naming the user as its author:

```
The user's own standing instructions for this connector:
Always run the test suite before saying a change works.
```

The model should be able to tell a standing instruction from this person apart from the
connector's description of itself. Those carry different authority, and running them together
hides that. Empty is the normal case and emits nothing at all — not even the heading.

### Reconnect behaviour

Editing this now counts as a tool-surface change, so it raises the same *"Tools changed. Start a
new ChatGPT conversation…"* notice that adding a tool does. ChatGPT reads connector instructions
once, when it loads the tools; without that the edit would look applied while nothing had
actually changed for the running conversation.

### Failure handling

The config field is repaired rather than rejected, exactly as the Goal prompts directly above it
are — free text a person typed, capped at 4000 characters and trimmed. One over-long field must
not send every root and every permission through conservative recovery. There is a test for that
which also asserts the rest of the config survives intact.

The renderer reads the group defensively (`config.mcp?.instructions ?? ''`). A state push from an
older main process carries no `mcp` at all, and a missing settings group should degrade to "none
set" rather than throw through `apply()` and blank the panel. Found by the existing renderer
tests, whose fixtures do exactly that.

### Verification

`npm run typecheck` clean. 2928 passing. The two failures left are environmental and reproduce
identically on a pristine `main` checkout here: PowerShell execution policy blocking `.ps1`, and
a locale that formats decimals with a comma.

Seven new tests in `test/mcp-user-instructions.test.ts`: empty adds nothing on either surface,
appended last and attributed on both, the app's own text untouched, survives a config reload,
whitespace-only trims to nothing, and an over-long value is capped without damaging the config.

### Open to direction

Placement and wording are yours to move — I put it under its own **Connector instructions**
heading in settings, but it would sit equally well beside the connector cards in the wizard. The
heading text itself is in one place (`userInstructions()` in `instructions.ts`) if you would
rather word it differently, and it is deliberately plain rather than a fence, since this is the
user's own app and their own words, not untrusted input.
