### PR TITLE
2.0.7: plus = gpt 5.6; pro = astra

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,25 @@ it architecturally cleaner and preferably smaller than before.
 
 **Rule: no build up; rewrite with the new feature in mind.**
 
+**Browser efficiency rules.** Opening the app, a suspended MV3 wake socket and a maintenance
+alarm are not permission to open a tab. Reuse a suitable existing document. One operation owns
+one elected tab across provider navigation and MV3 suspension; a missing receipt or a user-closed
+tab must not create a new opening attempt. Transfer opening authority at handout, not after page
+hydration. Keep broker worker reuse independent of tab retention: sleeping/finished workers can
+release their renderer after two minutes, subject to the existing draft/generation/document checks.
+Read bounded account-evaluated model metadata and installed tool declarations through the existing
+MAIN-world bridge. Do not infer availability from English labels or fixed release names, sweep every
+effort to discover a catalog, or add polling/fallback openers around an uncertain observation.
+
+Native attachments have one staging owner in `session/input-attachments.ts`: immutable originals,
+bounded thumbnails, serialized quota/pruning/admission and opaque IDs. The outbox owns membership;
+the bridge serves bounded chunks only to that exact pre-send browser claim. Never expose source
+paths or inject a file reference as though its bytes reached ChatGPT. Final Send must recheck the
+same text, attachment nodes and navigation epoch after every asynchronous authorization step.
+Pending plan stages are projected from the first durable input until its receipt materializes the
+queue. Temporary planner tabs retire after capture/cancellation only with exact idle/draft proof.
+
+
 **This tree is usually dirty and shared with the user and other agents — never `reset`,
 `checkout`, `clean`, reformat, or overwrite work you did not do.**
 
@@ -75,8 +94,9 @@ Four runtime planes, only two of which are servers:
 
 **The MCP server and the browser bridge are two different servers with two different
 threat models.** MCP is the model's capability endpoint. The bridge exists only for the
-Chrome extension and deliberately has no route that reads a file, runs a command, or
-changes a permission. Never merge their lifecycles or their auth.
+Chrome extension and has no arbitrary filesystem, command or permission authority. Its attachment
+route serves only immutable user-selected staging bytes belonging to an exact claimed input.
+Never merge their lifecycles or their auth.
 
 The extension never executes a tool. It observes ChatGPT and reports evidence. **The app is
 the only authority on what a local tool actually did.** The renderer has no Node, no
@@ -161,7 +181,7 @@ copy a release number that can drift. Core is cross-platform; main process is Ty
 extension is plain MV3 JavaScript with no build step; Vitest; `node-pty` is the main native
 terminal dependency. Desktop automation is available through native Windows and macOS backends.
 
-Fresh-install defaults from `config.ts` — **all Core tool permissions on**, **read-only off**,
+Fresh-install defaults from `config.ts` — **Core tool permissions on except opt-in ChatGPT file saving**, **read-only off**,
 **recording on**, session advisory/limit **400k/533k** estimated tokens, **auto-compaction on
 at 400k and level-based with live-work gating**, **multi-agent on** with `maxWorkers` 2 (hard max 8).
 Fresh multi-agent also starts with `allowUnattributedCalls=true`; `recoverAgentTabs` starts **off**
@@ -338,7 +358,7 @@ src/shared/types.ts           config/app/IPC types and Capabilities
 
 ── browser ────────────────────────────────────────────────────────────────
 src/main/bridge.ts            extension HTTP bridge + compaction/worker orchestration
-src/main/goal.ts              Goal/Loop OpenRouter driver, durable obligations, one draft per turn
+src/main/goal.ts              Goal/Loop LLM driver (OpenRouter default, custom endpoint optional), durable obligations, one draft per turn
 src/main/agents.ts            the one global star-topology multi-agent broker
 extension/manifest.json       MV3 composition root: service worker, isolated scripts/CSS, MAIN-world Fiber, popup, host/extension permissions
 extension/chatgpt-dom.js      EVERY ChatGPT selector and DOM-shape assumption
@@ -461,7 +481,7 @@ first?**
 | resumed first answer missed by Goal | `content.js::rememberResumeGoalPending()` / `bindResumeGoalTurn()` | `maybeRecoverResumeGoalTurn()` → exact single resume-user-turn + final/Fiber proof → ordinary `noteGoalTurn()`; synthetic `g-resume-<commandId>` is only a stable local turn id when no observed generation id exists |
 | worker lifecycle | `tools-core.ts` `agents` action dispatch | `agents.ts::stageSpawn()` / `stageMessages()` / `stageFinishAgent()` → `persistCriticalSwarmNow()` → staged commit/rollback → bridge worker/revive commands → `background.js::recoverDeferredRevivals()` → exact page liveness back into `agents.ts` |
 | browser command delivery | worker producers `bridge.ts::queueWorkerBootstrap()` / `queueWorkerRevival()`; **resume production** is bridge POST `/compact` after `continuation.ts::attachSummary()` → private `queueResumeCommand()` | durable command owner/lease → `/commands/redeem` / `/commands/ack` → `background.js::redeemCommand()` / `ackCommand()` → content send → receipt/recovery in `restoreCommands()`; exported `queueResume()` is a test/older-caller convenience wrapper, and private generic `queue()` is storage plumbing — neither is the semantic resume entrypoint |
-| which browser opens a fresh chat | `bridge.ts::offerPlacement()` / `pendingBrowserPlacement()` → `background.js::placeSuccessorChat()` | the `/compact` reply that produced the command carries `placement`, and chat A's own browser creates chat B in chat A's window; `openFreshChatInBrowser()` is the fallback after `BROWSER_PLACEMENT_MS` and the only path for a resume no page asked for |
+| which browser opens a fresh chat | `bridge.ts::offerPlacement()` / `pendingBrowserPlacement()` → `background.js::placeSuccessorChat()` | the `/compact` reply that produced the command carries `placement`, and chat A's own browser creates chat B in chat A's window; `pendingBrowserPlacement()` spends opening authority on handout, before hydration; no timer may issue a second OS open. `openFreshChatInBrowser()` handles a resume with no waiting browser collector |
 | extension document/conversation identity | `background.js::authorizeDocument()` / `registerDocument()` / `ownsDocument()` | `noteTabConversation()` + `chatgpt-dom.js::conversationFromPath()` / `conversationId()`; React-only evidence begins at `fiber.js::scan()` |
 | page observation commit | bridge POST `/events` | exact lost-worker-ACK recovery + `noteAgentAlive()` → `recorder.ts::recordChatObservations()` → durable Goal reply obligation → browser-recovery activity → context ceiling → staged/durable worker final → HTTP 200 lets extension journal retire the batch |
 | Overwrite / native ChatGPT presentation | `content.js::renderStreams()` | `websiteRenderForTurn()` + `completeReplacementForTurn()` + `hasUnrepresentedFiberCall()` → `chatgpt-dom.js::replaceActivity()` / `hideProgress()`; exact Fiber/page identities decide whether local activity is complete enough to replace native activity, while ChatGPT always keeps answer/code/actions |
@@ -498,6 +518,11 @@ single-instance lock
   → auto-connect MCP/tunnel if configured
   → start non-blocking updater lifetime: immediate pass + unreferenced six-hour recheck schedule
 ```
+
+`ui.chatBrowser` owns the Chrome/Edge choice for OS-originated ChatGPT launches. `browser.ts`
+reads it at launch time and tries only that family's installations; failures propagate to the
+request owner instead of opening the system default browser. The setting does not select a
+profile or override connected-extension delivery/source-tab placement. Legacy configs use Chrome.
 
 The **window activation gate** is a real lifetime boundary, not UI polish. Electron may deliver
 `second-instance` after its own `ready` event while this app is still restoring durable state and
@@ -607,6 +632,7 @@ earn it today.
 | `find` | `search` **and not** `command` | `tools-core.ts` → `search.ts` |
 | `apply_patch` | any of `create`/`edit`/`move`/`deleteFile` | `codex/apply-patch/*` |
 | `exec_command`, `write_stdin` | `command` | `codex/unified-exec.ts` |
+| `download_artifact` | `saveArtifact` | `tools-core.ts` → `artifact-fetch.ts` + `artifact-target.ts` |
 | `session` | recording enabled | session subsystem |
 | `agents` | multi-agent enabled | `agents.ts` |
 
@@ -2096,8 +2122,9 @@ terminal workers are not protected.
 
 **Tab closing is derived from model activity.** `bridge.ts::browserTabPolicy()` projects exact
 managed/protected conversations, activity timestamps and the configured `maxWorkers` retention
-count. `background.js::pruneManagedTabs()` retains that many app-owned tabs; above the count,
-only idle candidates older than one minute are retired, oldest model activity/turn completion first.
+count. `background.js::pruneManagedTabs()` closes managed tabs after two minutes without model
+activity even below that count. The count caps worker tabs only: when new worker work arrives,
+the oldest safe sleeping worker tab is evicted immediately if needed; its broker identity remains reusable.
 Active conversations, pending journals and unsent drafts are protected even above the count.
 Redundant document copies are handled separately from the retention floor. Tab selection is not
 model activity. One managed background browser window is reused for helpers/workers; a temporary
@@ -2234,8 +2261,9 @@ auto-compaction setting. The composer context meter shows estimated current-chat
 provider-reported count; Pro has a static ring, while other models show configured utilization.
 
 
-**Goal + Loop.** `goal.ts` is one OpenRouter engine with two standing modes and one optional
-per-chat objective. It sends only authored user messages and final assistant answers to the
+**Goal + Loop.** `goal.ts` is one LLM engine with two standing modes and one optional
+per-chat objective: OpenRouter by default, or a custom OpenAI-compatible endpoint
+(`goal.provider`). It sends only authored user messages and final assistant answers to the
 provider; tool rows, native progress and hidden reasoning stay out of that transcript. That provider
 view comes from the **local canonical recording**, not the live page. `goal.ts::
 conversationMessages()` keeps final assistant revisions only, coalesces duplicate legacy final
@@ -2304,12 +2332,13 @@ project. Keep both properties if you rewrite these; a loop that drifts off the b
 whole night it was left running for.
 
 The Goal **model picker** has its own narrow secret/network boundary. Renderer code never receives
-the OpenRouter key and never fetches the catalogue directly: IPC `goal:models` accepts only a bounded
+the provider key and never fetches the catalogue directly: IPC `goal:models` accepts only a bounded
 offset, fixes the page size at 20, and calls `goal.ts::listGoalModels()`. The main-process catalogue
 loader uses a 30-second request ceiling, 8 MiB response bound and 5,000-model parse cap, sorts newest
 releases first, and caches for five minutes **scoped to a SHA-256 fingerprint of the current API
-key** (or the public/no-key bucket). A key change therefore cannot reuse a restricted catalogue from
-the previous credential. `renderer/chat.ts::loadGoalModels()` / `paintGoalModels()` /
+key** (or the public/no-key bucket) **plus the endpoint URL**. A key or endpoint change therefore cannot reuse a restricted catalogue from
+the previous credential. A custom endpoint that answers no usable catalogue yields an empty
+list and the model stays a hand-typed field. `renderer/chat.ts::loadGoalModels()` / `paintGoalModels()` /
 `maybePageGoalModels()` own scroll-paged presentation only; load failure leaves the user's current
 model selection untouched.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ The app and the `extension/` companion are versioned together. **Reload the
 extension after updating the app**. If their bridge protocols are incompatible,
 the app refuses the extension and asks you to reload the matching copy.
 
+## [2.0.7] — 2026-09-07
+
+**plus = gpt 5.6; pro = astra**
+
+- Account-specific model and reasoning discovery now handles localized and nested ChatGPT pickers through native metadata. Model availability follows the signed-in account.
+- Fewer browser tabs: one operation retains one opening attempt across navigation, closure and restart. Sleeping workers release browser memory while keeping their reusable conversations.
+- Durable Goal/Loop and finish delivery preserves the exact task and turn, ordered queues and delivery receipts across recovery. Editing an objective re-evaluates an already completed answer.
+- Temporary Goal API failures retry with visible progress and provider retry timing. Finish-generated follow-ups arrive through the next tool response; new input or cancellation retires obsolete work.
+- Custom OpenAI-compatible Goal providers have separate credentials. Endpoint, model and reasoning stay together across settings changes; authenticated requests refuse redirects.
+- Compact & Resume preserves Project placement, continuation identity and live terminal ownership. Real handoff progress extends manual deadlines; cancelled helpers retire without reopening.
+- Explicit Chrome/Edge selection, more reliable startup and exact browser handoffs. Optional Windows login startup respects background launch; macOS startup and reopen handling are hardened.
+- Connector refresh checks the installed identity and tool declarations, including native cards with no Refresh button. The companion popup requires confirmed compatibility and explains manual mismatch recovery.
+- Drop files or paste images into the composer. Filename cards and previews stay above messages; native uploads retain exact ownership, bounded image handling and send confirmation. Later user drafts survive acknowledged bootstrap cleanup.
+- Opt-in artifact downloads save generated files inside approved folders with bounded transfers, validated destinations and no overwriting of existing files.
+- Plan stages stay visible during startup. Completed and cancelled planner tabs retire after generation and draft checks; streamed planning and retry progress stays in one timeline row.
+- Per-worker model and reasoning selection, reusable sleeping workers and custom Core/Desktop instructions, including concurrent settings-save fixes. Scheduled callers receive clearer guidance when attribution permission is disabled.
+- Worker token meters update from recorded tool activity. Usage recognizes the Sol model alias, uses updated configurable rates and preserves proven model identity. Context popups sit directly above the ring.
+- Clearer waiting status distinguishes active tools, workers and unknown waits. Tunnel outage detection and missing metrics no longer conflate unrelated states.
+- Finish notification actions include the macOS alert-style packaging declaration. Cross-platform regression coverage includes canonical download paths and symlink replacement protection.
+- Removed the debugging Reload companion button; normal browser extension management remains available.
+
+**Reload the browser extension after updating the app.** Protocol 13 prevents older companions from silently omitting file attachments.
+
 ## [2.0.6] — 2026-09-06
 
 **I am exhausted.**

--- a/README.md
+++ b/README.md
@@ -1,16 +1,7 @@
 > [!IMPORTANT]
-> **Set ChatGPT to English!!!!**
->
-> Set ChatGPT's interface language to **English**, then reload your ChatGPT tabs and retry model discovery in Chat On Steroids. The current model-picker integration relies on English UI labels. Other languages can leave the model list empty even when the extension is connected and all setup checks are green.
->
-> **Quick fix if the model picker isn't showing:**
->
-> 1. Open Chat On Steroids or click the model picker's **Refresh** button.
-> 2. Switch to the **Chrome window and ChatGPT tab that the app opens**.
-> 3. If ChatGPT shows a model list instead of the thinking-effort slider, click **GPT-5.6 Sol**, even if it already looks selected.
-> 4. Return to Chat On Steroids and **refresh the model picker again**.
->
-> This workaround has restored the model picker for a user whose setup checks were all green. If it still does not appear, please report it in [Issues](../../issues).
+> **2.0.7 needs its matching companion extension.** Reload the unpacked extension after updating.
+> Model discovery now reads your account's native picker state across languages and nested version menus.
+> See [Browser behavior](#browser-behavior-in-the-current-source) for tab reuse, Browser only and native file attachments.
 
 
 <div align="center">
@@ -72,15 +63,17 @@ shasum -a 256 Chat-On-Steroids-macOS-arm64.dmg    # macOS
 sha256sum Chat-On-Steroids-Linux-x64.AppImage     # Linux
 ```
 
-> **This is a beta with real permissions.** A fresh install starts with the full Core capability set on, read-only mode off, multi-agent mode on with two workers, and, on Windows, the Desktop permissions on. On macOS the Desktop permissions start off; enable them in **Settings → Workspace**, then grant Screen Recording and Accessibility in System Settings. Linux has Core tools but no Desktop computer-control backend. Review folder access before connecting: `exec_command` runs programs as your logged-in user.
+> **This is a beta with real permissions.** A fresh install starts with Core capabilities on except opt-in ChatGPT file saving, read-only mode off, multi-agent mode on with two workers, and, on Windows, the Desktop permissions on. On macOS the Desktop permissions start off; enable them in **Settings → Workspace**, then grant Screen Recording and Accessibility in System Settings. Linux has Core tools but no Desktop computer-control backend. Review folder access before connecting: `exec_command` runs programs as your logged-in user.
 
 ## Requirements
 
 - **Windows 10/11**, **macOS 13 Ventura or newer**, or a current desktop **Linux**, on x64 or ARM64 matching the build you downloaded.
-- **Chrome 116 or newer** for the companion extension. Without it you still get the MCP tools, but not session attribution, Compact & Resume, worker chats or the Goal loop.
+- **Chrome 116 or newer**, or a current Microsoft Edge with the companion extension. Without it you still get the MCP tools, but not session attribution, Compact & Resume, worker chats or the Goal loop.
+
+Using Edge? Choose **Settings → Browser & history → ChatGPT browser → Microsoft Edge**. Install the companion and sign in to ChatGPT in that browser's active profile (`edge://extensions` for Edge). This choice controls app-originated launches, including startup model discovery; already connected tabs and source-tab continuations keep their browser. Older configurations retain Chrome. If the selected browser is missing or cannot start, the app reports an error instead of opening a different browser. The setting chooses a browser family, not a particular profile.
 - **Linux:** a Secret Service keyring such as GNOME Keyring or KWallet. The app refuses Electron's unencrypted `basic_text` fallback for stored keys.
 - A ChatGPT workspace with **Developer mode** and custom MCP apps. OpenAI currently documents full MCP support, including write actions, as a beta for Business, Enterprise and Edu, with Pro limited to read and fetch. Business needs an admin to enable it. Check OpenAI's [Developer mode and MCP apps](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt) page if your workspace looks different.
-- An **OpenRouter API key** only if you select the API source for plans, Goal or Loop. The default ChatGPT helper source uses your connected browser session.
+- An **OpenRouter API key** (or your own OpenAI-compatible endpoint) only if you select the API source for plans, Goal or Loop. The default ChatGPT helper source uses your connected browser session.
 
 Use a normal ChatGPT conversation with the custom app enabled. OpenAI's built-in Agent mode does not use custom apps.
 
@@ -115,7 +108,7 @@ Permission changes take effect locally immediately. Schema changes schedule a se
 
 | Connector | Tools | What they do |
 | --- | --- | --- |
-| **Core** (all platforms) | `read`, `view_image`, `find`, `apply_patch`, `exec_command`, `write_stdin`, `session`, `agents` | Bounded reads and search inside approved folders, preflighted multi-file patches, shell commands and interactive terminals, lookups into the recorded session, and worker chat control |
+| **Core** (all platforms) | `read`, `view_image`, `find`, `apply_patch`, `exec_command`, `write_stdin`, `download_artifact`, `session`, `agents` | Bounded reads and search inside approved folders, preflighted multi-file patches, shell commands and interactive terminals, saving ChatGPT-generated files, lookups into the recorded session, and worker chat control |
 | **Desktop** (Windows, and macOS when switched on) | `observe`, `computer` | Screenshots, window and control inspection, mouse, keyboard and clipboard |
 
 The live tool list follows your settings: `find` is the no-shell search fallback and steps aside when commands are enabled. Enabling Session finish adds the Astra-only `session_finish` tool. Revoking a permission takes effect immediately, even while ChatGPT still shows the old schema. The full contract lives in [`docs/tool-surface.md`](docs/tool-surface.md).
@@ -148,11 +141,15 @@ For ordinary models, **Goal** checks a completed answer and either drafts a foll
 
 Finish reminders are added by the delivery layer, separate from the visible plan. Desktop notifications depend on OS support and notification settings; the app also offers **Generate Goal** while waiting at a finish point. Native notification actions and cold background browser focus are not yet verified across every supported desktop environment.
 
+At a finish point, temporary Goal API failures retry after 15 seconds by default, honoring a provider's retry delay. The same operation delivers its completed instruction through the next tool result; new user instructions or ending the turn cancel it. Permanent errors such as invalid credentials require correction.
+
+For the API backend, choose OpenRouter or a custom OpenAI-compatible endpoint under **Settings → Agents & automation**. Custom URLs use HTTPS, or HTTP on loopback for local servers. Enter the server's model ID and optional API key; keys use secure OS storage and stay out of browser state. Switching back to OpenRouter selects its default model.
+
 ### Multi-agent mode
 
 One prime chat can open up to eight worker chats (two by default) and exchange brokered messages with them through the `agents` tool. Provider rate limits still apply. Workers cannot talk to each other.
 
-Workers are reusable conversations. When one reports its result it goes to sleep, frees its slot and keeps its full chat. Messaging it again wakes the same conversation. At about 400k recorded tokens a worker becomes non-revivable after its next stop; workers never compact themselves. With background chats enabled, app-managed tabs share one browser window. Idle tabs remain open up to the configured worker capacity; above it, the oldest inactive work is eligible for closure after one minute. Active chats and unsent drafts remain protected.
+Workers are reusable conversations. When one reports its result it goes to sleep, frees its slot and keeps its full chat. Messaging it again wakes the same conversation. At about 400k recorded tokens a worker becomes non-revivable after its next stop; workers never compact themselves. With background chats enabled, app-managed tabs share one browser window. Sleeping and finished worker tabs become eligible for closure after one minute, even below the worker limit. This releases browser memory while preserving the reusable conversation. Active chats and unsent drafts remain protected.
 
 Each prime owns its worker history. If the last worker sleeps, the run is parked and another chat can start its own workers; the original prime still sees its full history in `agents action=status`, can spawn fresh workers, and can wake old ones when the execution slot is free. Turning multi-agent off pauses execution and keeps that history. **Clear swarm** is what discards it.
 
@@ -178,8 +175,20 @@ Report vulnerabilities privately per [`SECURITY.md`](SECURITY.md).
 
 The MCP connector uses ChatGPT's documented Developer mode and Secure MCP Tunnel path. The extension is different: it observes ChatGPT's web UI, records rendered conversation state locally, and multi-agent mode opens and types into extra ChatGPT tabs. None of that is a documented public automation API. Depending on your account, OpenAI's [terms and policies](https://openai.com/policies/) on automated access, rate limits and permitted use may apply. Read the agreement that governs your account before using the extension or multi-agent mode, and do not use these features to scrape ChatGPT, evade limits or bypass safety controls.
 
+## Browser behavior in the current source
+
+The published 2.0.6 build's English-language and nested-picker workaround remains relevant until you install a build containing these fixes. The current source reads account-evaluated model IDs, available efforts and version choices instead of English picker labels. New model families appear after **Reload ChatGPT models**, provided ChatGPT exposes them to your account in the supported picker structure. Discovery restores the previous selection and sends no message.
+
+The current composer accepts dropped files (including Markdown) and dropped text, or **Add photos & files**. Files keep their original bytes and appear as compact filename cards above the message. Up to 20 files and 512 MB total can be prepared per message; ChatGPT's account, format and upload limits still determine acceptance. Files wait for the next native message when a turn is running. The app sends only after every attachment is confirmed and the draft is still unchanged. A failed upload leaves a visible error and is never automatically resent. Install the matching protocol-13 companion with this source build.
+
+Opening the app reuses an idle ChatGPT tab for its initial observation when the browser is already present; showing the window again does not refresh a ready catalog or open Chrome. Explicit model reloads also reuse suitable tabs. A pending operation keeps its selected tab through settings navigation and extension-worker suspension. A slow page or missing receipt never authorizes a second OS open.
+
+In **Chat settings → Browser & history**, enable **Browser only** to prevent automatic plugin-refresh and recovery operations from creating tabs. Existing eligible tabs can still be used; explicit new chats, workers and model reloads retain their normal behavior. Closing a helper does not restart the same operation every maintenance cycle. Connector refresh verifies the installed App ID and complete tool declarations, and clicks Refresh only after the app has durably claimed a changed schema.
+
 ## Troubleshooting
 
+- **A new ChatGPT tab every half minute:** this is a bug, not normal operation. The current source fixes repeated helper ownership loss and duplicate opening after slow browser handoffs. Browser only also disables automatic helper creation.
+- **A folder cannot be listed:** use the actual virtual path shown for your approved folder. `/folder` is an example, not an automatically configured root. Confirm the Core plugin is installed and the folder is approved in the app.
 - **Tools missing or stale after a permission change:** tool-schema changes schedule a connector refresh after a 20-second debounce. If it fails, refresh the custom app in ChatGPT; this is separate from reloading the companion extension.
 - **Extension says app not found:** recording or multi-agent mode must be on for the bridge to run. Then reopen the popup.
 - **Extension version mismatch:** reload the unpacked extension after every app update.

--- a/docs/release-notes/v2.0.7.md
+++ b/docs/release-notes/v2.0.7.md
@@ -1,0 +1,38 @@
+## 2.0.7: plus = gpt 5.6; pro = astra
+
+- Account-specific model and reasoning discovery now handles localized and nested ChatGPT pickers through native metadata. Model availability follows the signed-in account.
+- Fewer browser tabs: one operation retains one opening attempt across navigation, closure and restart. Sleeping workers release browser memory while keeping their reusable conversations.
+- Durable Goal/Loop and finish delivery preserves the exact task and turn, ordered queues and delivery receipts across recovery. Editing an objective re-evaluates an already completed answer.
+- Temporary Goal API failures retry with visible progress and provider retry timing. Finish-generated follow-ups arrive through the next tool response; new input or cancellation retires obsolete work.
+- Custom OpenAI-compatible Goal providers have separate credentials. Endpoint, model and reasoning stay together across settings changes; authenticated requests refuse redirects.
+- Compact & Resume preserves Project placement, continuation identity and live terminal ownership. Real handoff progress extends manual deadlines; cancelled helpers retire without reopening.
+- Explicit Chrome/Edge selection, more reliable startup and exact browser handoffs. Optional Windows login startup respects background launch; macOS startup and reopen handling are hardened.
+- Connector refresh checks the installed identity and tool declarations, including native cards with no Refresh button. The companion popup requires confirmed compatibility and explains manual mismatch recovery.
+- Drop files or paste images into the composer. Filename cards and previews stay above messages; native uploads retain exact ownership, bounded image handling and send confirmation. Later user drafts survive acknowledged bootstrap cleanup.
+- Opt-in artifact downloads save generated files inside approved folders with bounded transfers, validated destinations and no overwriting of existing files.
+- Plan stages stay visible during startup. Completed and cancelled planner tabs retire after generation and draft checks; streamed planning and retry progress stays in one timeline row.
+- Per-worker model and reasoning selection, reusable sleeping workers and custom Core/Desktop instructions, including concurrent settings-save fixes. Scheduled callers receive clearer guidance when attribution permission is disabled.
+- Worker token meters update from recorded tool activity. Usage recognizes the Sol model alias, uses updated configurable rates and preserves proven model identity. Context popups sit directly above the ring.
+- Clearer waiting status distinguishes active tools, workers and unknown waits. Tunnel outage detection and missing metrics no longer conflate unrelated states.
+- Finish notification actions include the macOS alert-style packaging declaration. Cross-platform regression coverage includes canonical download paths and symlink replacement protection.
+- Removed the debugging Reload companion button; normal browser extension management remains available.
+
+**Reload the browser extension after updating the app.** Protocol 13 prevents older companions from silently omitting file attachments.
+
+### Downloads
+
+- `Chat-On-Steroids-Setup-x64.exe` — Windows x64
+- `Chat-On-Steroids-Setup-arm64.exe` — Windows on Arm
+- `Chat-On-Steroids-macOS-x64.dmg` · `Chat-On-Steroids-macOS-x64.zip` — macOS Intel
+- `Chat-On-Steroids-macOS-arm64.dmg` · `Chat-On-Steroids-macOS-arm64.zip` — macOS Apple silicon
+- `Chat-On-Steroids-Linux-x64.AppImage` · `Chat-On-Steroids-Linux-x64.deb` — Linux x64
+- `Chat-On-Steroids-Linux-arm64.AppImage` · `Chat-On-Steroids-Linux-arm64.deb` — Linux ARM64
+- `Chat-On-Steroids-Extension.zip` — standalone Chrome companion extension
+- `SHA256SUMS.txt` — SHA-256 checksums for every artifact above
+
+> **macOS:** publisher-unsigned and unnotarized; verify the checksum. Requires macOS 13 Ventura or newer. Ad-hoc sealing provides bundle integrity, not publisher trust.
+> **Linux:** prefer the DEB on Debian/Ubuntu. Where unprivileged user namespaces are disabled, the AppImage launcher can fall back to `--no-sandbox`.
+
+Core and the workspace support Windows, macOS and Linux. Desktop screen/input control is available on Windows and optionally macOS with Screen Recording and Accessibility permissions. Windows and Linux AppImage support verified updates; macOS and DEB use manual downloads.
+
+Native upload limits depend on ChatGPT and your account. Local context and usage figures are estimates. Package checks do not constitute overnight browser or device-specific stability proof. This project remains beta.

--- a/docs/tool-surface.md
+++ b/docs/tool-surface.md
@@ -12,19 +12,19 @@ separate secret tokenized local paths.
 
 | Connector | Purpose | Possible tools |
 | --- | --- | --- |
-| **Chat On Steroids Core** | Approved files, patches, terminal, recorded-session lookup, workers | `read`, `view_image`, `find`, `apply_patch`, `exec_command`, `write_stdin`, `session`, `agents` |
+| **Chat On Steroids Core** | Approved files, patches, terminal, ChatGPT file saving, recorded-session lookup, workers | `read`, `view_image`, `find`, `apply_patch`, `exec_command`, `write_stdin`, `download_artifact`, `session`, `agents` |
 | **Chat On Steroids Desktop** | **Windows/macOS:** screen, windows, mouse/keyboard and clipboard | `observe`, `computer` |
 
 The Desktop connector is optional on Windows/macOS. Core is the main connector everywhere.
 
-On a fresh current config, all Core tool permissions, session recording and multi-agent mode are
-enabled, while read-only mode is off. Windows also enables Desktop permissions; macOS starts them off and the user switches them on. Linux masks
+On a fresh current config, Core permissions except saving ChatGPT files are enabled, along with
+session recording and multi-agent mode; read-only mode is off. Saving ChatGPT files is opt-in. Windows also enables Desktop permissions; macOS starts them off and the user switches them on. Linux masks
 Desktop permissions off at runtime while preserving stored choices for a config later reopened on
 Windows or macOS. Existing configs keep explicit choices during upgrades; missing legacy permissions are
 not silently widened.
 
-With the fresh all-on capability snapshot, Core advertises seven schemas:
-`read`, `view_image`, `apply_patch`, `exec_command`, `write_stdin`, `session`, and `agents`.
+With fresh defaults, Core advertises `read`, `view_image`, `apply_patch`, `exec_command`,
+`write_stdin`, `session`, and `agents`. Enabling file saving adds `download_artifact`.
 `find` is the search fallback for a snapshot where search is enabled and command execution is
 unavailable. Tool exposure is monotonic within a running connector instance, so a permission
 changed mid-conversation can leave a previously exposed name listed; its handler still enforces
@@ -79,6 +79,17 @@ poll returns as soon as the process produces output rather than holding the full
 anything that arrives afterwards stays buffered for the next poll. A non-empty write keeps
 Codex's collection-window behaviour so one interactive response is gathered whole.
 
+### `download_artifact`
+
+Saves a native file reference into an approved folder. The schema requests ChatGPT
+injection through `_meta` `openai/fileParams`; availability requires live provider
+verification. The capability starts off and the default per-file limit is 20 MiB.
+Only HTTPS `files.oaiusercontent.com` sources and redirects are accepted. Destination
+parents must already exist; an existing destination is refused. Directory and partial
+file identity are rechecked before publication, with portable Node path I/O rather
+than a directory-handle-pinned race guarantee. Signed file credentials are omitted
+from recorded tool arguments.
+
 ### `session`
 
 Available while session recording is enabled. It has exactly two actions:
@@ -111,9 +122,11 @@ Available while multi-agent mode is enabled. It has exactly four actions:
   on a limited model can spawn workers on a cheaper one. Omitted means the account default;
   a slug ChatGPT does not recognise opens with the default too. The model is fixed for the
   life of that conversation, including across sleep/wake reuse. Each worker also takes an
-  optional `reasoning_effort`: none, minimal, low, medium, high, xhigh, max or ultra, forwarded
-  on the open URL independently of `model` — a level never selects or changes the model, and
-  omitting both inherits the normal worker defaults.
+  optional `reasoning_effort`: pro, none, minimal, low, medium, high, xhigh, max or ultra,
+  forwarded on the open URL independently of `model` — a level never selects or changes the
+  model, and omitting either inherits the default set in app settings, or the account default
+  when no setting is chosen. The vocabulary is the one in `shared/session.ts`; `pro` is the
+  ChatGPT browser Power tier and is listed here because a worker is a real browser chat.
 - `message` sends one message or an all-or-nothing batch. Messaging a sleeping worker is what
   wakes it, in the chat it already has.
 - `status` reports the run and workers, including who is asleep and how many worker slots are free.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -90,6 +90,7 @@ mac:
   category: public.app-category.developer-tools
   minimumSystemVersion: "13.0"
   extendInfo:
+    NSUserNotificationAlertStyle: alert
     NSScreenCaptureUsageDescription: Chat On Steroids captures a display or window only when the enabled Desktop connector asks to observe it.
   # v2.0.2 intentionally ships unsigned/unnotarized macOS artifacts. Make that policy
   # deterministic instead of depending on whatever identities or Apple env vars happen to be

--- a/extension/background.js
+++ b/extension/background.js
@@ -40,7 +40,7 @@ const MODEL_REQUEST_TIMEOUT_MS = 190_000;
 /** The reason a deadline aborts with, so it is a fact the caller can act on rather than prose. */
 const TIMED_OUT = 'the app took too long to answer';
 /** Bumped only when the request/response shape changes; the app compares it. */
-const BRIDGE_PROTOCOL = 12;
+const BRIDGE_PROTOCOL = 13;
 
 /**
  * Journal caps. The byte figure is what actually matters — chrome.storage.session has a
@@ -219,6 +219,9 @@ let settled = [];
  * bridge redeem is still the authority fence and rejects commands that no longer exist.
  */
 let deferredRevivals = [];
+// Opening custody is durable independently of a page receipt. Only the app's next outbox
+// publication retires an input id; navigation, user-close and MV3 suspension do not.
+let inputOpenings = {};
 /** One in-flight same-tab offer per deferred command in this MV3 worker lifetime. */
 const deferredRevivalOffers = new Map();
 /** App says an active agent/recovery episode still needs the maintenance cadence. */
@@ -240,13 +243,15 @@ function load() {
 }
 
 async function loadOnce() {
-  const stored = await chrome.storage.local.get(['port', 'token', 'disconnected', 'deferredRevivals', 'commandAckOutbox']);
+  const stored = await chrome.storage.local.get(['port', 'token', 'disconnected', 'deferredRevivals', 'commandAckOutbox', 'inputOpenings']);
   port = typeof stored.port === 'number' ? stored.port : null;
   token = typeof stored.token === 'string' ? stored.token : null;
   // Deliberately in `local` rather than `session`: a choice to disconnect that a browser
   // restart undoes is not a choice, it is a delay.
   disconnected = stored.disconnected === true;
   deferredRevivals = Array.isArray(stored.deferredRevivals) ? stored.deferredRevivals.slice(-100) : [];
+  inputOpenings = stored.inputOpenings && typeof stored.inputOpenings === 'object' && !Array.isArray(stored.inputOpenings)
+    ? Object.fromEntries(Object.entries(stored.inputOpenings).filter(([id, row]) => /^[a-f0-9-]{36}$/i.test(id) && row && (row.tab === null || Number.isInteger(row.tab))).slice(-1000)) : {};
   const live = await chrome.storage.session.get([
     'settled',
     'journal',
@@ -322,6 +327,7 @@ function persistLive() {
       // revival text is duplicated into extension storage.
       chrome.storage.local.set({
         commandAckOutbox: commandAckOutbox.slice(-200),
+        inputOpenings,
         deferredRevivals: deferredRevivals.slice(-100)
       })
     ])
@@ -1290,12 +1296,15 @@ function deferredRevivalId(value) {
   return commandMarkerId(value);
 }
 
-async function rememberDeferredRevival(idValue, conversationValue) {
+async function rememberDeferredRevival(idValue, conversationValue, openingSpent = false) {
   await load();
   const id = deferredRevivalId(idValue);
   const conversationId = cleanConversationId(conversationValue);
   if (!id || !conversationId) return false;
-  if (deferredRevivals.some((entry) => entry?.id === id && cleanConversationId(entry.conversationId) === conversationId)) {
+  const existing = deferredRevivals.find((entry) => entry?.id === id && cleanConversationId(entry.conversationId) === conversationId);
+  if (existing) {
+    if (openingSpent) existing.openingSpent = true;
+    await persistLive();
     return true;
   }
   // There can only be one not-yet-redeemed wake for one existing conversation. Seeing a newer
@@ -1316,7 +1325,7 @@ async function rememberDeferredRevival(idValue, conversationValue) {
         entry.id !== id &&
         cleanConversationId(entry.conversationId) !== conversationId
     ),
-    { id, conversationId, queuedAt: Date.now() }
+    { id, conversationId, queuedAt: Date.now(), openingSpent }
   ].slice(-100);
   await persistLive();
   return true;
@@ -1637,8 +1646,8 @@ async function reconcileBackgroundWindow(policy) {
       const url = new URL(tab.pendingUrl || tab.url || '');
       if (url.origin !== 'https://chatgpt.com') return false;
       const inputId = url.searchParams.get('cos-input') || new URLSearchParams(url.hash.slice(1)).get('cos-input');
-      // Catalog helpers deliberately outlive their request. After browser restart,
-      // the old marker still owns that warm helper even when discovery has a new nonce.
+      // Catalog markers retain cleanup ownership across browser restart until the
+      // exact empty document can safely retire.
       const catalogHelper = url.pathname === '/' && /^[a-f0-9-]{36}$/i.test(url.searchParams.get('cos-model-catalog') || '');
       return (inputId && inputIds.has(inputId)) || catalogHelper;
     } catch { return false; }
@@ -1680,7 +1689,7 @@ async function createChatTab(url, background = false, active = !background) {
     if (existing) {
       if (backgroundWorkArea && ['left', 'top', 'width', 'height'].some(key => existing[key] !== backgroundWorkArea[key]))
         await chrome.windows.update(existing.id, backgroundWorkArea);
-      return chrome.tabs.create({ url, windowId: existing.id, active: false });
+      return chrome.tabs.create({ url, windowId: existing.id, active });
     }
     const window = await chrome.windows.create({ url, type: 'normal', state: 'minimized', focused: false });
     if (!Number.isInteger(window?.id) || !window.tabs?.[0]) throw new Error('background_window_not_ready');
@@ -1692,8 +1701,17 @@ async function createChatTab(url, background = false, active = !background) {
   });
 }
 
-async function deliverDesktopInputs(inputs, background) {
-  if (!Array.isArray(inputs) || !inputs.length) return;
+async function deliverDesktopInputs(inputs, background, activeIds) {
+  if (!Array.isArray(inputs)) return;
+  // An offer can disappear while its chat has running tools. Only the complete app-owned
+  // outbox identity projection proves retirement; missing legacy metadata retires nothing.
+  const currentIds = Array.isArray(activeIds) ? new Set(activeIds) : null;
+  const retired = currentIds ? Object.keys(inputOpenings).filter(id => !currentIds.has(id)) : [];
+  if (retired.length) {
+    for (const id of retired) delete inputOpenings[id];
+    await persistLive();
+  }
+  if (!inputs.length) return;
   let tabs = await chrome.tabs.query({ url: CHATGPT_TAB_URLS });
   const matchesInput = (input, tab) => {
     if (!input || !/^[a-f0-9-]{36}$/i.test(input.id)) return false;
@@ -1712,25 +1730,36 @@ async function deliverDesktopInputs(inputs, background) {
     let tab = candidates.sort((a, b) => a.id - b.id)[0];
     if (input.close === true && input.lifetime === 'temporary-planner') {
       if (!tab) continue;
-      // Preserve the warm planner until newer app work has an actual browser tab.
-      // Terminal input metadata is the lifecycle authority, including after restart;
-      // unrelated personal/catalog tabs are not a replacement for this handoff.
+      // Keep the latest completed preview warm until its work has a tab. The app can
+      // retire cancelled/obsolete planners immediately; document proof still gates closure.
       const replacements = Array.isArray(input.replacements) ? input.replacements : [];
       const replacement = tabs.find(candidate => candidate.id !== tab.id && replacements.some(next => matchesInput(next, candidate)));
-      if (!replacement) continue;
+      if (!replacement && input.retire !== true) continue;
       const documentId = tabDocuments[String(tab.id)];
       const source = { tab: tab.id, documentId, navigationEpoch: tabEpochs[String(tab.id)] };
       try {
         const proof = await chrome.tabs.sendMessage(tab.id, { type: 'clf-close-temporary-planner', id: input.id, owner: input.owner }, { documentId });
         const current = await chrome.tabs.get(tab.id);
-        const successor = await chrome.tabs.get(replacement.id);
+        const successor = replacement ? await chrome.tabs.get(replacement.id) : null;
         if (proof?.safe === true && ownsDocument(source) && String(current.url || '').includes(marker) &&
-            replacements.some(next => matchesInput(next, successor))) await chrome.tabs.remove(tab.id);
+            (input.retire === true || (successor && replacements.some(next => matchesInput(next, successor))))) await chrome.tabs.remove(tab.id);
       } catch { /* only the exact still-owned temporary document may close */ }
       continue;
     }
+    const opening = inputOpenings[input.id];
+    if (opening && opening.tab !== null) tab = candidates.find(candidate => candidate.id === opening.tab);
+    if (!tab && opening) continue;
+    if (!opening) {
+      if (Object.keys(inputOpenings).length >= 1000) continue;
+      // Spend authority before Chrome can create anything. A crash or failed write cannot
+      // leave a created tab followed by an apparently unattempted operation.
+      inputOpenings[input.id] = { tab: tab?.id ?? null };
+      await persistLive();
+    }
     if (!tab) {
       tab = await createChatTab(target ? `https://chatgpt.com/c/${encodeURIComponent(target)}` : `https://chatgpt.com/?${input.lifetime === 'temporary-planner' ? 'temporary-chat=true&' : ''}${marker}#${marker}`, background);
+      inputOpenings[input.id] = { tab: tab.id };
+      await persistLive();
       tabs.push(tab);
       continue;
     }
@@ -1769,13 +1798,28 @@ let pluginRefreshFlight = null;
 function pluginRefreshMarker(tab) {
   try { const url = new URL(tab?.pendingUrl || tab?.url || ''); return url.origin === 'https://chatgpt.com' && url.pathname === '/' && /^#settings\/Plugins(?:\/plugin_asdk_app_[a-zA-Z0-9_-]+)?$/.test(url.hash) ? url.searchParams.get('cos-plugin-refresh') : null; } catch { return null; }
 }
-function inspectRequestedPluginRefresh(publications, background) {
+function inspectRequestedPluginRefresh(publications, background, browserOnly = false) {
   if (pluginRefreshFlight || !Array.isArray(publications) || !publications.length) return pluginRefreshFlight;
   pluginRefreshFlight = (async () => {
     const pending = await call('/plugin-refresh', { method: 'POST', body: JSON.stringify({ action: 'pending' }) });
     if (!pending.ok || !Array.isArray(pending.data?.requests)) return;
     const requests = pending.data.requests.slice(0, 2);
     const tabs = await chrome.tabs.query({ url: CHATGPT_TAB_URLS });
+    const saved = (await chrome.storage.session.get('pluginRefreshOwner')).pluginRefreshOwner;
+    const owner = saved && typeof saved.id === 'string' && Number.isInteger(saved.tab) ? saved : null;
+    // A provider SPA transition strips our query. The operation still owns the same
+    // tab: preserve that identity across MV3 suspension before inspecting its URL.
+    if (owner && requests.some(request => request.id === owner.id)) {
+      const current = await chrome.tabs.get(owner.tab).catch(() => null);
+      if (!current) return; // A user-closed helper is not permission to reopen it every poll.
+      if (pluginRefreshMarker(current) !== owner.id) {
+        const url = new URL(current.pendingUrl || current.url || '');
+        if (url.origin !== 'https://chatgpt.com' || url.pathname !== '/' || !/^#settings\/Plugins(?:\/plugin_asdk_app_[a-zA-Z0-9_-]+)?$/.test(url.hash)) return;
+        url.searchParams.set('cos-plugin-refresh', owner.id);
+        await chrome.tabs.update(current.id, { url: url.href });
+        return;
+      }
+    }
     for (const tab of tabs) {
       const id = pluginRefreshMarker(tab);
       if (!id || requests.some(request => request.id === id)) continue;
@@ -1788,7 +1832,11 @@ function inspectRequestedPluginRefresh(publications, background) {
     const held = tabs.find(tab => requests.some(request => request.id === pluginRefreshMarker(tab)));
     const request = requests.find(request => request.id === pluginRefreshMarker(held)) || requests[0];
     if (!held) {
-      try { await createChatTab(`https://chatgpt.com/?cos-plugin-refresh=${request.id}#settings/Plugins${request.appId ? `/plugin_${request.appId}` : ''}`, background); }
+      if (browserOnly) return;
+      try {
+        const tab = await createChatTab(`https://chatgpt.com/?cos-plugin-refresh=${request.id}#settings/Plugins${request.appId ? `/plugin_${request.appId}` : ''}`, background);
+        await chrome.storage.session.set({ pluginRefreshOwner: { id: request.id, tab: tab.id } });
+      }
       catch {
         // Preserve the pre-claim obligation and expose the failed browser boundary.
         // Swallowing this error made a due request look as if its wake never arrived.
@@ -1796,6 +1844,7 @@ function inspectRequestedPluginRefresh(publications, background) {
       }
       return;
     }
+    await chrome.storage.session.set({ pluginRefreshOwner: { id: request.id, tab: held.id } });
     let timer;
     try {
       await Promise.race([chrome.tabs.sendMessage(held.id, { type: 'clf-plugin-refresh', request }), new Promise(resolve => { timer = setTimeout(resolve, 25000); })]);
@@ -1821,45 +1870,51 @@ function inspectRequestedModels(request) {
   const wanted = request && /^[a-f0-9-]{36}$/i.test(request.nonce) && Number.isFinite(request.expiresAt) && Date.now() < request.expiresAt ? request : null;
   modelCatalogFlight = (async () => {
     const observed = await chrome.tabs.query({ url: CHATGPT_TAB_URLS });
+    const owner = wanted && (await chrome.storage.session.get('modelCatalogOwner')).modelCatalogOwner;
+    // One request retains its elected tab through MV3 suspension. A missing or
+    // navigated-away tab is an unfinished request, never another create instruction.
+    if (owner?.nonce === wanted?.nonce && Number.isInteger(owner?.tab) &&
+        !observed.some(tab => tab.id === owner.tab)) return;
     const tabs = wanted ? observed : observed.filter(tab => catalogTabNonce(tab));
-    if (!wanted && tabs.length < 2) return;
-    // Reuse a loaded idle document without navigation. A dedicated helper stays
-    // warm between requests; its URL marker identifies ownership, not the request.
+    if (!wanted && !tabs.length) return;
+    // Reuse a loaded idle document without navigation. A dedicated helper marker
+    // identifies cleanup ownership if its prior request ended before safe retirement.
     tabs.sort((a, b) => Number(!!catalogTabNonce(b)) - Number(!!catalogTabNonce(a)) || a.id - b.id);
     const proofs = await Promise.all(tabs.map(candidate => catalogProbe(candidate.id, catalogTabNonce(candidate))));
-    let tab = tabs.find((_candidate, index) => proofs[index]?.ready === true);
+    let tab = tabs.find((candidate, index) => proofs[index]?.ready === true &&
+      (!owner || owner.nonce !== wanted?.nonce || candidate.id === owner.tab));
     if (wanted && Date.now() >= wanted.expiresAt) return;
     if (!wanted && !tab) return;
     if (!tab) {
       // An existing helper may be temporarily busy. Retain it and wait.
-      if (tabs.some(candidate => catalogTabNonce(candidate))) return;
+      if (wanted.allowOpen === false || owner?.nonce === wanted.nonce || tabs.some(candidate => catalogTabNonce(candidate))) return;
       tab = await createChatTab(`https://chatgpt.com/?cos-model-catalog=${wanted.nonce}`, true);
+      await chrome.storage.session.set({ modelCatalogOwner: { nonce: wanted.nonce, tab: tab.id } });
       await chrome.tabs.update(tab.id, { autoDiscardable: false });
       return;
     }
-    // App startup can open a second marked helper before its bridge sees the
-    // surviving extension. One ready keeper owns discovery; retire only proven
-    // empty duplicates through the existing document-scoped close protocol.
-    const retireDuplicates = async () => {
-      if (!catalogTabNonce(tab)) return;
-      for (const duplicate of tabs) {
-        if (duplicate.id === tab.id || !catalogTabNonce(duplicate) || duplicate.pendingUrl) continue;
-        const source = { tab: duplicate.id, documentId: tabDocuments[String(duplicate.id)], navigationEpoch: tabEpochs[String(duplicate.id)] };
+    // Discovery completion releases every dedicated blank renderer, including the
+    // elected tab. Borrowed user documents never carry cleanup authority.
+    const retireCatalogTabs = async () => {
+      for (const candidate of tabs) {
+        if (!catalogTabNonce(candidate) || candidate.pendingUrl) continue;
+        const source = { tab: candidate.id, documentId: tabDocuments[String(candidate.id)], navigationEpoch: tabEpochs[String(candidate.id)] };
         if (!ownsDocument(source)) continue;
         try {
           let timer;
           const proof = await Promise.race([
-            chrome.tabs.sendMessage(duplicate.id, { type: 'clf-tab-close-check', conversationId: null }, { documentId: source.documentId }),
+            chrome.tabs.sendMessage(candidate.id, { type: 'clf-tab-close-check', conversationId: null }, { documentId: source.documentId }),
             new Promise(resolve => { timer = setTimeout(() => resolve(null), 3000); })
           ]).finally(() => clearTimeout(timer));
-          const [keeper, latest] = await Promise.all([chrome.tabs.get(tab.id), chrome.tabs.get(duplicate.id)]);
+          const latest = await chrome.tabs.get(candidate.id);
           if (proof?.safe !== true || proof.conversationId !== null || proof.navigationEpoch !== source.navigationEpoch || !ownsDocument(source) ||
-            keeper.pendingUrl || keeper.url !== tab.url || latest.pendingUrl || latest.url !== duplicate.url) continue;
-          await chrome.tabs.remove(duplicate.id);
-        } catch { /* Busy, drafting or changed documents keep their tab. */ }
+            latest.pendingUrl || latest.url !== candidate.url) continue;
+          await chrome.tabs.remove(candidate.id);
+        } catch { /* Busy, drafting or changed documents keep their tab for ordinary maintenance. */ }
       }
     };
-    if (!wanted) { await retireDuplicates(); return; }
+    if (!wanted) { await retireCatalogTabs(); return; }
+    await chrome.storage.session.set({ modelCatalogOwner: { nonce: wanted.nonce, tab: tab.id } });
     modelCatalogTarget = { tab: tab.id, nonce: wanted.nonce, url: tab.url || tab.pendingUrl };
     let timer;
     try {
@@ -1867,7 +1922,7 @@ function inspectRequestedModels(request) {
         chrome.tabs.sendMessage(tab.id, { type: 'clf-model-catalog', nonce: wanted.nonce, expiresAt: wanted.expiresAt }),
         new Promise(resolve => { timer = setTimeout(resolve, Math.min(35000, wanted.expiresAt - Date.now())); })
       ]);
-      if (inspected?.ok === true) await retireDuplicates();
+      if (inspected?.ok === true) await retireCatalogTabs();
     } finally { clearTimeout(timer); }
   })().catch(() => undefined).finally(() => { modelCatalogTarget = null; modelCatalogFlight = null; });
   return modelCatalogFlight;
@@ -1932,6 +1987,7 @@ async function applyRequestedBrowserPreferences(request) {
 
 /** Retire idle app-owned documents and redundant copies, preserving exact unsent drafts. */
 async function pruneManagedTabs(tabs, policy, protectedChats, closable) {
+  const retired = new Set((Array.isArray(policy.retiredConversations) ? policy.retiredConversations : []).map(cleanConversationId).filter(Boolean));
   const managed = new Set((Array.isArray(policy.managedConversations) ? policy.managedConversations : []).map(cleanConversationId).filter(Boolean));
   for (const id of closable) managed.add(id);
   const blocked = new Set((Array.isArray(policy.blockedConversations) ? policy.blockedConversations : []).map(cleanConversationId).filter(Boolean));
@@ -1941,6 +1997,8 @@ async function pruneManagedTabs(tabs, policy, protectedChats, closable) {
   const keeper = new Map();
   for (const tab of ordered) if (owned(tab) && !keeper.has(conversationForTab(tab))) keeper.set(conversationForTab(tab), tab.id);
   const keep = Number.isInteger(policy.tabsToKeepOpen) ? Math.max(1, policy.tabsToKeepOpen) : 1;
+  const workers = new Set((Array.isArray(policy.workerConversations) ? policy.workerConversations : []).map(cleanConversationId).filter(Boolean));
+  const sleeping = new Set((Array.isArray(policy.sleepingWorkerConversations) ? policy.sleepingWorkerConversations : []).map(cleanConversationId).filter(Boolean));
   const activity = policy.conversationActivityAt || {};
   // Evict by model work/turn completion, never by which browser tab was selected.
   const candidates = ordered.filter(owned).sort((a, b) =>
@@ -1952,15 +2010,23 @@ async function pruneManagedTabs(tabs, policy, protectedChats, closable) {
     if (!Number.isInteger(tab.id)) continue;
     const duplicate = keeper.get(conversationId) !== tab.id && remaining.some(other => other.id !== tab.id && conversationForTab(other) === conversationId);
     if (protectedChats.has(conversationId)) continue;
-    if (!duplicate && (remaining.filter(owned).length <= keep || !closable.has(conversationId))) continue;
+    // The two-minute idle deadline applies below capacity too. Only stopped workers
+    // may be evicted early to make room; primes/helpers never consume worker slots.
+    const workerSurplus = sleeping.has(conversationId) && remaining.filter(other => workers.has(conversationForTab(other))).length > keep;
+    if (!duplicate && !retired.has(conversationId) && !closable.has(conversationId) && !workerSurplus) continue;
     const source = { tab: tab.id, documentId: tabDocuments[String(tab.id)], navigationEpoch: tabEpochs[String(tab.id)] };
     if (!ownsDocument(source) || journalCountForConversation(conversationId) > 0) continue;
+    const cancelledClaims = (Array.isArray(policy.cancelledDecisionClaims) ? policy.cancelledDecisionClaims : [])
+      .filter(claim => claim.conversationId === conversationId);
+    const cancelledDecisions = cancelledClaims.filter(claim => claim.owner === `${source.tab}:${source.documentId}:${source.navigationEpoch}`);
+    // Cancellation names a document, not every future tab that happens to reopen its chat.
+    if (cancelledClaims.length && !cancelledDecisions.length) continue;
     try {
       const current = await chrome.tabs.get(tab.id);
       if (conversationFromUrl(current.url) !== conversationId || current.pendingUrl) continue;
 
       const proof = await chrome.tabs.sendMessage(tab.id, { type: 'clf-tab-close-check', conversationId,
-        allowGenerating: blocked.has(conversationId) }, { documentId: source.documentId });
+        allowGenerating: blocked.has(conversationId), ...(cancelledDecisions.length ? { cancelledDecisions } : {}) }, { documentId: source.documentId });
       if (proof?.safe !== true || proof.conversationId !== conversationId || proof.navigationEpoch !== source.navigationEpoch || !ownsDocument(source)) continue;
       const latest = await chrome.tabs.get(tab.id);
       if (latest.pendingUrl || conversationFromUrl(latest.url) !== conversationId || !ownsDocument(source) || journalCountForConversation(conversationId) > 0) continue;
@@ -1996,12 +2062,14 @@ async function maintainOnce() {
   offerStopTurns(reply.data.stopTurns);
   const area = reply.data.browserWorkArea;
   backgroundWorkArea = area && ['x', 'y', 'width', 'height'].every(key => Number.isInteger(area[key])) && area.width > 0 && area.height > 0
-    ? { left: area.x, top: area.y, width: area.width, height: area.height } : null;
+    ? { left: area.x + Math.floor((area.width - Math.min(1100, area.width)) / 2),
+        top: area.y + Math.floor((area.height - Math.min(800, area.height)) / 2),
+        width: Math.min(1100, area.width), height: Math.min(800, area.height) } : null;
   const backgroundReady = await reconcileBackgroundWindow(reply.data);
-  if (reply.data.placement?.background === true) await placeSuccessorChat(reply.data.placement, null);
+  if (reply.data.placement) await placeSuccessorChat(reply.data.placement, null);
   inspectRequestedModels(reply.data.modelCatalogRequest);
-  inspectRequestedPluginRefresh(reply.data.pluginRefreshRequests, reply.data.background === true);
-  await deliverDesktopInputs(reply.data.inputs, reply.data.background === true);
+  inspectRequestedPluginRefresh(reply.data.pluginRefreshRequests, reply.data.background === true, reply.data.browserOnly === true);
+  await deliverDesktopInputs(reply.data.inputs, reply.data.background === true, reply.data.inputOpeningIds);
   if (!backgroundReady) await reconcileBackgroundWindow(reply.data);
   const monitoring = reply.data.recoveryMonitoring === true;
   if (monitoring !== recoveryMonitoring) {
@@ -2092,16 +2160,15 @@ async function maintainOnce() {
     const [target] = (owned.length > 0 ? owned : candidates).sort((a, b) => a.id - b.id);
     const repairAction = target ? 'reloaded' : 'reopened';
     try {
-      // A repair the app wants in front of the user — an automatic compaction's pickup — raises
-      // the tab and its window before acting. A background tab is a throttled tab, and the
-      // page this reload brings back has tens of seconds of work to do in it.
+      // Select the working tab within Chrome without stealing OS focus from the
+      // desktop app. Tab selection and window activation are separate operations.
       if (target && focus) {
         await chrome.tabs.update(target.id, { active: true });
-        if (typeof target.windowId === 'number') await chrome.windows.update(target.windowId, { focused: true });
       }
       if (target) await chrome.tabs.reload(target.id);
       else {
-        await createChatTab(`https://chatgpt.com/c/${encodeURIComponent(conversationId)}`, !focus && reply.data.background === true, focus);
+        if (reply.data.browserOnly === true) continue;
+        await createChatTab(`https://chatgpt.com/c/${encodeURIComponent(conversationId)}`, reply.data.background === true, focus);
       }
     } catch {
       // A tab changed between the scan and action, or Chrome refused it. Report the exact failed
@@ -2236,6 +2303,27 @@ function conversationFromUrl(value) {
   }
 }
 
+/**
+ * The ChatGPT Project a URL belongs to, or null.
+ *
+ * Matches src/main/session/continuation.ts's
+ * normalizeProjectId: only `g-p-` plus 32 hex digits counts. A Project chat's path appends the
+ * Project's display name to that id, so the name is stripped here rather than carried into an
+ * address that a rename would invalidate. Custom GPTs are also served from `/g/`, and their
+ * slugs do not have this shape, so they are correctly not Projects.
+ */
+function projectFromUrl(value) {
+  try {
+    const url = new URL(String(value || ''));
+    if (url.protocol !== 'https:' || (url.hostname !== 'chatgpt.com' && url.hostname !== 'chat.openai.com')) return null;
+    if (url.pathname.length > 512) return null;
+    const match = /^\/g\/(g-p-[0-9a-f]{32})(?:-[^/]*)?\//i.exec(url.pathname);
+    return match ? match[1].toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}
+
 function isChatGptUrl(value) {
   try {
     const url = new URL(String(value || ''));
@@ -2264,12 +2352,12 @@ const HANDLERS = {
     if (!ownsDocument(source) || !/^[a-f0-9-]{36}$/i.test(String(message.id || ''))) return { ok: false };
     const tab = await chrome.tabs.get(source.tab);
     if (!ownsDocument(source) || pluginRefreshMarker(tab) !== message.id) return { ok: false };
-    if (!['claim', 'current', 'complete', 'fail'].includes(message.action)) return { ok: false };
+    if (!['claim', 'current', 'manual', 'complete', 'fail'].includes(message.action)) return { ok: false };
     const body = JSON.stringify({ action: message.action, id: message.id, appId: message.appId, connectorName: message.connectorName, tools: message.tools, versionId: message.versionId, error: message.error });
     if (body.length > 310000) return { ok: false };
     const result = await call('/plugin-refresh', { method: 'POST', body });
     if (!ownsDocument(source) || pluginRefreshMarker(await chrome.tabs.get(source.tab)) !== message.id) return { ok: false };
-    if (['current', 'complete', 'fail'].includes(message.action) && result.ok && result.data?.ok) void maintain();
+    if (['current', 'manual', 'complete', 'fail'].includes(message.action) && result.ok && result.data?.ok) void maintain();
     return result;
   },
   async model_catalog(message, _sender, source) {
@@ -2307,6 +2395,11 @@ const HANDLERS = {
     if (message.ack === true && message.lifetime !== 'temporary-planner') {
       if (message.conversationId !== conversationId || !ownsDocument(source)) return { ok: false, error: 'stale_send_receipt' };
       return ackDesktopInput(id, owner, conversationId, message.messageId);
+    }
+    if (typeof message.attachmentId === 'string') {
+      if (message.owner !== owner || !ownsDocument(source)) return { ok: false };
+      const result = await call('/input/attachment', { method: 'POST', body: JSON.stringify({ id, owner, conversationId, attachmentId: message.attachmentId, offset: message.offset }) });
+      return ownsDocument(source) ? result : { ok: false, error: 'stale_document' };
     }
     const result = await call(typeof message.partial === 'string' ? '/input/progress' : typeof message.response === 'string' ? '/input/answer' : message.fail === true ? '/input/fail' : message.ack === true ? '/input/ack' : '/input/claim', {
       method: 'POST', body: JSON.stringify({ id, owner, conversationId, requiresAuthorization: message.requiresAuthorization === true, authorize: message.authorize === true, partial: typeof message.partial === 'string' ? message.partial.slice(-8000) : undefined, messageId: typeof message.messageId === 'string' ? message.messageId : undefined, error: message.error, response: typeof message.response === 'string' ? message.response.slice(0, 16001) : undefined })
@@ -2631,10 +2724,19 @@ const HANDLERS = {
     if (!ownsDocument(source)) return { ok: false, error: 'stale_document' };
     await noteTabConversation(source, message.conversationId);
     if (!ownsDocument(source)) return { ok: false, error: 'stale_document' };
+    // MessageSender.url can still name the document's initial New Chat address after
+    // ChatGPT assigns /c/B through an SPA transition. Read Chrome's current tab and
+    // retain the exact document/epoch lease across that await before accepting its route.
+    const tab = await chrome.tabs.get(source.tab).catch(() => null);
+    if (!ownsDocument(source) || !tab || tab.pendingUrl || tab.status === 'loading' ||
+        !isChatGptUrl(tab.url) || conversationFromUrl(tab.url) !== cleanConversationId(message.conversationId))
+      return { ok: false, error: 'stale_document' };
+    const sourceUrl = tab.url;
     const result = await call('/compact', {
       method: 'POST',
       body: JSON.stringify({
         conversationId: message.conversationId,
+        ...(sourceUrl ? { project: projectFromUrl(sourceUrl) } : {}),
         resume: message.resume !== false,
         cancel: message.cancel === true,
         ticket: message.ticket === true,
@@ -2654,7 +2756,8 @@ const HANDLERS = {
           ? { token: message.token, sourceDispatch: true }
           : {}),
         ...(typeof message.token === 'string' && typeof message.sourceMessageId === 'string'
-          ? { token: message.token, sourceMessageId: message.sourceMessageId }
+          ? { token: message.token, sourceMessageId: message.sourceMessageId,
+              ...(Number.isSafeInteger(message.sourceProgress) ? { sourceProgress: message.sourceProgress } : {}) }
           : {}),
         ...(typeof message.token === 'string' && message.destinationAttempt === true
           ? { token: message.token, destinationAttempt: true }
@@ -2710,7 +2813,7 @@ const HANDLERS = {
     return ownsDocument(source) ? result : { ok: false, error: 'stale_document' };
   },
   /**
-   * Raises the exact tab whose owned document is about to act on its own — a Goal draft, an
+   * Selects the exact tab whose owned document is about to act on its own — a Goal draft, an
    * automatic Compact & Resume.
    *
    * The sender is the locator. Never search by conversation and never open a fallback: focus is
@@ -2718,7 +2821,7 @@ const HANDLERS = {
    * background visibility out of completion/draft/compaction authority and makes a duplicate
    * tab impossible on this path.
    */
-  async focus_tab(message, sender, source) {
+  async focus_tab(message, _sender, source) {
     await load();
     if (!ownsDocument(source)) return { ok: false, error: 'stale_document' };
     const conversationId = cleanConversationId(message.conversationId);
@@ -2733,10 +2836,7 @@ const HANDLERS = {
       if (!ownsDocument(source)) return { ok: false, error: 'stale_document' };
     }
     try {
-      const activated = await chrome.tabs.update(source.tab, { active: true });
-      const senderWindow = sender && sender.tab && typeof sender.tab.windowId === 'number' ? sender.tab.windowId : null;
-      const windowId = senderWindow ?? (activated && typeof activated.windowId === 'number' ? activated.windowId : null);
-      if (windowId !== null) await chrome.windows.update(windowId, { focused: true });
+      await chrome.tabs.update(source.tab, { active: true });
     } catch {
       // Focus is a courtesy. The page owns Goal regardless, so browser/UI refusal must not turn
       // a valid hidden completion into a failed continuation.
@@ -2884,7 +2984,7 @@ const HANDLERS = {
     const id = deferredRevivalId(message.id);
     if (!id) return { ok: false, error: 'bad_command_id' };
     const senderTabId = Number.isInteger(source?.tab) ? source.tab : null;
-    const remembered = await rememberDeferredRevival(id, conversationId);
+    const remembered = await rememberDeferredRevival(id, conversationId, true);
     if (remembered && senderTabId !== null) deferredRevivalOffers.set(id, senderTabId);
     return remembered ? { ok: true, deferred: true } : { ok: false, error: 'bad_command_id' };
   },
@@ -3146,10 +3246,15 @@ function deferredRevivalUrl(entry) {
  * reason this decision lives here rather than in the app.
  *
  * The offer is spent by the app on handout, so this runs once per command; a second poll, from
- * this tab or another tab of the same chat, is never given the same id. Nothing is retried
- * locally either — when no redeem arrives the app opens it the old way, which is the only
- * recovery that still works if this window is closing.
+ * this tab or another tab of the same chat, is never given the same id. Missing redemption
+ * ends at the command deadline; it never grants another browser-opening attempt.
  */
+/** Only the continuation's captured Project chooses a successor's scope. */
+function successorChatBase(offered) {
+  const project = typeof offered === 'string' && /^g-p-[0-9a-f]{32}$/.test(offered) ? offered : null;
+  return project ? `https://chatgpt.com/g/${project}/project` : 'https://chatgpt.com/';
+}
+
 async function placeSuccessorChat(raw, tabId) {
   const id = commandMarkerId(raw && raw.id);
   if (id && raw.background === true) {
@@ -3159,7 +3264,7 @@ async function placeSuccessorChat(raw, tabId) {
     const query = [marker];
     if (model) query.push(`model=${encodeURIComponent(model)}`);
     if (effort) query.push(`reasoning_effort=${encodeURIComponent(effort)}`);
-    const created = await createChatTab(`https://chatgpt.com/?${query.join('&')}#${marker}`, true);
+    const created = await createChatTab(`${successorChatBase(raw.project)}?${query.join('&')}#${marker}`, true);
     if (Number.isInteger(created?.id)) {
       await chrome.tabs.update(created.id, { autoDiscardable: false });
       discardProtectedTabs[String(created.id)] = true;
@@ -3167,13 +3272,22 @@ async function placeSuccessorChat(raw, tabId) {
     }
     return;
   }
-  if (!id || typeof tabId !== 'number') return;
+  if (!id) return;
+  if (typeof tabId !== 'number') {
+    const conversationId = cleanConversationId(raw.homeConversationId);
+    if (!conversationId) return;
+    try {
+      const tabs = await chrome.tabs.query({ url: CHATGPT_TAB_URLS });
+      tabId = tabs.filter(tab => conversationForTab(tab) === conversationId).sort((a, b) => a.id - b.id)[0]?.id;
+    } catch { return; }
+    if (typeof tabId !== 'number') return;
+  }
   let home = null;
   try {
     home = await chrome.tabs.get(tabId);
   } catch {
-    // The polling tab closed between its request and this reply. Nothing here can place a
-    // window-bound tab without it, and the app's fallback is what covers exactly this.
+    // The polling tab closed between its request and this reply. Its operation has spent
+    // opening authority, so the command deadline reports the unsuccessful placement.
     return;
   }
   if (!home || typeof home.windowId !== 'number') return;
@@ -3185,15 +3299,19 @@ async function placeSuccessorChat(raw, tabId) {
   const query = [marker];
   if (model) query.push(`model=${encodeURIComponent(model)}`);
   if (reasoningEffort) query.push(`reasoning_effort=${encodeURIComponent(reasoningEffort)}`);
-  const create = { url: `https://chatgpt.com/?${query.join('&')}#${marker}`, windowId: home.windowId, active: true };
+  const create = { url: `${successorChatBase(raw.project)}?${query.join('&')}#${marker}`, windowId: home.windowId, active: raw.active !== false };
   // Directly after the chat it continues, so a handoff reads as one piece of work instead of a
   // tab appended to the far end of a long strip.
   if (typeof home.index === 'number') create.index = home.index + 1;
   try {
-    await chrome.tabs.create(create);
+    const created = await chrome.tabs.create(create);
+    if (raw.active === false && Number.isInteger(created?.id)) {
+      await chrome.tabs.update(created.id, { autoDiscardable: false });
+      discardProtectedTabs[String(created.id)] = true;
+      await persistLive();
+    }
   } catch {
-    // Window teardown or browser policy rejected the create. The app's placement fallback
-    // turns that into an ordinary OS open rather than a lost command.
+    // Opening authority was spent. The command deadline reports an unsuccessful attempt.
   }
 }
 
@@ -3205,12 +3323,41 @@ async function acceptBrowserRevival(raw) {
 }
 
 /**
+ * Reconciles browser-persisted wake markers with the app before recovery can create a tab.
+ *
+ * The marker deliberately survives a browser restart, while the corresponding app command can
+ * be cancelled, committed, superseded or retired during the same interval. Treating the marker
+ * itself as proof of live work lets a dead id reopen its old ChatGPT conversation on every
+ * browser startup. The app owns command truth, so ask it once for the whole bounded set and fail
+ * closed on transport/version errors: keeping an inert marker for a later retry is harmless;
+ * opening an unproven tab is not.
+ */
+async function reconcileDeferredRevivalsWithApp() {
+  if (deferredRevivals.length === 0) return true;
+  const entries = deferredRevivals
+    .map((entry) => ({ id: deferredRevivalId(entry?.id), conversationId: cleanConversationId(entry?.conversationId) }))
+    .filter((entry) => entry.id && entry.conversationId)
+    .slice(-100);
+  const result = await call('/commands/revivals/pending', {
+    method: 'POST',
+    body: JSON.stringify({ entries })
+  });
+  if (!result.ok || !Array.isArray(result.data?.pending)) return false;
+
+  const pending = new Set(result.data.pending.filter((id) => typeof id === 'string'));
+  const before = deferredRevivals.length;
+  deferredRevivals = deferredRevivals.filter((entry) => pending.has(entry?.id));
+  if (deferredRevivals.length !== before) await persistLive();
+  return true;
+}
+
+/**
  * Re-presents deferred revival markers after MV3/document/browser lifetime loss.
  *
  * There is deliberately no command text here and no local "sent" decision. An existing exact
  * conversation gets first chance to install the content-side readiness waiter. A marked exact
- * chat is created only when the scan finds none, or a complete existing document cannot receive
- * and cannot be repaired. Either path still has to win `/commands/redeem`, so several recovery
+ * chat is created only after the app confirms a live command and the scan proves absence.
+ * Either path still has to win `/commands/redeem`, so several recovery
  * triggers cannot duplicate or cross-deliver text.
  */
 function recoverDeferredRevivals() {
@@ -3227,30 +3374,34 @@ function recoverDeferredRevivals() {
     if (deferredRevivals.length !== before) await persistLive();
     if (deferredRevivals.length === 0) return;
 
+    if (!(await reconcileDeferredRevivalsWithApp()) || deferredRevivals.length === 0) return;
+
     let tabs = [];
     try {
       tabs = await chrome.tabs.query({ url: CHATGPT_TAB_URLS });
     } catch {
-      tabs = [];
+      return;
     }
 
     for (const entry of [...deferredRevivals]) {
       const exact = tabs
         .filter((tab) => tab && typeof tab.id === 'number' && conversationForTab(tab) === entry.conversationId)
         .sort((a, b) => a.id - b.id);
+      if (!entry.openingSpent) {
+        entry.openingSpent = true;
+        await persistLive();
+      } else if (!exact.length) continue;
       let routed = false;
-      let starting = false;
       for (const tab of exact) {
         if (await restoreChatgptTab(tab.id)) {
           offerDeferredRevivalToTab(entry, tab);
           routed = true;
           break;
         }
-        // A loading document is not proven broken. Let its registration or the next alarm retry
-        // the same tab; opening during this transient is the original duplication race.
-        if (tab.status !== 'complete') starting = true;
       }
-      if (routed || starting) continue;
+      // A failed receiver/injection is not proof that its tab is absent. Keep the exact
+      // conversation as the only target, including complete but temporarily inaccessible pages.
+      if (routed || exact.length) continue;
 
       const url = deferredRevivalUrl(entry);
       if (!url) continue;
@@ -3259,8 +3410,8 @@ function recoverDeferredRevivals() {
         const created = await chrome.tabs.create({ url, active: false });
         if (created && typeof created.id === 'number') tabs.push({ ...created, url });
       } catch {
-        // Browser policy/window teardown can reject create; the local marker remains for the next
-        // browser/service-worker lifetime instead of turning that transport failure into a wake failure.
+        // Opening authority stays spent even if Chrome rejects creation. The app's command
+        // deadline reports failure; a browser/service-worker restart cannot mint another tab.
       }
     }
   })();
@@ -3302,8 +3453,7 @@ async function restoreChatgptTab(id) {
     // re-run revival routing; opening a second tab during that handoff recreates the race.
     return true;
   } catch {
-    // A complete exact tab that cannot receive or be repaired is proven unusable. Revival may
-    // open one replacement; a loading tab is handled conservatively by the caller.
+    // Injection failure does not transfer ownership to a replacement tab.
     return false;
   }
 }

--- a/extension/chatgpt-dom.js
+++ b/extension/chatgpt-dom.js
@@ -29,23 +29,9 @@ var CLF_DOM = (() => {
   // Keep both explicit structural anchors; hashed CSS-module names remain off limits.
   const TOOL_LEGACY = 'span[class*="tool-message"]';
   const TOOL = `${TOOL_LEGACY}, div.pointer-events-none.contents`;
-  /**
-   * The control ChatGPT puts inside a *connector* tool row and nowhere else.
-   *
-   * Collapsed, a connector row carries no name, no tool id and no connector attribute —
-   * inspected live it is a `group/tool-message` span wrapping a button whose only
-   * distinguishing mark is this label, above turn-level attributes that say nothing about
-   * what ran. The identity ChatGPT holds (`api_tool`, the connector's name, the request
-   * path) appears only once the row or its side panel is opened, and opening rows behind
-   * the user's back to read it is not something this extension will do.
-   *
-   * So this is the one structural thing that separates a connector row from a built-in
-   * one — "Searched the web" and friends are a different component. It matters because
-   * the app uses these rows as its only evidence of *where a tool call came from*: a row
-   * that is not a connector row must never vouch for a connector call, or a turn that
-   * merely searched the web ends up adopting a call made from another device.
-   */
-  const CONNECTOR = '[aria-label="Open tool call list" i]';
+  // MAIN-world scan stamps only a row whose own message group proves api_tool.
+  // A translated label or a generic built-in tool button never establishes identity.
+  const CONNECTOR = '[data-clf-fiber]';
   const STOP =
     'button[data-testid="stop-button"], button[data-testid="composer-stop-button"], ' +
     'button[aria-label="Stop streaming"], button[aria-label="Stop generating"], button[aria-label="Stop answering"]';
@@ -580,10 +566,17 @@ var CLF_DOM = (() => {
     const changed = event => { if (event.isTrusted) touched = true; };
     for (const name of events) host?.addEventListener(name, changed, true);
     const same = () => !touched && stillCurrent() && composer() === box && box?.isConnected && box.textContent === insertedText;
+    const ownsAttachments = () => {
+      if (!same() || !host) return false;
+      const current = [...host.querySelectorAll('button[aria-label]')].filter(node => composerFileName(node));
+      return current.length === files.length && current.every(node => files.includes(node)) &&
+        !host.querySelector('[aria-busy="true"], [role="progressbar"], [data-inline-file-uploading]');
+    };
     return {
       attachments(nodes) { if (same()) files = [...nodes]; },
+      current: ownsAttachments,
       async clear() {
-        if (!same() || !host) return false;
+        if (!ownsAttachments() || !host) return false;
         const current = [...host.querySelectorAll('button[aria-label]')].filter(node => composerFileName(node));
         if (current.length !== files.length || current.some(node => !files.includes(node)) ||
             host.querySelector('[aria-busy="true"], [role="progressbar"], [data-inline-file-uploading]')) return false;
@@ -1379,7 +1372,14 @@ var CLF_DOM = (() => {
    */
   function composerActions() {
     return safe(() => {
-      const anchor = document.querySelector(SEND) || document.querySelector(STOP) || document.querySelector(SPEECH);
+      // The current provider microphone has no stable button test id; its sprite and
+      // composer trailing parent identify it without interpreting a translated label.
+      const anchor = document.querySelector(SEND) || document.querySelector(STOP) || document.querySelector(SPEECH) ||
+        [...(composerBox()?.querySelectorAll(`${TRAILING} button`) || [])]
+        .find(button => !button.closest(OWN_SURFACES) && [...button.querySelectorAll('svg use')].some(use => {
+          const href = use.getAttribute('href') || use.getAttribute('xlink:href') || '';
+          return href.slice(href.lastIndexOf('#')) === '#microphone-regular-24';
+        }));
       const explicit = anchor ? anchor.closest(TRAILING) : document.querySelector(TRAILING);
       if (!anchor) return explicit ? { host: explicit, before: null } : null;
 
@@ -1592,7 +1592,7 @@ var CLF_DOM = (() => {
     }, false);
   }
 
-  async function send({ acceptanceTimeoutMs = 30000, stillCurrent = () => true } = {}) {
+  async function send({ acceptanceTimeoutMs = 30000, stillCurrent = () => true, matchesUser = null, observeEvidence = null, clearAcceptedDraft = true } = {}) {
     try {
       const box = composer();
       if (!box || !box.isConnected || !stillCurrent() || generating() || stopButton()) return false;
@@ -1610,6 +1610,7 @@ var CLF_DOM = (() => {
       const priorUsers = messages().filter((message) => message.role === 'user');
       const priorUserNodes = new Set(priorUsers.map((message) => message.node));
       const priorUserIds = new Set(priorUsers.map((message) => message.id).filter(Boolean));
+      let submittedMessageObserved = false;
 
       // click()/dispatchEvent() only prove that JavaScript ran, not that ChatGPT accepted a
       // prompt. Observe for a page-owned consequence instead of sleeping and re-sampling on a
@@ -1624,7 +1625,10 @@ var CLF_DOM = (() => {
         for (let at = visible.length - 1; at >= 0; at--) {
           const message = visible[at];
           if (message.role !== 'user') continue;
-          if (!priorUserNodes.has(message.node) && !priorUserIds.has(message.id) && compact(message.text) === expected) return true;
+          if (!priorUserNodes.has(message.node) && !priorUserIds.has(message.id) && (matchesUser ? matchesUser(message, submitted) : compact(message.text) === expected)) {
+            submittedMessageObserved = true;
+            return true;
+          }
         }
         if (currentConversation !== beforeConversation) return false;
         const current = composer();
@@ -1638,11 +1642,18 @@ var CLF_DOM = (() => {
         let done = false;
         let observer = null;
         let timer = null;
+        let unsubscribeEvidence = null;
         const finish = (value) => {
           if (done) return;
           done = true;
           if (observer) observer.disconnect();
+          if (unsubscribeEvidence) unsubscribeEvidence();
           if (timer !== null) clearTimeout(timer);
+          // A fresh matching user row proves this text was accepted. Some provider
+          // transitions retain that same draft; leaving it lets the next Loop append
+          // to and resend the entire bootstrap. Preserve replaced editors/new drafts.
+          if (clearAcceptedDraft && value && submittedMessageObserved && stillCurrent() && composer() === box)
+            clearPromptExact(submitted);
           resolve(value);
         };
         const check = () => {
@@ -1657,6 +1668,7 @@ var CLF_DOM = (() => {
           characterData: true,
           attributes: true
         });
+        if (observeEvidence) unsubscribeEvidence = observeEvidence(check);
         // Observe this one click through late React acceptance; never click again. The
         // upper bound remains below the app's command lease/deadline.
         const timeout = Number.isFinite(acceptanceTimeoutMs) ? Math.max(1, Math.min(30000, acceptanceTimeoutMs)) : 30000;
@@ -1686,68 +1698,44 @@ var CLF_DOM = (() => {
   }
 
   /** Native ChatGPT photo input, observed as #upload-photos. Sending waits for every tile. */
-  const composerFileName = (button) => /^Remove file(?: \d+)?: (.+)$/.exec(button.getAttribute('aria-label') || '')?.[1];
+  function composerFileName(button) {
+    const group = button.closest('[role="group"][aria-label]');
+    if (group?.querySelector('[data-default-action="true"] button')) {
+      const actions = [...group.querySelectorAll('button')].filter(node => !node.closest('[data-default-action="true"]'));
+      return actions.length === 1 && actions[0] === button ? group.getAttribute('aria-label') : undefined;
+    }
+    return /^Remove file(?: \d+)?: (.+)$/.exec(button.getAttribute('aria-label') || '')?.[1];
+  }
   function hasComposerAttachments() {
     const host = composerBox() || composerActions()?.host;
     return !!host && (!!host.querySelector('[data-inline-file-uploading], [role="progressbar"]') ||
       [...host.querySelectorAll('button[aria-label]')].some(button => composerFileName(button)));
   }
   /** Observed ChatGPT Plugins settings surface. Missing/ambiguous structure is not proof. */
-  function pluginRefreshView(connectorName, expectedTools = [], expectedAppId = null) {
-    return safe(() => {
-      const shown = node => node && !node.closest('[hidden],[aria-hidden="true"]') && node.getClientRects().length > 0;
-      const panels = [...document.querySelectorAll('[role="tabpanel"]')].filter(panel => shown(panel) &&
-        text(document.getElementById(panel.getAttribute('aria-labelledby'))).trim() === 'Plugins');
-      if (panels.length !== 1) return null;
-      const panel = panels[0];
-      const headings = [...panel.querySelectorAll('h1,h2,h3,[role="heading"]')].filter(node => shown(node) && text(node) === connectorName);
-      if (!expectedAppId && headings.length !== 1) return null;
-      // Settings uses adjacent label/value divs. textContent concatenates App Id with
-      // its value (and the following label), destroying the identity delimiter.
-      const body = (panel.innerText || text(panel, 400000)).slice(0, 400000);
-      const ids = [...body.matchAll(/App Id\s+(asdk_app_[a-zA-Z0-9_-]+)/g)];
-      const versions = [...body.matchAll(/Version Id\s+(asdk_app_v_[a-zA-Z0-9_-]+)/g)];
-      if (ids.length !== 1 || (expectedAppId && ids[0][1] !== expectedAppId)) return null;
-      const refresh = [...panel.querySelectorAll('button')].filter(node => shown(node) && text(node) === 'Refresh');
-      const identity = { appId: ids[0][1], versionId: versions.length === 1 ? versions[0][1] : null, connectorName,
-        refresh: refresh.length === 1 ? refresh[0] : null };
-      const copies = [...panel.querySelectorAll('button')].filter(node => shown(node) && (text(node) === 'Copy input schema' || node.getAttribute('aria-label') === 'Copy input schema'));
-      const normalize = value => String(value).replace(/\s+/g, ' ').trim();
-      const tools = [];
-      for (const copy of copies.slice(0, 17)) {
-        let block = copy.parentElement;
-        while (block?.parentElement && block.parentElement !== panel &&
-          [...block.parentElement.querySelectorAll('button')].filter(node => text(node) === 'Copy input schema' || node.getAttribute('aria-label') === 'Copy input schema').length === 1) block = block.parentElement;
-        const raw = block?.innerText || block?.textContent || '';
-        const marker = raw.toUpperCase().indexOf('INPUT SCHEMA');
-        if (marker < 0) return { ...identity, tools: null };
-        const prefix = raw.slice(0, marker).trim();
-        const names = [...new Set([...(block?.querySelectorAll('*') || [])].filter(node => node.children.length === 0)
-          .map(node => text(node)).filter(name => /^[a-z][a-z0-9_]{0,79}$/.test(name) && prefix.startsWith(name)))];
-        if (names.length !== 1) return { ...identity, tools: null };
-        const name = names[0], expected = expectedTools.find(tool => tool.name === name);
-        const description = prefix.slice(name.length).trim().replace(/^(?:(?:PUBLIC|READ ONLY|READ|WRITE|OPEN WORLD|CLOSED WORLD|DESTRUCTIVE|IDEMPOTENT|OUTPUT SCHEMA RECOMMENDED)\s*)+/, '').trim();
-        const schemaText = raw.slice(marker + 'INPUT SCHEMA'.length).replace(/^\s*Copy input schema\s*/, '');
-        const start = schemaText.indexOf('{');
-        let end = -1, depth = 0, quoted = false, escaped = false;
-        for (let i = start; i >= 0 && i < Math.min(schemaText.length, 200000); i++) {
-          const char = schemaText[i];
-          if (quoted) { if (escaped) escaped = false; else if (char === '\\') escaped = true; else if (char === '"') quoted = false; }
-          else if (char === '"') quoted = true;
-          else if (char === '{') depth++;
-          else if (char === '}' && --depth === 0) { end = i + 1; break; }
-        }
-        if (start < 0 || end < 0) return { ...identity, tools: null };
-        tools.push({ name, description: expected && normalize(description) === normalize(expected.description) ? expected.description : description, inputSchema: JSON.parse(schemaText.slice(start, end)) });
-      }
-      return { ...identity,
-        tools: copies.length > 0 && copies.length <= 16 && new Set(tools.map(tool => tool.name)).size === tools.length ? tools : null };
-    }, null);
+  async function pluginRefreshView(connectorName, expectedTools = [], expectedAppId = null) {
+    const snapshot = await new Promise(resolve => {
+      const nonce = crypto.randomUUID();
+      const finish = value => { clearTimeout(timer); window.removeEventListener('message', receive); resolve(value); };
+      const receive = event => {
+        const data = event.data;
+        if (event.source === window && event.origin === location.origin && data?.source === 'clf-plugin-reply' && data.nonce === nonce && data.v === 1) finish(data.plugin);
+      };
+      const timer = setTimeout(() => finish(null), 1500);
+      window.addEventListener('message', receive); window.postMessage({ source: 'clf-plugin-ask', nonce }, location.origin);
+    });
+    const route = /^#settings\/Plugins\/plugin_(asdk_app_[a-zA-Z0-9_-]+)$/.exec(location.hash);
+    if (!snapshot || snapshot.appId !== route?.[1] || (expectedAppId ? snapshot.appId !== expectedAppId : snapshot.connectorName !== connectorName) ||
+        !Array.isArray(snapshot.tools) || snapshot.tools.length < 1 || snapshot.tools.length > 16 || JSON.stringify(snapshot.tools).length > 300000 ||
+        snapshot.tools.some(tool => !tool || typeof tool.name !== 'string' || !/^[a-z][a-z0-9_]{0,79}$/.test(tool.name) || typeof tool.description !== 'string' || tool.inputSchema?.type !== 'object') ||
+        new Set(snapshot.tools.map(tool => tool.name)).size !== snapshot.tools.length) return null;
+    const buttons = [...document.querySelectorAll('button[data-clf-plugin-refresh]')].filter(button => button.getAttribute('data-clf-plugin-refresh') === snapshot.appId && button.getClientRects().length > 0);
+    return typeof snapshot.refreshAvailable === 'boolean' && buttons.length === (snapshot.refreshAvailable ? 1 : 0) ? { appId: snapshot.appId, connectorName: snapshot.connectorName, versionId: typeof snapshot.versionId === 'string' ? snapshot.versionId.slice(0, 200) : null,
+      tools: snapshot.tools.map(({ name, description, inputSchema }) => ({ name, description, inputSchema })), refresh: buttons[0] || null } : null;
   }
   function pluginInstalledButtons(connectorName) {
     return safe(() => {
       const panels = [...document.querySelectorAll('[role="tabpanel"]')].filter(panel => panel.getClientRects().length > 0 &&
-        text(document.getElementById(panel.getAttribute('aria-labelledby'))).trim() === 'Plugins');
+        panel.getAttribute('aria-labelledby')?.endsWith('-trigger-Plugins'));
       if (panels.length !== 1) return null;
       // Installed settings rows are buttons, not the links in the /plugins catalog.
       // Match the name's own leaf so adjacent permission text cannot alter identity.
@@ -1760,15 +1748,17 @@ var CLF_DOM = (() => {
   function pluginManagementIdle() {
     return safe(() => ![...document.querySelectorAll('textarea,input:not([type="hidden"]),[contenteditable="true"]')].some(node => node.getClientRects().length > 0 && String(node.value || node.textContent || '').trim()), false);
   }
-  async function uploadImages(images, stillCurrent = () => true, draft = null) {
+  async function uploadImages(images, stillCurrent = () => true, draft = null, files = []) {
+    if (files.length) images = [...(images || []), ...files];
     if (!images?.length) return true;
-    if (!Array.isArray(images) || images.length > 4 || !stillCurrent() || hasComposerAttachments()) return false;
-    const input = document.querySelector('input#upload-photos[type="file"][accept="image/*"]');
+    if (!Array.isArray(images) || images.length > 20 || !stillCurrent() || hasComposerAttachments()) return false;
+    const input = document.querySelector(files.length ? 'input#upload-files[type="file"]' : 'input#upload-photos[type="file"][accept="image/*"]');
     if (!input) return false;
     const priorTiles = new Set((composerBox() || composerActions()?.host)?.querySelectorAll('button[aria-label]') || []);
     const transfer = new DataTransfer();
     try {
       for (const image of images) {
+        if (image instanceof File) { transfer.items.add(image); continue; }
         if (typeof image.name !== 'string' || !/^data:image\/webp;base64,[A-Za-z0-9+/]+={0,2}$/.test(image.dataUrl) || image.dataUrl.length > 512100) return false;
         const raw = atob(image.dataUrl.split(',')[1]);
         const bytes = Uint8Array.from(raw, (char) => char.charCodeAt(0));
@@ -1804,193 +1794,168 @@ var CLF_DOM = (() => {
       };
       observer = new MutationObserver(check);
       observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true });
-      timer = setTimeout(() => finish(false), 60000);
+      timer = setTimeout(() => finish(false), files.length ? 600000 : 60000);
       check();
     });
   }
 
-  const CHAT_EFFORT_LABELS = { none: 'Instant', medium: 'Medium', high: 'High', xhigh: 'Extra High', pro: 'Pro' };
-  const normalizeModelLabel = (value) => String(value || '').toLowerCase().replace(/[^a-z0-9.]/g, '');
-  /** One visible picker adapter for discovery and application; DOM ordinals are authoritative. */
-  function modelPickerAccess(stillCurrent) {
-    const shown = (node) => node && !node.closest('[aria-hidden="true"]') && node.getClientRects().length > 0;
-    const picker = () => document.querySelector('[data-testid="composer-intelligence-picker-content"]');
-    const items = () => [...(picker()?.querySelectorAll('[role="menuitemradio"]') || [])].filter(shown);
-    const trigger = () => [...(composerActions()?.host?.querySelectorAll('button[aria-haspopup="menu"]') || [])]
-      .filter(shown).find((node) => /(?:Instant|Medium|High|Pro|Thinking effort)/i.test(node.textContent || ''));
-    const wait = (read, timeoutMs = 3000) => new Promise((resolve) => {
-      let observer, timer;
-      const finish = (value) => { observer?.disconnect(); clearTimeout(timer); resolve(value); };
-      const check = () => { if (!stillCurrent()) return finish(null); const value = read(); if (value) finish(value); };
-      observer = new MutationObserver(check);
-      observer.observe(document.documentElement, { subtree: true, childList: true, attributes: true, characterData: true });
-      timer = setTimeout(() => finish(null), timeoutMs); check();
+  const normalizeModelLabel = value => String(value || '').toLowerCase().replace(/[^a-z0-9.]/g, '');
+  /** One bounded read through the existing MAIN-world helper; no provider API or setters. */
+  function readPickerState() {
+    return new Promise(resolve => {
+      const nonce = crypto.randomUUID();
+      const finish = value => { clearTimeout(timer); window.removeEventListener('message', receive); resolve(value); };
+      const receive = event => {
+        const data = event.data;
+        if (event.source !== window || event.origin !== location.origin || data?.source !== 'clf-picker-reply' || data.nonce !== nonce || data.v !== 1) return;
+        const state = data.picker;
+        const valid = state && typeof state.version === 'string' && Number.isInteger(state.currentBucket) &&
+          Array.isArray(state.versions) && state.versions.length > 0 && state.versions.length <= 20 &&
+          state.versions.every(v => typeof v.id === 'string' && /^[a-zA-Z0-9._-]{1,80}$/.test(v.id) && typeof v.label === 'string' && v.label.length > 0 && v.label.length <= 80) &&
+          Array.isArray(state.choices) && state.choices.length > 0 && state.choices.length <= 12 &&
+          state.choices.every(c => Number.isInteger(c.bucket) && typeof c.id === 'string' && /^[a-zA-Z0-9._-]{1,80}$/.test(c.id) && typeof c.label === 'string' && c.label.length > 0 && c.label.length <= 80 &&
+            ['none','minimal','low','medium','high','xhigh','max','ultra','pro'].includes(c.effort) && typeof c.available === 'boolean') &&
+          new Set(state.versions.map(v => v.id)).size === state.versions.length && new Set(state.choices.map(c => c.bucket)).size === state.choices.length &&
+          state.versions.some(v => v.id === state.version) && state.choices.some(c => c.bucket === state.currentBucket);
+        finish(valid ? state : null);
+      };
+      const timer = setTimeout(() => finish(null), 1500);
+      window.addEventListener('message', receive);
+      window.postMessage({ source: 'clf-picker-ask', nonce }, location.origin);
     });
-    const power = () => picker()?.querySelector('[role="menuitem"][aria-label="Power"]');
-    // Latest is a routing choice, not a model identity. At Pro the native badge
-    // explicitly names the generation (observed: 6 Pro versus explicit 5.6 Pro).
-    const latestProModel = () => {
-      const label = picker()?.querySelector('[role="menuitem"][aria-label="Select model"]')?.textContent?.trim();
-      const match = label?.match(/^(?:GPT[- ]?)?(\d+(?:\.\d+)?)\s*Pro$/i);
-      return match ? `GPT-${match[1]} Pro` : null;
+  }
+  /** UI only transports a requested selection. Provider state proves identity and availability. */
+  function modelPickerAccess(stillCurrent) {
+    const shown = node => node && !node.closest('[hidden],[aria-hidden="true"],[inert]') && node.getClientRects().length > 0;
+    const picker = () => document.querySelector('[data-testid="composer-intelligence-picker-content"]');
+    const trigger = () => {
+      const candidates = [...(composerActions()?.host?.querySelectorAll('button[aria-haspopup="menu"]') || [])]
+        .filter(node => shown(node) && !node.closest(OWN_SURFACES) && node.id !== 'composer-plus-btn' && node.getAttribute('data-testid') !== 'composer-plus-btn');
+      return candidates.length === 1 ? candidates[0] : null;
     };
-    const current = () => {
-      if (power()?.getAttribute('aria-disabled') === 'true') return null;
-      const description = (power()?.getAttribute('aria-describedby') || '').split(/\s+/).map((id) => document.getElementById(id)?.textContent || '').join(' ');
-      const match = description.match(/(Instant|Medium|Extra High|High|Pro),\s*(\d+) of (\d+)/i);
-      if (!match) return null;
-      const position = Number(match[2]), total = Number(match[3]);
-      return total >= 1 && total <= 12 && position >= 1 && position <= total ? { label: match[1], position, total, available: !/Upgrade required/i.test(description) } : null;
-    };
+    const wait = (read, timeout = 3000) => new Promise(resolve => {
+      let reading = false, dirty = false, done = false;
+      const finish = value => { if (done) return; done = true; observer.disconnect(); clearTimeout(timer); resolve(value); };
+      const check = async () => {
+        if (done) return;
+        if (!stillCurrent()) return finish(null);
+        if (reading) { dirty = true; return; }
+        reading = true;
+        try { let value = read(); if (value?.then) value = await value; if (stillCurrent() && value) finish(value); }
+        catch { finish(null); }
+        finally { reading = false; if (dirty && !done) { dirty = false; void check(); } }
+      };
+      const observer = new MutationObserver(check);
+      observer.observe(document.documentElement, { subtree: true, childList: true, attributes: true, characterData: true });
+      const timer = setTimeout(() => finish(null), timeout); void check();
+    });
+    const state = predicate => wait(async () => { const value = await readPickerState(); return value && (!predicate || predicate(value)) ? value : null; });
+    const key = (node, value) => { if (!node || !stillCurrent()) return false; node.focus(); node.dispatchEvent(new KeyboardEvent('keydown', { key: value, code: value, bubbles: true, cancelable: true })); return true; };
     return {
-      items, current, wait, latestProModel,
-      async models() {
-        const toggle = picker()?.querySelector('[role="menuitem"][aria-label="Select model"]');
-        if (items().length && toggle?.getAttribute('aria-expanded') !== 'false') return items();
-        if (!toggle || !stillCurrent()) return null;
-        toggle.click(); return wait(() => toggle.getAttribute('aria-expanded') !== 'false' && items().length ? items() : null);
-      },
+      state,
       async open() {
-        // A newly created helper registers before React necessarily mounts the composer.
-        // Observe that same document becoming ready, instead of freezing a null trigger.
-        const button = await wait(trigger, 15000);
-        if (!button || !stillCurrent()) return false;
-        if (!picker()) {
-          // Native menu triggers handle keyboard/pointer activation; HTMLElement.click()
-          // alone does not exercise their pointer-down opening contract.
-          button.focus();
-          button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', bubbles: true, cancelable: true }));
+        if (!picker()) { const button = await wait(trigger, 15000); if (!key(button, 'Enter') || !await wait(picker)) return null; }
+        return state();
+      },
+      close() { key(trigger(), 'Escape'); },
+      async version(version) {
+        const before = await state(); if (!before) return null;
+        const versionRows = () => [...(picker()?.querySelectorAll('[role="menuitemradio"]') || [])].filter(shown);
+        if (before.version === version && !versionRows().length) return before;
+        const label = before.versions.find(v => v.id === version)?.label;
+        if (!label) return null;
+        // The picker may already show the version list (including a checked row).
+        // Select that row to return to its effort view; never assume the slider is open.
+        if (!versionRows().length) {
+          const toggle = [...picker().querySelectorAll('[role="menuitem"][aria-expanded]')].filter(shown);
+          if (toggle.length !== 1) return null;
+          toggle[0].click();
         }
-        return !!(await wait(picker));
+        const option = await wait(() => {
+          const rows = versionRows().filter(node => node.textContent.trim() === label && node.getAttribute('aria-disabled') !== 'true');
+          return rows.length === 1 ? rows[0] : null;
+        });
+        if (!key(option, 'Enter')) return null;
+        return state(next => next.version === version && !versionRows().length);
       },
-      close() { if (stillCurrent()) trigger()?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true })); },
-      async choose(model) {
-        if (!await this.models()) return false;
-        let option = items().find((node) => normalizeModelLabel(node.textContent) === normalizeModelLabel(model));
-        if (!option || !stillCurrent() || option.getAttribute('aria-disabled') === 'true') return false;
-        const alreadySelected = option.getAttribute('aria-checked') === 'true';
-        // Selecting even the checked row returns from the model submenu to Power.
-        // Neither the Select model toggle nor radio rows must remain mounted there.
-        const activate = node => {
-          node.focus();
-          node.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', bubbles: true, cancelable: true }));
-        };
-        activate(option);
-        if (!await wait(current)) return false;
-        if (alreadySelected) return stillCurrent();
-        // Reopen to prove the actual checked model, then return to its power row.
-        if (!await this.models()) return false;
-        option = items().find((node) => normalizeModelLabel(node.textContent) === normalizeModelLabel(model) && node.getAttribute('aria-checked') === 'true');
-        if (!option || !stillCurrent()) return false;
-        activate(option);
-        return !!await wait(current);
-      },
-      async step(direction) {
-        const before = current(); if (!before || !stillCurrent()) return false;
-        const expected = before.position + direction;
-        if (expected < 1 || expected > before.total) return false;
-        const key = direction < 0 ? 'ArrowLeft' : 'ArrowRight';
-        const control = power();
-        const target = control.querySelector('[role="slider"]') || control;
-        target.focus(); target.dispatchEvent(new KeyboardEvent('keydown', { key, code: key, bubbles: true, cancelable: true }));
-        return !!(await wait(() => { const next = current(); return next?.position === expected && next.total === before.total && next; }));
+      async bucket(bucket) {
+        let current = await state();
+        for (let count = 0; current && count < 12; count++) {
+          if (current.currentBucket === bucket) return current;
+          const from = current.choices.findIndex(c => c.bucket === current.currentBucket), to = current.choices.findIndex(c => c.bucket === bucket);
+          if (from < 0 || to < 0) return null;
+          const expected = current.choices[from + (to > from ? 1 : -1)].bucket;
+          const controls = [...picker().querySelectorAll('[role="menuitem"][aria-keyshortcuts]')].filter(node => shown(node) && node.getAttribute('aria-keyshortcuts').includes('ArrowRight'));
+          if (controls.length !== 1 || !key(controls[0], to > from ? 'ArrowRight' : 'ArrowLeft')) return null;
+          const version = current.version;
+          current = await state(next => next.version === version && next.currentBucket === expected);
+        }
+        return null;
       }
     };
   }
-  /** Reads actual account choices in an idle app-owned page and restores its selection. */
+  // The mounted provider picker carries the MAIN-world snapshot's exact identity.
+  // Removing that native node also removes the evidence; never cache across navigation.
   function visibleModelSelection() {
-    // Passive observation only: never open a picker just to poll its selection.
-    const ui = modelPickerAccess(() => true);
-    const checked = ui.items().find(node => node.getAttribute('aria-checked') === 'true');
-    let model = checked?.textContent?.trim();
-    if (model === 'Latest') model = ui.current()?.label.toLowerCase() === 'pro' ? ui.latestProModel() : null;
-    if (!model || !/^[a-zA-Z0-9 ._-]{1,80}$/.test(model)) return null;
-    const effort = Object.entries(CHAT_EFFORT_LABELS).find(([, label]) => label === ui.current()?.label)?.[0];
-    return { model, ...(effort ? { reasoningEffort: effort } : {}) };
+    const node = document.querySelector('[data-testid="composer-intelligence-picker-content"]');
+    const model = node?.getAttribute('data-clf-selected-model'), reasoningEffort = node?.getAttribute('data-clf-selected-effort');
+    return model && /^[a-zA-Z0-9._-]{1,80}$/.test(model) && ['none','minimal','low','medium','high','xhigh','max','ultra','pro'].includes(reasoningEffort)
+      ? { model, reasoningEffort } : null;
   }
   async function inspectModelSettings(stillCurrent = () => true, failure = () => {}) {
-    const ui = modelPickerAccess(stillCurrent);
-    if (!await ui.open()) { failure('picker_unavailable'); return null; }
-    // The model submenu replaces the Power row. Capture its ordinal before
-    // opening that submenu, while the original model is still selected.
-    const originalPower = await ui.wait(ui.current);
-    const options = await ui.models();
-    const originalModel = options?.find((node) => node.getAttribute('aria-checked') === 'true')?.textContent?.trim();
-    if (!originalModel || !originalPower) { failure(originalPower ? 'model_unconfirmed' : 'power_unknown'); ui.close(); return null; }
-    const models = options.filter((node) => node.getAttribute('aria-disabled') !== 'true').map((node) => (node.textContent || '').trim()).filter((name) => /^[a-zA-Z0-9 ._-]{1,80}$/.test(name)).slice(0, 20);
-    if (!models.length) { failure('model_unconfirmed'); ui.close(); return null; }
-    let result = [];
+    const ui = modelPickerAccess(stillCurrent), original = await ui.open();
+    if (!original) { ui.close(); failure('picker_unavailable'); return null; }
+    const result = new Map();
     let restored = false;
     try {
-      for (const label of models) {
-        if (!await ui.choose(label)) throw new Error('model_unconfirmed');
-        const first = await ui.wait(ui.current); if (!first) throw new Error('power_unknown');
-        for (let n = first.position; n > 1; n--) if (!await ui.step(-1)) throw new Error('power_unconfirmed');
-        const efforts = [];
-        for (let n = 1; n <= first.total; n++) {
-          const power = ui.current(); if (!power || power.position !== n) throw new Error('power_changed');
-          const effort = Object.entries(CHAT_EFFORT_LABELS).find(([, name]) => name.toLowerCase() === power.label.toLowerCase())?.[0];
-          if (power.available && effort && !efforts.includes(effort)) {
-            if (label === 'Latest') {
-              const actual = effort === 'pro' && ui.latestProModel();
-              if (actual) result.push({ id: actual.toLowerCase().replace(/\s+/g, '-'), label: actual, efforts: [effort] });
-            } else efforts.push(effort);
-          }
-          if (n < first.total && !await ui.step(1)) throw new Error('power_unconfirmed');
+      // One observation per version, not one mutation per effort. Computed choices
+      // include account/workspace denials which the raw global preset list does not prove.
+      for (const version of original.versions) {
+        const state = await ui.version(version.id);
+        if (!state) throw new Error('model_unconfirmed');
+        for (const choice of state.choices.filter(c => c.available)) {
+          const entry = result.get(choice.id) || { id: choice.id, label: choice.label, efforts: [] };
+          if (!entry.efforts.includes(choice.effort)) entry.efforts.push(choice.effort);
+          result.set(choice.id, entry);
         }
-        if (label !== 'Latest') result.push({ id: label.toLowerCase().replace(/\s+/g, '-'), label, efforts });
       }
-    } catch (error) { failure(['model_unconfirmed', 'power_unknown', 'power_unconfirmed', 'power_changed'].includes(error?.message) ? error.message : 'inspection_failed'); result = null; }
+    } catch { failure('model_unconfirmed'); result.clear(); }
     finally {
-      if (stillCurrent() && await ui.choose(originalModel)) {
-        for (let n = 0; n < 12; n++) {
-          const power = ui.current();
-          if (!power) break;
-          if (power.position === originalPower.position) { restored = power.label === originalPower.label && power.total === originalPower.total; break; }
-          if (!await ui.step(power.position > originalPower.position ? -1 : 1)) break;
-        }
+      if (stillCurrent() && await ui.version(original.version)) {
+        const state = await ui.bucket(original.currentBucket);
+        const previous = original.choices.find(c => c.bucket === original.currentBucket);
+        const selected = state?.choices.find(c => c.bucket === state.currentBucket);
+        restored = selected?.id === previous.id && selected?.effort === previous.effort;
       }
       ui.close();
     }
     if (!restored) failure('restore_failed');
-    if (!restored || !stillCurrent() || !result?.length) return null;
-    // A provider may expose the same numeric Pro choice both directly and via Latest.
-    const catalog = new Map();
-    for (const model of result) {
-      const existing = catalog.get(model.id);
-      if (existing) existing.efforts = [...new Set([...existing.efforts, ...model.efforts])];
-      else catalog.set(model.id, model);
-    }
-    return [...catalog.values()];
+    return restored && stillCurrent() && result.size ? [...result.values()] : null;
   }
-  /** Apply requested choices, proving their actual checked/ordinal state before Send. */
   async function selectModelSettings(model, effort, stillCurrent = () => true) {
     if (!model && !effort) return true;
-    if (effort && !CHAT_EFFORT_LABELS[effort]) return false;
-    const ui = modelPickerAccess(stillCurrent);
-    if (!await ui.open()) return false;
+    const ui = modelPickerAccess(stillCurrent), original = await ui.open();
+    if (!original) { ui.close(); return false; }
+    let selected = false;
     try {
-      let latest = false;
-      if (model) {
-        const options = await ui.models();
-        const exact = options?.some(node => normalizeModelLabel(node.textContent) === normalizeModelLabel(model));
-        // A discovered numeric Pro identity may live under Latest. It is admitted
-        // only after its final power badge proves the requested generation again.
-        latest = !exact && /^gpt-?\d+(?:\.\d+)?-pro$/i.test(model) && effort === 'pro';
-        if (!await ui.choose(latest ? 'Latest' : model)) return false;
-      }
-      const confirmed = (power) => power.available && (!latest || normalizeModelLabel(ui.latestProModel()) === normalizeModelLabel(model));
-      if (!effort) return stillCurrent();
-      const first = await ui.wait(ui.current); if (!first) return false;
-      if (first.label.toLowerCase() === CHAT_EFFORT_LABELS[effort].toLowerCase()) return confirmed(first);
-      for (let n = first.position; n > 1; n--) if (!await ui.step(-1)) return false;
-      for (let n = 1; n <= first.total; n++) {
-        const power = ui.current();
-        if (power?.label.toLowerCase() === CHAT_EFFORT_LABELS[effort].toLowerCase()) return confirmed(power);
-        if (n < first.total && !await ui.step(1)) return false;
+      // Exact provider slug is preferred. Existing saved display slugs may resolve
+      // only to an actually observed, available pair; never to an account default.
+      const matches = c => c.available && (!effort || c.effort === effort) && (!model || c.id === model || normalizeModelLabel(c.label) === normalizeModelLabel(model));
+      for (const version of [original.versions.find(v => v.id === original.version), ...original.versions.filter(v => v.id !== original.version)]) {
+        const state = await ui.version(version.id); if (!state) return false;
+        const choices = state.choices.filter(matches);
+        if (!choices.length) continue;
+        const choice = choices.find(c => c.bucket === state.currentBucket) || choices[0];
+        const after = await ui.bucket(choice.bucket);
+        const confirmed = after?.choices.find(c => c.bucket === after.currentBucket);
+        selected = stillCurrent() && confirmed?.available === true && confirmed.id === choice.id && confirmed.effort === choice.effort;
+        return selected;
       }
       return false;
-    } finally { ui.close(); }
+    } finally {
+      if (!selected && stillCurrent() && await ui.version(original.version)) await ui.bucket(original.currentBucket);
+      ui.close();
+    }
   }
 
   return {
@@ -2003,8 +1968,20 @@ var CLF_DOM = (() => {
     pluginInstalledButtons,
     pluginManagementIdle,
     selectModelSettings,
-    temporaryChatReady: () => [...document.querySelectorAll('button')].some(button =>
-      button.getAttribute('aria-label') === 'Turn off temporary chat' || text(button, 100) === 'Turn off temporary chat'),
+    temporaryChatReady: () => safe(() => [...document.querySelectorAll('button')].some(button => {
+      if (button.closest(`${OWN_SURFACES}, [data-message-author-role], [data-testid^="conversation-turn-"]`) || !button.getClientRects().length) return false;
+      // The provider renders both icons at once. Only the visible checked glyph proves
+      // the mode; translated labels and the requested URL are not activation receipts.
+      return [...button.querySelectorAll('svg use')].some(use => {
+        const href = use.getAttribute('href') || use.getAttribute('xlink:href') || '';
+        if (href.slice(href.lastIndexOf('#')) !== '#chat-temp-checked') return false;
+        for (let node = use.parentElement; node; node = node.parentElement) {
+          const style = getComputedStyle(node);
+          if (node.hidden || style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse' || style.opacity === '0') return false;
+        }
+        return true;
+      });
+    }), false),
     confirmTemporaryChatIntroduction: () => {
       const dialog = [...document.querySelectorAll('[role="dialog"]')].find(node =>
         [...node.querySelectorAll('h1,h2,[role="heading"]')].some(heading => text(heading, 100) === 'Temporary Chat') && /Not in history/.test(text(node, 2000)));

--- a/extension/content.js
+++ b/extension/content.js
@@ -550,6 +550,10 @@
    */
   let unwitnessedGeneration = false;
   let lastChangeAt = 0;
+  function noteTurnProgress() {
+    lastChangeAt = Date.now();
+    if (stagePanel?.root.dataset.clfStageKind === 'wait') removeStagePanel();
+  }
   let stallReported = false;
   let userStopped = false;
   /**
@@ -663,6 +667,7 @@
   let job = null;
   /** Local tool calls the app still has running. Only ever a hint from /activity. */
   let pendingTools = 0;
+  let operationProgress = null;
   let pressedAt = 0;
   let localError = '';
   let retirementHandledFor = null;
@@ -691,7 +696,38 @@
    */
   const USER_SEND_RECEIPT_MS = 30_000;
   let userSendReceipt = null;
+  const pageViewChecks = new Set(); // Existing readiness waits also observe accepted MAIN-world snapshots.
   const sendText = (value) => String(value || '').replace(/\s+/g, '');
+  /** Exact submitted text belongs to a stable user id, never its Markdown decoration. */
+  function matchesSubmittedUser(message, expected) {
+    if (!message || message.role !== 'user' || !message.id || !message.node?.isConnected ||
+        retiredMessages.has(message.id) || isStale(message.node) || typeof expected !== 'string' || expected.length > 240000) return false;
+    const turn = stampedFiberTurn({ node: message.node }, [...fiberTurns.values()], fiberScanToken);
+    if (turn && turn.conversationId !== CLF_DOM.conversationId()) return false;
+    const authored = (turn?.messages || []).filter(candidate => candidate.role === 'user' && candidate.stable === true &&
+      (candidate.rawMessageId === message.id || candidate.messageId === message.id));
+    if (authored.length > 1) return false;
+    // A current exact-id provider object supersedes display text. If absent, an unchanged
+    // plain-text bubble retains the existing exact-text receipt contract; no Markdown stripping.
+    const actual = authored.length === 1 ? authored[0].rawText : message.text;
+    return typeof actual === 'string' && actual.length <= 256000 && sendText(actual) === sendText(expected);
+  }
+  // A first fresh route may await authored evidence. A second route (including an
+  // observed return to New Chat) revokes this send; text proof is not its lifetime.
+  function submittedSendLifetime(target, startedEpoch = epoch) {
+    let elected = target || null;
+    let revoked = false;
+    return () => {
+      const route = CLF_DOM.conversationId();
+      if (!alive || epoch !== startedEpoch || (elected && route !== elected)) revoked = true;
+      if (!elected && route) elected = route;
+      return !revoked;
+    };
+  }
+  function sendSubmittedText(stillCurrent, clearAcceptedDraft = true) {
+    return CLF_DOM.send({ stillCurrent, clearAcceptedDraft, matchesUser: matchesSubmittedUser,
+      observeEvidence: check => { pageViewChecks.add(check); return () => pageViewChecks.delete(check); } });
+  }
   const GOAL_MARKER_INSTRUCTION = '\n\nFor this Goal session only: at the end of each final reply, write exactly one separate last line: [[COS_GOAL:COMPLETE]] if the entire requested task is finished, or [[COS_GOAL:CONTINUE]] if requested work remains. Do not claim completion for partial work. If user input is required, explain it and omit both markers.';
   function rememberUserSend() {
     // Only the explicitly selected offline Goal backend changes the user prompt.
@@ -846,10 +882,9 @@
    * turned an unattended Loop into a Goal that stopped at the second turn.
    */
   let pendingObjectiveMode = 'goal';
-  // Whether the opening message written from that goal actually reached ChatGPT. Only a sent
-  // one survives the conversation reset below, because only a sent one is the reason the id
-  // this tab is about to adopt exists at all.
-  let pendingObjectiveSent = false;
+  // One opening send owns its route while exact authored-user evidence arrives. Acceptance
+  // alone (for example a cleared composer) never binds the goal to a later sidebar chat.
+  let pendingObjectiveSend = null;
   /** Set while a specific goal is being saved or its opening message written. */
   let objectiveBusy = false;
   /** The last specific-goal failure, in the app's words, until the next attempt replaces it. */
@@ -1316,7 +1351,7 @@
     priorSections = new WeakSet(baselineSections);
     priorMarks = baselineMarks;
     turnStartedAt = Date.now();
-    lastChangeAt = Date.now();
+    noteTurnProgress();
     quietSince = 0;
     quietTurn = null;
     quietOutcome = null;
@@ -1471,6 +1506,7 @@
     since = 0;
     job = null;
     pendingTools = 0;
+    operationProgress = null;
     // An SPA move into another identified chat leaves this document facing a full transcript
     // it has never seen, exactly as a reload does. Until the app has said which of those user
     // messages it already holds, none of them can be read as a send — see resumeIdentityPending.
@@ -1505,7 +1541,7 @@
     // different conversation would attach it to whichever chat happened to be opened next.
     pendingObjective = '';
     pendingObjectiveMode = 'goal';
-    pendingObjectiveSent = false;
+    pendingObjectiveSend = null;
     objectiveBusy = false;
     objectiveError = '';
     removeStagePanel();
@@ -1758,7 +1794,7 @@
     const selection = CLF_DOM.visibleModelSelection?.();
     const model = (selection?.model || '').trim().toLowerCase().replace(/\s+/g, '-');
     // Exact aliases match shared/chat-models.ts::isProModel (the extension is plain JS).
-    const pro = /^(?:astra|gpt-?6(?:\.0)?-(?:pro|astra)|gpt-?5\.6-pro)$/.test(model) ||
+    const pro = /^(?:astra|gpt-?6-astra|gpt-?\d+(?:[.-]\d+)?-pro)$/.test(model) ||
       (/^(?:gpt-?6(?:\.0)?|gpt-?5\.6(?:-sol)?)$/.test(model) && selection?.reasoningEffort === 'pro');
     if (!fiberPresent && !unwitnessedGeneration && model && !pro && answerText(turn).length > 0) return { outcome: 'completed' };
     if (turnStalled()) {
@@ -1878,7 +1914,7 @@
           const conversationId = CLF_DOM.conversationId();
           const sameConversation = !receipt.conversationId || receipt.conversationId === conversationId;
           const newIdentity = !receipt.previousMessageId || receipt.previousMessageId !== message.id;
-          if (sameConversation && newIdentity && receipt.text === sendText(message.text)) {
+          if (sameConversation && newIdentity && matchesSubmittedUser(message, receipt.text)) {
             userSendReceipt = null;
             return true;
           }
@@ -1918,7 +1954,12 @@
         // marker has already disappeared. reconcileContinuationMarker() releases the gate on
         // the app's answer, committed or refused; only an unreachable app keeps it shut.
         const continuation = message.text.match(CONTINUATION_MARKER);
-        if (continuation && continuation[1] === 'RESUME') {
+        // The app's settled disposition outlives this DOM row. A remount or a later
+        // quotation of its marker cannot turn a committed chat back into a shadow.
+        const settledContinuation = continuation && [...reconciledContinuations.keys()].some(
+          key => key.startsWith(`${continuation[1]}:${continuation[2]}\u0000${conversationId || ''}\u0000`)
+        );
+        if (continuation && continuation[1] === 'RESUME' && bootstrap !== 'resume' && !settledContinuation) {
           continuationJournalPending = true;
           commandJournalGate = true;
         }
@@ -2024,16 +2065,12 @@
     // lifetime is owned by chrome.tabs.onRemoved in background.js; an SPA move is proven
     // here only when another concrete conversation id replaces the old one.
     if (id && id !== conversationId) {
-      // A goal written into a chat that had no id yet, whose opening message is the reason
-      // this id exists. It has to outlive the reset below — which exists to stop a goal
-      // leaking into whatever chat is opened next, and this is the one case where the next
-      // chat *is* the one the goal was written for. Only a message that actually reached
-      // ChatGPT counts; an abandoned attempt is dropped with everything else.
-      const abandonedOpening = Boolean(pendingObjective) && !pendingObjectiveSent;
-      const carried = pendingObjectiveSent ? pendingObjective : '';
-      // Read here, with the text, because resetConversation() below clears both and the mode
-      // is the half that cannot be reconstructed afterwards from anything on this page.
-      const carriedMode = pendingObjectiveMode === 'loop' ? 'loop' : 'goal';
+      // A dispatched opening may learn its route before the provider exposes its exact
+      // authored user row. Keep that operation pending; only the receipt below binds it.
+      const opening = pendingObjectiveSend?.current() ? {
+        receipt: pendingObjectiveSend, objective: pendingObjective, mode: pendingObjectiveMode, config: goalConfig
+      } : null;
+      const abandonedOpening = Boolean(pendingObjective) && !opening;
       if (conversationId) {
         // A genuine move to another *identified* chat: close the old one out and start
         // clean. The order matters — what the old chat left on screen is retired before
@@ -2052,6 +2089,16 @@
         agent = null;
         agentCommandId = null;
         resetConversation();
+        // New Chat can be reached from an older chat in the same document. Retire that
+        // old recording normally, transferring only this dispatched opening to its first
+        // elected route's epoch. Its user receipt is still required before Goal binding.
+        if (opening) {
+          pendingObjective = opening.objective;
+          pendingObjectiveMode = opening.mode;
+          goalConfig = opening.config;
+          pendingObjectiveSend = opening.receipt;
+          pendingObjectiveSend.current = submittedSendLifetime(id, epoch);
+        }
         // The same question boot asks, at the same moment boot asks it: which of this chat's
         // user messages does the app already hold? resetConversation() has just armed the
         // identity gate, and until it is answered this document reads no transcript at all,
@@ -2068,7 +2115,7 @@
         if (abandonedOpening) {
           pendingObjective = '';
           pendingObjectiveMode = 'goal';
-          pendingObjectiveSent = false;
+          pendingObjectiveSend = null;
           goalConfig = null;
           goalDraft = null;
           objectiveError = '';
@@ -2076,19 +2123,23 @@
           removeStagePanel();
         }
       }
-      // …and this is the moment a goal saved into a New Chat finally has something to be
-      // saved against. The message that produced this id was written from that goal, so the
-      // chat is already one turn into it; binding here is what lets the ordinary loop pick
-      // it up from the next turn onwards. See pendingObjective.
-      if (carried) {
+    }
+    // Route assignment and authored text can arrive in either order. This receipt is
+    // evaluated on the existing observer, rather than only on the one route-change edge.
+    if (id && pendingObjectiveSend?.accepted && pendingObjectiveSend.current()) {
+      const users = CLF_DOM.messages().filter(message => message.role === 'user');
+      if (users.length === 1 && matchesSubmittedUser(users[0], pendingObjectiveSend.text)) {
+        const carried = pendingObjective;
+        const carriedMode = pendingObjectiveMode;
+        const boundEpoch = epoch;
         pendingObjective = '';
         pendingObjectiveMode = 'goal';
-        pendingObjectiveSent = false;
+        pendingObjectiveSend = null;
         // The mode goes with it, and this is the only request that can carry it: from here on
         // the chat has an id, and anything that asks the app which mode to use gets the
         // standing switch's answer rather than the one the user actually chose.
         void ask({ type: 'goal_objective', conversationId: id, text: carried, mode: carriedMode }).then((reply) => {
-          if (!alive || conversationId !== id) return;
+          if (!alive || epoch !== boundEpoch || conversationId !== id) return;
           if (reply && reply.ok === true) {
             const stored = reply.data && typeof reply.data.objective === 'string' ? reply.data.objective : carried;
             const switched =
@@ -2242,7 +2293,7 @@
       priorSections = new WeakSet(baselineSections);
       priorMarks = baselineMarks;
       turnStartedAt = Date.now();
-      lastChangeAt = Date.now();
+      noteTurnProgress();
       // "Wait for this turn to finish" was about a turn that has now been replaced. Keeping
       // it would make the composer explain, after the fact, a refusal that no longer applies.
       localError = '';
@@ -3362,6 +3413,7 @@
       else fiberTurns.set(turn.index, turn);
     }
     for (const [index, value] of fiberTurns) if (value === null) fiberTurns.delete(index);
+    for (const check of pageViewChecks) void check();
     completeDesktopDecision();
     const markedTurns = markedContinuationTurns();
     const continuationReconciliation = reconcileContinuationMarkers(markedTurns);
@@ -3472,7 +3524,7 @@
         return true;
       });
       if (fresh.length > 0) {
-        if (generating && index === activeTurnIndex) lastChangeAt = Date.now();
+        if (generating && index === activeTurnIndex) noteTurnProgress();
         emit({
           kind: 'tool_evidence',
           ...(index === activeTurnIndex ? { turnId: activeLocalTurnId } : {}),
@@ -3576,7 +3628,7 @@
           const signature = `${activity.label}\u0000${owner}`;
           if (pageToolsReported.get(activity.messageId) === signature) continue;
           pageToolsReported.set(activity.messageId, signature);
-          if (generating && index === activeTurnIndex) lastChangeAt = Date.now();
+          if (generating && index === activeTurnIndex) noteTurnProgress();
           emit({
             kind: 'page_tool',
             text: activity.label,
@@ -3646,7 +3698,7 @@
           `\u0000${message.createTime || ''}\u0000${message.rawMessageId || ''}`;
         if (priorMessage?.signature === signature) continue;
         messagesReported.set(message.messageId, { signature, owner, conflicted: ownerConflict });
-        if (state === 'streaming') lastChangeAt = Date.now();
+        if (state === 'streaming') noteTurnProgress();
         const liveAssistant =
           Boolean(localOwner) ||
           (generating && (index === activeTurnIndex || (activeTurnIndex < 0 && index === answer.turns.length - 1)));
@@ -3666,7 +3718,8 @@
           ...(liveAssistant ? { activeNow: true } : {}),
           state,
           final: state === 'final',
-          ...(state === 'final' && localOwner && goalTerminalCandidate('completed', localOwner)
+          ...(state === 'final' && localOwner && goalTerminalCandidate('completed', localOwner, markedTurns.some(([, marked]) =>
+              marked.kind === 'HANDOFF' && marked.answer === turn))
             ? { goalEligible: true }
             : {})
         });
@@ -5574,6 +5627,7 @@
         // Keep waiting only for failures that can genuinely mean "the local app/worker is
         // not reachable yet". A structured application refusal is an answer to the identity
         // question, so it must release the gate rather than freezing this page forever.
+        if (current()) { operationProgress = null; injectStage(); }
         if (resumeIdentityPending && appAnswered(reply)) resumeIdentityPending = false;
         return;
       }
@@ -5679,7 +5733,7 @@
         if (generating && isWork(entry)) exactTurnActivity = true;
       }
       if (streamAdded > 0) trimStream();
-      if (exactTurnActivity) lastChangeAt = Date.now();
+      if (exactTurnActivity) noteTurnProgress();
 
       const fresh = Array.isArray(data.entries) ? data.entries : [];
       let added = 0;
@@ -5697,6 +5751,7 @@
       const nextSince = Number(data.nextSince);
       if (Number.isFinite(nextSince) && nextSince > since) since = nextSince;
       job = data.job || null;
+      operationProgress = data.progress || null;
       pendingTools = Number.isFinite(Number(data.pendingTools)) ? Number(data.pendingTools) : 0;
       // The generation this chat has open in the app, if any. Only ever *read* by
       // resumeOpenTurn(), on the boot pull, and only to work out whether this document is
@@ -6691,7 +6746,7 @@
         if (!goal) {
           pendingObjective = '';
           pendingObjectiveMode = 'goal';
-          pendingObjectiveSent = false;
+          pendingObjectiveSend = null;
           return;
         }
         await openWithObjective(goal, which);
@@ -6767,7 +6822,7 @@
     const openingEpoch = epoch;
     pendingObjective = goal;
     pendingObjectiveMode = mode === 'loop' ? 'loop' : 'goal';
-    pendingObjectiveSent = false;
+    pendingObjectiveSend = null;
     // Enough of a config for the panel to draw: the model comes back with the reply, so
     // until then it says "the model", which is what modelLabel('') is for. The mode is this
     // tab's own claim until the app answers with what it stored — drawn from the button that
@@ -6811,7 +6866,7 @@
       // pending ownership claim rather than letting a later observer bind it there.
       pendingObjective = '';
       pendingObjectiveMode = 'goal';
-      pendingObjectiveSent = false;
+      pendingObjectiveSend = null;
       goalConfig = null;
       setGoalPhase('');
       return;
@@ -6844,23 +6899,20 @@
     // document listener in every ChatGPT renderer. Mint the same receipt explicitly at the
     // irreversible boundary so the first user row can open its local generation.
     rememberUserSend();
-    const submittedText = sendText(CLF_DOM.composer()?.textContent);
-    const sendingTarget = () => {
-      if (current()) return true;
-      const users = CLF_DOM.messages().filter(message => message.role === 'user');
-      return alive && pendingObjective === goal && goalConfig?.enabled === true &&
-        pendingObjectiveMode === (mode === 'loop' ? 'loop' : 'goal') && users.length === 1 && sendText(users[0].text) === submittedText;
-    };
-    const sent = await CLF_DOM.send({ stillCurrent: sendingTarget });
+    const openingSend = { text: opening, current: submittedSendLifetime(null, openingEpoch), accepted: false };
+    const sendingTarget = () => pendingObjectiveSend === openingSend && openingSend.current() &&
+      pendingObjective === goal && goalConfig?.enabled === true && pendingObjectiveMode === (mode === 'loop' ? 'loop' : 'goal');
+    pendingObjectiveSend = openingSend;
+    const sent = await sendSubmittedText(sendingTarget);
     if (!sendingTarget()) return;
     if (!sent) {
+      pendingObjectiveSend = null;
       setGoalPhase('sending', 'ChatGPT would not send the message');
       return;
     }
-    // From here the goal outlives this composer: ChatGPT is about to name the conversation,
-    // and that name is what the goal is finally saved against. See observe().
-    pendingObjectiveSent = true;
+    openingSend.accepted = true;
     setGoalPhase('');
+    observe();
   }
 
   function renderMenu() {
@@ -7379,14 +7431,32 @@
               : 0;
       return { stage, detail: '', body: '', kind: 'compact', steps: COMPACT_STEPS, at, done: false };
     }
-    return goalStageView(goal);
+    const goalView = goalStageView(goal);
+    if (goalView) return goalView;
+    const now = input.now ?? Date.now();
+    // A real assistant change immediately wins over a wait caption. Generation alone
+    // does not prove which remote dependency is pending, so never invent one.
+    if (now - (input.changedAt ?? now) < 3000) return null;
+    const progress = input.progress;
+    const frame = (stage, detail = '') => ({ stage, detail, body: '', kind: 'wait' });
+    if (progress?.tools?.count > 0 && now - progress.tools.since >= 3000)
+      return frame(progress.tools.count === 1 ? 'Waiting for a local tool to finish' : `Waiting for ${progress.tools.count} local tools to finish`);
+    const workers = progress?.workers;
+    if (workers && (workers.active > 0 || workers.failed > 0)) {
+      const summary = `${workers.finished} finished · ${workers.active} running${workers.failed ? ` · ${workers.failed} failed` : ''}`;
+      // Running siblings are not proof that the prime is blocked on them.
+      return frame(workers.active === 1 ? `Worker still running: ${workers.names?.[0] || 'Worker'}` : workers.active > 1
+        ? `${workers.active} workers still running` : 'A worker needs attention', summary);
+    }
+    return input.generating ? frame('Still waiting for the current operation to complete') : null;
   }
 
   /**
-   * The short name of an OpenRouter model id, for a caption a person reads at a glance.
+   * The short name of a model id, for a caption a person reads at a glance.
    *
    * `deepseek/deepseek-v4-flash` is the id the API wants and not what anybody calls it. The
-   * vendor prefix and the `:free`/`:nitro` variant suffix are both routing detail.
+   * vendor prefix and the `:free`/`:nitro` variant suffix are both routing detail. A custom
+   * endpoint id without a slash passes through untouched.
    */
   function modelLabel(id) {
     const name = String(id || '').trim();
@@ -7430,9 +7500,12 @@
   function goalStageView(goal) {
     if (!goal) return null;
     const draft = goal.draft || null;
-    const who = modelLabel(goal.model);
+    const who = modelLabel(draft?.model || goal.model);
+    const backend = draft?.backend || goal.backend;
+    const dest = backend === 'chatgpt' ? 'ChatGPT helper' : backend === 'templates' ? 'offline templates'
+      : goal.provider === 'custom' ? 'custom endpoint' : 'OpenRouter';
     const bar = (at, done = false) => ({ steps: GOAL_STEPS, at, done });
-    const failure = goal.error || (draft && draft.stage === 'failed' ? draft.error || 'OpenRouter did not answer' : '');
+    const failure = goal.error || (draft && draft.stage === 'failed' ? draft.error || `${dest} did not answer` : '');
     if (failure) {
       const at = draft && draft.stage === 'failed' ? 2 : (GOAL_STEP_AT[goal.phase] ?? 1);
       if (goal.phase === 'retrying') {
@@ -7462,14 +7535,14 @@
       return { stage: 'Sending it to ChatGPT', detail: '', body: draft.reply, kind: 'goal', ...bar(3) };
     }
     if (goal.phase === 'requesting' && !draft) {
-      return { stage: 'Sending the answer to OpenRouter', detail: who, body: '', kind: 'goal', ...bar(1) };
+      return { stage: `Sending the answer to ${dest}`, detail: who, body: '', kind: 'goal', ...bar(1) };
     }
     if (!draft) return null;
     if (draft.stage === 'no-reply') {
       return { stage: 'Goal reached', detail: 'nothing was sent', body: '', kind: 'goal-done', ...bar(2, true) };
     }
     if (draft.stage === 'sending') {
-      return { stage: 'Sending the answer to OpenRouter', detail: who, body: '', kind: 'goal', ...bar(1) };
+      return { stage: `Sending the answer to ${dest}`, detail: who, body: '', kind: 'goal', ...bar(1) };
     }
     if (draft.stage === 'answering') {
       // Streamed, so the wait has something in it. The text is the message being written for
@@ -7505,10 +7578,10 @@
       phase: nativePhase,
       goal: goalConfig
         ? {
+            ...goalConfig,
             phase: goalPhase,
             error: goalError,
             retryMs: goalRetryWaitMs,
-            model: goalConfig.model,
             draft: goalDraft,
             opening: composerChat().state === 'new' && Boolean(pendingObjective)
           }
@@ -7645,9 +7718,10 @@
       return;
     }
     const view = stageView({
-      job,
+      job, progress: operationProgress, changedAt: lastChangeAt,
+      generating: generating && CLF_DOM.generating(),
       goal: goalConfig
-        ? { phase: goalPhase, error: goalError, retryMs: goalRetryWaitMs, model: goalConfig.model, draft: goalDraft, opening }
+        ? { ...goalConfig, phase: goalPhase, error: goalError, retryMs: goalRetryWaitMs, draft: goalDraft, opening }
         : null
     });
     if (!view) {
@@ -8024,7 +8098,7 @@
       }
       attemptCrossed = true;
       rememberUserSend();
-      if (!(await CLF_DOM.send())) {
+      if (!(await sendSubmittedText(current))) {
         CLF_DOM.clearPromptExact(prompt);
         nativeBusy = false;
         nativePhase = 'waiting';
@@ -8122,6 +8196,13 @@
     return [...found.entries()].filter(([, marked]) => marked && marked.messageId);
   }
 
+  // Only the bridge's terminal transaction dispositions retire a marker. An extension-local
+  // lease refusal (for example stale_document after SPA navigation) never reached that owner.
+  const continuationRefused = (reply) => reply?.ok === false && reply.status === 409 && [
+    'no_such_continuation', 'source_message_conflict', 'destination_message_conflict',
+    'resume_commit_rejected', 'automatic_compaction_disabled'
+  ].includes(reply.data?.error);
+
   /**
    * Advances one continuation solely from durable app state and ChatGPT's stable message ids.
    * This runs before ordinary page journaling so a marked replacement commits its rebind before
@@ -8138,7 +8219,7 @@
         destinationMessageId: marked.messageId
       });
       if (!reply || reply.ok !== true) {
-        if (!appAnswered(reply)) return false;
+        if (!continuationRefused(reply)) return false;
         // The app has spoken and there is no transaction to wait for: the continuation was
         // committed and forgotten long ago (a resumed chat merely reopened), or it was rejected.
         // Either way this marked message is ordinary history now. Holding the journal shut on a
@@ -8146,7 +8227,8 @@
         releaseContinuationJournal();
         return 'settled';
       }
-      if (reply.data && typeof reply.data.commandId === 'string') {
+      if (reply.data?.committed !== true) return false;
+      if (typeof reply.data.commandId === 'string') {
         rememberResumeGoalPending(conversationId, reply.data.commandId);
       }
       releaseContinuationJournal();
@@ -8157,9 +8239,13 @@
       type: 'compact',
       conversationId,
       token: marked.token,
-      sourceMessageId: marked.messageId
+      sourceMessageId: marked.messageId,
+      // A monotonic measure of the exact response, not the page's generating spinner.
+      sourceProgress: Math.min(4_000_000, (marked.answer?.messages || []).reduce(
+        (total, message) => total + String(message.rawText || '').length, 0
+      ) + (marked.answer?.calls || []).filter(call => call?.answered === true).length)
     });
-    if (!bound || bound.ok !== true) return appAnswered(bound) ? 'settled' : false;
+    if (!bound || bound.ok !== true) return continuationRefused(bound) ? 'settled' : false;
     // The answer turn, not the prompt's — see answerTurnFor. Its calls are the ones that have
     // to be finished, too: a brief cut while the compaction turn is still running a tool
     // describes a machine that is still changing.
@@ -8309,16 +8395,16 @@
   const GOAL_CONTINUABLE = new Set(['completed']);
 
   /**
-   * Browser-local terminal shape only. Goal config/key intentionally do not participate:
-   * those are app authority and may arrive after a one-second answer has already ended.
+   * Browser-local terminal identity only. A pending compaction delays Goal pickup; it does
+   * not change an ordinary final into a handoff answer. Only the exact marked answer has
+   * that role. Keep config/key and mutable busy flags out of this durable reply evidence.
    */
-  function goalTerminalCandidate(outcome, localTurnId) {
+  function goalTerminalCandidate(outcome, localTurnId, handoffAnswer) {
     return Boolean(
       !desktopDecisionChat() &&
         localTurnId &&
         GOAL_CONTINUABLE.has(outcome) &&
-        !nativeBusy &&
-        !(job && job.busy) &&
+        !handoffAnswer &&
         bootstrap !== 'worker'
     );
   }
@@ -8358,15 +8444,9 @@
    * does not change a second later, so nothing retries.
    */
   function noteGoalTurn(ended, outcome, endedTurnId) {
-    if (desktopDecision && desktopDecision.onTarget()) {
-      const users = CLF_DOM.messages().filter((message) => message.role === 'user');
-      if (outcome === 'completed' && users.length > 0 && sendText(users.at(-1).text) === sendText(desktopDecision.text)) {
-        const decision = desktopDecision;
-        decision.completedTurn = ended;
-        completeDesktopDecision();
-      }
-      return;
-    }
+    // The accepted helper user receipt and current provider terminal own its result.
+    // A renderer lifecycle edge must not create a second, captured-node owner.
+    if (desktopDecision && desktopDecision.onTarget()) return;
     if (!endedTurnId || !goalUsable()) return;
     // Only a finished, non-partial answer. See GOAL_CONTINUABLE for why every other outcome —
     // including `interrupted` — belongs to recovery rather than to this loop.
@@ -8681,7 +8761,7 @@
     }
     if (draft.stage === 'failed') {
       goalDraft = null;
-      const why = draft.error || 'OpenRouter did not answer';
+      const why = draft.error || `${draft.backend === 'chatgpt' ? 'ChatGPT helper' : draft.backend === 'templates' ? 'Offline templates' : goalConfig && goalConfig.provider === 'custom' ? 'custom endpoint' : 'OpenRouter'} did not answer`;
       const pending = goalConfig && goalConfig.pending;
       let retrying = draft.retryable === true && goalTurnId === draft.turnId;
       // A reload loses the document-local claim while the app keeps both the failed attempt
@@ -8761,7 +8841,7 @@
           !goalUsable() || generating || CLF_DOM.generating() || nativeBusy || job?.busy) return;
       rememberUserSend();
       sendAttempted = true;
-      const sent = await CLF_DOM.send({ stillCurrent: () => onDocument() && goalUsable() });
+      const sent = await sendSubmittedText(() => onDocument() && goalUsable());
       if (!onDocument()) return;
       goalDraft = null;
       if (!sent) {
@@ -9403,6 +9483,21 @@
     };
     if (await failIfRetargeted()) return;
     if (!CLF_DOM.insertPrompt(boot.text, true)) return void (await fail('ChatGPT refused the inserted text'));
+    const sendingBootstrap = submittedSendLifetime(target);
+    // Stop/composer-clear may acknowledge acceptance before the authored row mounts.
+    // Keep the original draft lease through that receipt, exactly as desktop delivery does;
+    // identical text alone must never erase a later trusted edit or a replacement editor.
+    const bootstrapDraft = CLF_DOM.captureComposerDraft(boot.text, () => !attempt?.cancelled && sendingBootstrap());
+    const priorBootstrapUser = CLF_DOM.messages().filter(message => message.role === 'user').at(-1)?.id;
+    const clearAcknowledgedBootstrap = async acknowledged => {
+      if (acknowledged?.ok !== true || acknowledged.data?.ok === false || !bootstrapDraft.current()) return;
+      const receipt = await waitPageView(() => {
+        const latest = CLF_DOM.messages().filter(message => message.role === 'user').at(-1);
+        return latest?.id !== priorBootstrapUser && matchesSubmittedUser(latest, boot.text);
+      }, () => !attempt?.cancelled && sendingBootstrap(), 15000);
+      if (receipt) await bootstrapDraft.clear();
+    };
+    try {
     // Give synchronous React/input work one microtask turn to replace the editing host, then
     // re-prove the exact draft before the irreversible send. This used to sleep for 100 ms.
     // Long-hidden Chrome tabs throttle wall-clock timers, so that tiny "stability" delay became
@@ -9438,44 +9533,63 @@
     }
     if (await failIfRetargeted()) return;
     const resumeMarker = boot.type === 'resume' ? String(boot.text || '').match(CONTINUATION_MARKER) : null;
+    // The last custody writes await HTTP. They cannot preserve the composer or SPA route
+    // that was checked above; prove both again after each write and at the native click.
+    const exactBootstrapDraft = () => squeeze(CLF_DOM.composer()?.textContent) === expectedText;
+    const rejectChangedBootstrap = async () => {
+      if (await failIfRetargeted()) return true;
+      if (exactBootstrapDraft()) return false;
+      if (boot.type === 'resume' && !squeeze(CLF_DOM.composer()?.textContent)) {
+        continuationJournalPending = false;
+        await ask({ type: 'compact', token: resumeMarker[2], destinationLost: true });
+        return true;
+      }
+      await fail('the composer changed during bootstrap authorization; the draft was preserved and nothing was sent');
+      continuationJournalPending = false;
+      return true;
+    };
+    let acceptedBootstrap = null;
+    const bootstrapConversation = () => {
+      const found = CLF_DOM.conversationId();
+      if (!found || (conversationId && conversationId !== found) ||
+          (acceptedBootstrap && (acceptedBootstrap.conversationId !== found || acceptedBootstrap.epoch !== epoch))) return null;
+      const message = CLF_DOM.messages().find(message => message.role === 'user' &&
+        matchesSubmittedUser(message, expectedText));
+      if (!message || (acceptedBootstrap && acceptedBootstrap.messageId !== message.id)) return null;
+      acceptedBootstrap ||= { conversationId: found, epoch, messageId: message.id };
+      return found;
+    };
     if (boot.type === 'resume') {
       if (!resumeMarker || resumeMarker[1] !== 'RESUME') {
         return void (await fail('the resume bootstrap had no valid continuation marker'));
       }
       continuationJournalPending = true;
       const permit = await ask({ type: 'compact', token: resumeMarker[2], destinationAttempt: true });
+      if (await rejectChangedBootstrap()) return;
       if (!permit || permit.ok !== true || !permit.data || permit.data.allowed !== true) {
-        CLF_DOM.clearPromptExact(boot.text);
+        await bootstrapDraft.clear();
         return;
       }
       // As on the source side: the claim above promises nothing was submitted, and this second
       // write is the exclusive cut taken immediately before the click.
       const armed = await ask({ type: 'compact', token: resumeMarker[2], destinationDispatch: true });
+      if (await rejectChangedBootstrap()) return;
       if (!armed || armed.ok !== true || !armed.data || armed.data.armed !== true) {
-        CLF_DOM.clearPromptExact(boot.text);
+        await bootstrapDraft.clear();
         return;
       }
     }
+    if (!stillOnTarget() || !exactBootstrapDraft()) { await rejectChangedBootstrap(); return; }
     // The destination Resume prompt is the first authored evidence in a brand-new chat.
     // Record it before send() clicks so reportMessages can open B's turn immediately instead
     // of waiting until Fiber eventually exposes the first connector request.
     rememberUserSend();
-    if (!(await CLF_DOM.send())) {
-      // Read before the draft is cleared below: a composer that no longer holds the brief in a
-      // chat that still has no id has sent nothing. send() returns false at once for an empty
-      // composer — the user pressed Escape as the brief landed on 2026-09-02 — and only a
-      // composer still holding the text is the ambiguous case, where the click may have gone
-      // through and ChatGPT was merely slow to show it.
-      const draft = CLF_DOM.composer();
-      const nothingSent = !CLF_DOM.conversationId() && (!draft || squeeze(draft.textContent) !== expectedText);
-      CLF_DOM.clearPromptExact(boot.text);
+    if (!(await sendSubmittedText(sendingBootstrap, false))) {
+      // Once send() was invoked, a missing/cleared draft cannot prove that no click
+      // happened. Only the exact pre-click check above may release the dispatch.
       if (boot.type === 'resume') {
-        // Nothing marked will ever appear in this document, so nothing is pending for it to
-        // journal against. Left raised, the gate unrecorded everything the user typed into this
-        // chat afterwards. The proven case also hands the armed dispatch back to the app, which
-        // offers the same brief to a fresh chat instead of sitting armed for six hours.
-        continuationJournalPending = false;
-        if (nothingSent) void ask({ type: 'compact', token: resumeMarker[2], destinationLost: true });
+        // Retain the armed ticket and journal gate for exact marker reconciliation; never
+        // replay an ambiguous click or let ordinary events create its shadow session.
         return;
       }
       return void (await fail('ChatGPT did not accept the bootstrap send'));
@@ -9495,7 +9609,7 @@
     // is the resume destination — see pullActivity — not here, because this ACK's reply is the
     // outbox's, not the app's.
     if (boot.type === 'resume') {
-      const found = CLF_DOM.conversationId();
+      const found = bootstrapConversation();
       if (found) rememberResumeGoalPending(found, boot.id);
     }
 
@@ -9508,7 +9622,8 @@
     // the loop below because ChatGPT has not assigned their new conversation id yet.
     if (target) {
       publishBootstrapSelection(target);
-      await ask({ type: 'ack', id: boot.id, status: 'sent', conversationId: target, agent, client: RUN_ID });
+      const acknowledged = await ask({ type: 'ack', id: boot.id, status: 'sent', conversationId: target, agent, client: RUN_ID });
+      await clearAcknowledgedBootstrap(acknowledged);
       return;
     }
 
@@ -9518,17 +9633,19 @@
     // clock the app is running, so this page never outlives the command it is working on.
     for (let tries = 0; tries < 80; tries++) {
       await sleep(500);
-      const found = CLF_DOM.conversationId();
+      const found = boot.type === 'resume' ? bootstrapConversation() : CLF_DOM.conversationId();
       if (found) {
         if (boot.type === 'resume') rememberResumeGoalPending(found, boot.id);
         publishBootstrapSelection(found);
-        await ask({ type: 'ack', id: boot.id, status: 'sent', conversationId: found, agent, client: RUN_ID });
+        const acknowledged = await ask({ type: 'ack', id: boot.id, status: 'sent', conversationId: found, agent, client: RUN_ID });
+        await clearAcknowledgedBootstrap(acknowledged);
         return;
       }
     }
     // Sent, but this tab never saw an id, so nothing can be bound to it. Reported honestly:
     // the app ends the slot or the continuation rather than waiting on a chat it cannot name.
     await ask({ type: 'ack', id: boot.id, status: 'sent', agent, client: RUN_ID });
+    } finally { bootstrapDraft.dispose(); }
   }
 
   // ----------------------------------------------------------------- start
@@ -9700,7 +9817,7 @@
     decision.publishing = true;
     void ask({ type: 'desktop_input', id: decision.id, owner: decision.owner, lifetime: decision.temporary ? 'temporary-planner' : undefined, response: decision.response }).then((reply) => {
       if (reply?.data?.ok === true && desktopDecision === decision && alive && epoch === decision.epoch && CLF_DOM.conversationId() === decision.conversationId) {
-        // Keep this exact temporary receipt until a replacement work tab exists.
+        // Keep this exact temporary receipt until maintenance retires this planner.
         // Its owner/text proves later safe closure without publishing the answer twice.
         if (decision.temporary) decision.accepted = true;
         else desktopDecision = null;
@@ -9709,14 +9826,21 @@
   }
   function completeDesktopDecision() {
     const decision = desktopDecision;
-    if (!decision?.completedTurn || !decision.onTarget() || decision.response) return;
-    const users = CLF_DOM.messages().filter(message => message.role === 'user');
-    if (!users.length || sendText(users.at(-1).text) !== sendText(decision.text)) return;
-    // Native markdown may still contain only the first two JSON characters after the
-    // page model has completed. Use the recorder's exact scan-stamped terminal message,
-    // never the rendered text or a timeout-based guess about whether it has settled.
-    const turn = stampedFiberTurn(decision.completedTurn, [...fiberTurns.values()], fiberScanToken);
-    if (!turn?.endMessageId) return;
+    if (!decision?.messageId || !decision.onTarget() || decision.response || pendingTools > 0 || userStopped) return;
+    const messages = CLF_DOM.messages();
+    const userIndex = messages.findLastIndex(message => message.role === 'user');
+    const assistant = messages.at(-1);
+    if (userIndex < 0 || messages[userIndex].id !== decision.messageId || assistant?.role !== 'assistant' ||
+        !assistant.id || !assistant.node?.isConnected || isStale(assistant.node) || retiredMessages.has(assistant.id)) return;
+    const pageTurn = CLF_DOM.turns().at(-1);
+    const nodes = pageTurn?.nodes || (pageTurn?.node ? [pageTurn.node] : []);
+    if (pageTurn?.role !== 'assistant' || !nodes.some(node => node.contains(assistant.node))) return;
+    // React may replace the section after local turn_end but before canonical final text.
+    // The accepted user and its current assistant message survive that remount; a captured
+    // section, reusable data-turn-id or previous terminal must never own the helper result.
+    const turn = stampedFiberTurn(pageTurn, [...fiberTurns.values()], fiberScanToken);
+    if (!turn?.endMessageId || turn.conversationId !== decision.conversationId || turn.endMessageId !== assistant.id ||
+        (turn.calls || []).some(call => call.answered !== true)) return;
     const terminal = (turn.messages || []).filter(message => message.role === 'assistant' &&
       (message.rawMessageId === turn.endMessageId || message.messageId === turn.endMessageId));
     if (terminal.length !== 1) return;
@@ -9730,7 +9854,7 @@
     if (!decision || (!decision.conversationId && !decision.temporary) || !decision.onTarget() || decision.partialPublishing) return;
     const users = CLF_DOM.messages().filter(message => message.role === 'user');
     const latest = CLF_DOM.turns().at(-1);
-    if (latest?.role !== 'assistant' || !users.length || sendText(users.at(-1).text) !== sendText(decision.text)) return;
+    if (latest?.role !== 'assistant' || !decision.messageId || users.at(-1)?.id !== decision.messageId) return;
     const text = finalAnswerText(latest).slice(-8000);
     if (!text || text === decision.lastPartial) return;
     decision.partialPublishing = true;
@@ -9801,29 +9925,39 @@
       if (!(await CLF_DOM.selectModelSettings(input.model, input.reasoningEffort, onTarget))) return fail(providerLimitation() || 'Requested model or reasoning could not be confirmed');
       if (!onTarget() || CLF_DOM.generating() || (!ownsFreshPage() && (CLF_DOM.composer()?.textContent || '').trim()) || CLF_DOM.hasComposerAttachments()) return fail('The ChatGPT composer changed before sending');
       if (!CLF_DOM.insertPrompt(input.text, ownsFreshPage())) return fail('ChatGPT did not accept the text');
-      draft = CLF_DOM.captureComposerDraft(input.text, onTarget);
-      if (!(await CLF_DOM.uploadImages(input.images, onTarget, draft))) return fail('Image upload was not confirmed. Check the unsent draft in ChatGPT before trying again.');
+      const sendingTarget = submittedSendLifetime(target, forEpoch);
+      draft = CLF_DOM.captureComposerDraft(input.text, () => sendAttempted ? sendingTarget() : onTarget());
+      const files = [];
+      for (const attachment of input.attachments || []) {
+        const parts = [];
+        for (let offset = 0; offset < attachment.size; offset += 524288) {
+          if (!onTarget()) return false;
+          const response = await ask({ type: 'desktop_input', id: input.id, owner: input.owner, conversationId: target, attachmentId: attachment.id, offset });
+          const chunk = response?.data?.chunk;
+          if (typeof chunk !== 'string' || chunk.length > 699052) return fail('Attachment transfer failed. The message was not sent.');
+          const bytes = Uint8Array.from(atob(chunk), char => char.charCodeAt(0));
+          if (bytes.length !== Math.min(524288, attachment.size - offset)) return fail('Attachment transfer was incomplete.');
+          parts.push(bytes);
+        }
+        files.push(new File(parts, attachment.name, { type: attachment.mimeType }));
+      }
+      if (!(await CLF_DOM.uploadImages(input.images, onTarget, draft, files))) return fail('Attachment upload was not confirmed. Check the unsent draft and any file error in ChatGPT before trying again.');
       await Promise.resolve();
       // Cancellation revokes this exact claim while model/image preparation awaits.
       // A cancellation after this check can race the click; only the receipt proves delivery.
       const authorized = await ask({ type: 'desktop_input', id: input.id, owner: input.owner, conversationId: target, authorize: true });
       if (authorized?.data?.ok !== true) return false;
-      if (!onTarget() || sendText(CLF_DOM.composer()?.textContent) !== sendText(input.text)) return fail('The composer changed; your draft was preserved');
+      if (!onTarget() || !draft.current() || sendText(CLF_DOM.composer()?.textContent) !== sendText(input.text)) return fail('The composer changed; your draft was preserved');
+      const previousUserId = CLF_DOM.messages().filter(row => row.role === 'user').at(-1)?.id;
       rememberUserSend();
       const submittedText = sendText(CLF_DOM.composer()?.textContent);
-      const sendingTarget = () => {
-        if (!alive) return false;
-        if (target || !CLF_DOM.conversationId()) return onTarget();
-        const users = CLF_DOM.messages().filter((row) => row.role === 'user');
-        return users.length === 1 && sendText(users[0].text) === submittedText;
-      };
       if (input.purpose === 'decision') {
-        decision = { id: input.id, owner: input.owner, text: input.text, temporary, onTarget: sendingTarget, conversationId: null, epoch: forEpoch, response: '', publishing: false };
+        decision = { id: input.id, owner: input.owner, messageId: null, text: input.text, temporary, onTarget: sendingTarget, conversationId: null, epoch: forEpoch, response: '', publishing: false };
         desktopDecision = decision;
       }
       if (input.projectId) desktopProjectInput = { id: input.id, owner: input.owner };
       sendAttempted = true;
-      if (!(await CLF_DOM.send({ stillCurrent: sendingTarget }))) return false;
+      if (!(await sendSubmittedText(sendingTarget, false))) return false;
       // Composer clear/Stop can prove acceptance before React mounts the user row.
       // Wait for that exact receipt, not merely /c navigation: Temporary Chat never
       // acquires a /c URL and used to discard its live decision during this gap.
@@ -9831,22 +9965,30 @@
         const conversation = CLF_DOM.conversationId();
         if ((!conversation && !temporary) || (target && !onTarget())) return null;
         const users = CLF_DOM.messages().filter(row => row.role === 'user');
-        if ((!target && users.length !== 1) || sendText(users.at(-1)?.text) !== submittedText) return null;
+        if ((!target && users.length !== 1) || users.at(-1)?.id === previousUserId || !matchesSubmittedUser(users.at(-1), submittedText)) return null;
         return { conversation, user: users.at(-1) };
       }, sendingTarget, 15000);
       if (!receipt) return false;
       const deliveredConversation = receipt.conversation;
       sent = true;
       if (decision) {
+        decision.messageId = receipt.user.id;
         decision.conversationId = deliveredConversation;
         decision.epoch = epoch;
         decision.onTarget = () => alive && epoch === decision.epoch && CLF_DOM.conversationId() === deliveredConversation;
         desktopDecisionSession = { conversationId: deliveredConversation, temporary };
-        publishDesktopDecision(decision);
+        completeDesktopDecision();
       }
       // The claim remains inert if this ACK is lost; no duplicate send after a reload.
       const acknowledged = await ask({ type: 'desktop_input', id: message.id, conversationId: deliveredConversation, messageId: receipt.user?.id, owner: input.owner, lifetime: input.lifetime, ack: true });
-      return acknowledged?.data?.ok === true;
+      const accepted = acknowledged?.data?.ok === true;
+      // Stop/composer-clear may precede the exact user row. This receipt, not that early
+      // native acceptance, owns retirement of the still-untouched prepared draft. A
+      // rejected/cancelled claim, trusted edit, replacement editor or route preserves it.
+      if (accepted && sendingTarget() && CLF_DOM.messages().filter(row => row.role === 'user').at(-1)?.id === receipt.user.id) {
+        try { await draft.clear(); } catch { /* Unprovable native cleanup preserves the draft. */ }
+      }
+      return accepted;
     } finally {
       if (draft) {
         try { if (!sendAttempted) await draft.clear(); }
@@ -9867,11 +10009,20 @@
   }
   function waitPageView(read, current, milliseconds) {
     return new Promise(resolve => {
-      let observer, timer;
-      const finish = value => { observer?.disconnect(); clearTimeout(timer); resolve(value); };
-      const check = () => { if (!current()) return finish(null); const value = read(); if (value) finish(value); };
-      observer = new MutationObserver(check); observer.observe(document.documentElement, { subtree: true, childList: true, attributes: true, characterData: true });
-      timer = setTimeout(() => finish(null), milliseconds); check();
+      let busy = false, dirty = false, done = false;
+      const finish = value => { if (done) return; done = true; pageViewChecks.delete(check); observer.disconnect(); clearTimeout(timer); resolve(value); };
+      const check = async () => {
+        if (done) return;
+        if (!current()) return finish(null);
+        if (busy) { dirty = true; return; }
+        busy = true;
+        try { let value = read(); if (value?.then) value = await value; if (current() && value) finish(value); }
+        catch { finish(null); }
+        finally { busy = false; if (dirty && !done) { dirty = false; void check(); } }
+      };
+      const observer = new MutationObserver(check); observer.observe(document.documentElement, { subtree: true, childList: true, attributes: true, characterData: true });
+      pageViewChecks.add(check);
+      const timer = setTimeout(() => finish(null), milliseconds); void check();
     });
   }
   async function refreshManagedPlugin(request) {
@@ -9897,39 +10048,43 @@
         // The provider's installed-row navigation drops the query marker. This
         // already-owned discovery may learn its resulting exact App Id, but cannot
         // claim Refresh until the management document has its marker again.
-        const discovered = await waitPageView(() => {
+        const discovered = await waitPageView(async () => {
           const url = new URL(location.href);
           const route = /^#settings\/Plugins\/plugin_(asdk_app_[a-zA-Z0-9_-]+)$/.exec(url.hash);
-          const next = CLF_DOM.pluginRefreshView(request.connectorName, request.tools);
+          const next = await CLF_DOM.pluginRefreshView(request.connectorName, request.tools);
           return route && next?.appId === route[1] ? url.href : null;
         }, () => alive && epoch === requestEpoch && !generating && !CLF_DOM.generating() &&
           new URL(location.href).origin === 'https://chatgpt.com' && location.pathname === '/' && CLF_DOM.pluginManagementIdle(), 8000);
         if (!discovered || !alive || epoch !== requestEpoch || location.href !== discovered) return false;
         const url = new URL(discovered); url.searchParams.set('cos-plugin-refresh', request.id);
-        location.replace(url.href); return true;
+        history.replaceState(history.state, '', url.href); return true;
       }
       // Identity and Refresh paint before the tool declarations. A partial settings
       // panel is neither an old schema nor permission to click; wait on the existing
       // DOM observer and leave an unclaimed request available if hydration times out.
-      const view = await waitPageView(() => {
-        const next = CLF_DOM.pluginRefreshView(request.connectorName, request.tools, request.appId);
+      const view = await waitPageView(async () => {
+        const next = await CLF_DOM.pluginRefreshView(request.connectorName, request.tools, request.appId);
         const route = /^#settings\/Plugins\/plugin_(asdk_app_[a-zA-Z0-9_-]+)$/.exec(new URL(location.href).hash);
         return route && next?.appId === route[1] && Array.isArray(next.tools) && next.tools.length > 0 ? next : null;
       }, current, 8000);
       if (!view) return false;
       if (!current()) return false;
-      if (!view || (request.appId && view.appId !== request.appId) || !view.refresh || view.refresh.disabled) { await fail('Exact connector settings or Refresh control could not be verified'); return false; }
+      if (request.appId && view.appId !== request.appId) { await fail('Exact connector settings could not be verified'); return false; }
       const ownedEpoch = epoch, appId = view.appId;
-      const stillCurrent = () => current() && epoch === ownedEpoch && CLF_DOM.pluginRefreshView(request.connectorName, request.tools, appId)?.appId === appId;
+      const stillCurrent = () => current() && epoch === ownedEpoch && new URL(location.href).hash === `#settings/Plugins/plugin_${appId}`;
       const before = schemaKey(view.tools), expected = schemaKey(request.tools);
       if (before === expected) {
         return (await ask({ type: 'plugin_refresh', action: 'current', id: request.id, appId, connectorName: request.connectorName, tools: view.tools }))?.data?.ok === true && stillCurrent();
       }
+      if (!view.refresh || view.refresh.disabled) {
+        const error = 'Connector schema differs, but ChatGPT exposes no Refresh control. Recreate or republish this custom app to load the current tool schema.';
+        return (await ask({ type: 'plugin_refresh', action: 'manual', id: request.id, appId, connectorName: request.connectorName, tools: view.tools, error }))?.data?.ok === true && stillCurrent();
+      }
       const claimed = await ask({ type: 'plugin_refresh', action: 'claim', id: request.id, appId, connectorName: request.connectorName, tools: view.tools });
-      if (!claimed?.data?.ok || !stillCurrent()) { await fail('Connector refresh claim or page ownership was not confirmed'); return false; }
+      if (!claimed?.data?.ok || !stillCurrent() || view.refresh.isConnected === false || view.refresh.disabled) { await fail('Connector refresh claim or page ownership was not confirmed'); return false; }
       view.refresh.click(); // the durable main-process attempt owns this one click
-      const after = await waitPageView(() => {
-        const next = CLF_DOM.pluginRefreshView(request.connectorName, request.tools, appId);
+      const after = await waitPageView(async () => {
+        const next = await CLF_DOM.pluginRefreshView(request.connectorName, request.tools, appId);
         return next && before !== expected && schemaKey(next.tools) === expected ? next : null;
       }, stillCurrent, 12000);
       if (!after) { await fail('Refresh was requested, but a changed matching schema was not observed'); return false; }
@@ -10036,6 +10191,14 @@
         return false;
       }
       if (message.type === 'clf-tab-close-check') {
+        // Maintenance carries the app's terminal tombstone for this exact claimed
+        // document. Revocation is independent of whether the renderer is safe to close.
+        const cancelled = (Array.isArray(message.cancelledDecisions) ? message.cancelledDecisions : [])
+          .find(claim => claim.id === desktopDecision?.id && claim.owner === desktopDecision?.owner);
+        if (desktopDecision && cancelled?.id === desktopDecision.id && cancelled.owner === desktopDecision.owner &&
+            desktopDecision.epoch === epoch && desktopDecision.onTarget() && message.conversationId === conversationId) {
+          desktopDecision = null;
+        }
         void (async () => {
           const observedEpoch = epoch;
           const expectedTerminal = fiberTerminalMessageId;
@@ -10057,8 +10220,9 @@
         const users = CLF_DOM.messages().filter(row => row.role === 'user');
         const exact = desktopDecision?.id === message.id && desktopDecision?.owner === message.owner;
         sendResponse({ safe: temporaryPlannerPage() && location.href.includes(`cos-input=${message.id}`) &&
+          !generating && !CLF_DOM.generating() && pendingTools === 0 && !CLF_DOM.hasComposerAttachments() &&
           !(CLF_DOM.composer()?.textContent || '').trim() &&
-          (users.length === 0 || (exact && users.length === 1 && sendText(users[0].text) === sendText(desktopDecision.text))) });
+          (users.length === 0 || (exact && users.length === 1 && matchesSubmittedUser(users[0], desktopDecision.text))) });
         return false;
       }
       if (message.type === 'clf-render-stream') {

--- a/extension/fiber.js
+++ b/extension/fiber.js
@@ -1,12 +1,15 @@
 /**
  * The only code this extension runs in ChatGPT's own JavaScript context.
  *
- * It exists for one reason: a collapsed connector row shows the word "Called tool" and
+ * A collapsed connector row shows the word "Called tool" and
  * nothing else, but the React Fiber behind it already knows exactly which tool ran, under
  * which connector, and how many further calls that single row is standing in for. That
  * last part is why this file has to exist at all — the page renders one row for a run of
  * calls, not always to the same tool, so the visible rows are not a list of the calls, and
  * no amount of DOM reading from the isolated world can recover the ones it folded away.
+ * The same bounded bridge also reads account-evaluated model choices and the installed
+ * connector's public tool declarations. Neither path exports account/session objects or
+ * invokes React callbacks; the isolated world owns UI actions and operation claims.
  *
  * Everything here is written on the assumption that it is the least trusted code in the
  * extension:
@@ -45,8 +48,8 @@
   const ACTIVE_HELPER = '__clfFiberHelper';
   const ASK = 'clf-fiber-ask';
   const REPLY = 'clf-fiber-reply';
-  /** The control ChatGPT puts in a connector tool row and nowhere else. */
-  const CONNECTOR = '[aria-label="Open tool call list" i]';
+  /** Only a successfully described connector row carries this scan reference. */
+  const CONNECTOR = '[data-clf-fiber]';
   /**
    * A runaway guard on the climb, not a claim about how the page is shaped.
    *
@@ -1253,6 +1256,8 @@
    * DOM at the same instant — React can re-render between the two.
    */
   function scan(nonce) {
+    // The existing scan also refreshes mounted-picker evidence; no new poll timer.
+    try { pickerSnapshot(); } catch { /* An unknown picker cannot affect recording. */ }
     // The request nonce already uniquely names this scan across the two worlds. Reuse it as
     // the ephemeral frame token rather than minting a second random value: every DOM stamp
     // can then prove both which descriptor index it names and which exact scan produced it.
@@ -1262,15 +1267,12 @@
     const rows = [];
     let turns = [];
     let scanOk = true;
-    try {
-      turns = turnsOf(scanToken);
-    } catch {
-      turns = [];
-      scanOk = false;
-    }
     let found;
     try {
-      found = document.querySelectorAll(CONNECTOR);
+      // Inspect existing native tool containers, never translated control labels.
+      // The row-local Fiber group is the authority; built-in tools fail describe().
+      found = [...document.querySelectorAll(TOOL)].filter(row => !row.closest(OWN_SURFACES));
+      for (const old of document.querySelectorAll(CONNECTOR)) old.removeAttribute('data-clf-fiber');
     } catch {
       return post({ source: REPLY, nonce, scanToken, v: VERSION, scanOk: false, rows: [], turns }, location.origin);
     }
@@ -1285,7 +1287,7 @@
         descriptor = null;
       }
       try {
-        row.setAttribute('data-clf-fiber', `${scanToken}:${index}`);
+        if (descriptor) row.setAttribute('data-clf-fiber', `${scanToken}:${index}`);
       } catch {
         // If the page will not take the marker, the descriptor is unusable: drop it
         // rather than let the other side match it to a row by position.
@@ -1293,16 +1295,145 @@
       }
       if (descriptor) rows.push(descriptor);
     }
+    // Row stamps must exist before native activity projection excludes connectors.
+    try {
+      turns = turnsOf(scanToken);
+    } catch {
+      turns = [];
+      scanOk = false;
+    }
     post({ source: REPLY, nonce, scanToken, v: VERSION, scanOk, rows, turns }, location.origin);
+  }
+
+  /** Picker data is account-evaluated state, never a scraped English announcement.
+   * Copy only selection metadata; no conversation, account object or callbacks cross worlds. */
+  function pickerSnapshot() {
+    const node = document.querySelector('[data-testid="composer-intelligence-picker-content"]');
+    let state = null;
+    try { state = readPickerSnapshot(node); } catch { /* Unknown state invalidates prior proof. */ }
+    const selected = state?.choices.find(choice => choice.bucket === state.currentBucket && choice.available);
+    for (const [attribute, value] of [['data-clf-selected-model', selected?.id], ['data-clf-selected-effort', selected?.effort]]) {
+      if (!value) node?.removeAttribute(attribute);
+      else if (node.getAttribute(attribute) !== value) node.setAttribute(attribute, value);
+    }
+    return state;
+  }
+  function readPickerSnapshot(node) {
+    let fiber = node && fiberOf(node);
+    for (let up = 0; fiber && up < MAX_CLIMB; up++, fiber = fiber.return) {
+      const props = fiber.memoizedProps;
+      const state = props?.composerIntelligencePickerState, data = props?.modelsData;
+      if (!state || !Array.isArray(data?.versions)) continue;
+      if (data.versions.length > 20 || !Array.isArray(state.bucketSelections) || state.bucketSelections.length > 12) return null;
+      const id = value => typeof value === 'string' && /^[a-zA-Z0-9._-]{1,80}$/.test(value) ? value : null;
+      const label = value => typeof value === 'string' && value.trim().length > 0 && value.length <= 80 ? value.trim() : null;
+      const effortOf = choice => choice.category?.modelLane === 'pro' ? 'pro'
+        : ['auto', 'instant'].includes(choice.category?.modelLane) ? 'none'
+        : ({ standard: 'medium', extended: 'high', max: 'xhigh', minimal: 'minimal', low: 'low', medium: 'medium', high: 'high', xhigh: 'xhigh', ultra: 'ultra' })[choice.thinkingEffort] || null;
+      const choices = state.bucketSelections.map(choice => {
+        const name = label(choice.category?.shortLabel);
+        return { bucket: choice.bucket, id: id(choice.modelSlug),
+          label: name && (/^\d/.test(name) ? `GPT-${name}` : name), effort: effortOf(choice),
+          available: choice.availability?.status === 'available' && !props.modelSwitcherDenialsBySlug?.[choice.modelSlug] };
+      });
+      const versions = data.versions.filter(version => version.enabled === true).map(version => ({ id: id(version.id), label: label(version.displayTextForIntelligence) }));
+      if (!versions.length || versions.some(v => !v.id || !v.label) || choices.some(c => !Number.isInteger(c.bucket) || !c.id || !c.label || !c.effort) ||
+          new Set(versions.map(v => v.id)).size !== versions.length || new Set(choices.map(c => c.bucket)).size !== choices.length) return null;
+      const version = id(state.selectedVersionEntry?.id), currentBucket = state.currentBucket;
+      if (!versions.some(v => v.id === version) || !choices.some(c => c.bucket === currentBucket)) return null;
+      const selected = state.currentSelection;
+      const chosen = choices.find(c => c.bucket === currentBucket);
+      if (selected?.modelSlug !== chosen.id || effortOf(selected) !== chosen.effort) return null;
+      return { version, currentBucket, versions, choices };
+    }
+    return null;
+  }
+
+  function copySchema(value, budget, depth = 0) {
+    if (depth > 32 || --budget.nodes < 0) throw new Error('schema_bound');
+    const spend = bytes => { budget.bytes -= bytes; if (budget.bytes < 0) throw new Error('schema_bound'); };
+    if (value === null) { spend(4); return null; }
+    if (typeof value === 'string') { spend(value.length * 3 + 2); return value; }
+    if (typeof value === 'boolean' || (typeof value === 'number' && Number.isFinite(value))) { spend(32); return value; }
+    if (!value || typeof value !== 'object') throw new Error('schema_shape');
+    if (Array.isArray(value)) {
+      if (value.length > budget.nodes) throw new Error('schema_bound');
+      spend(value.length + 2); return value.map(item => copySchema(item, budget, depth + 1));
+    }
+    const keys = Object.keys(value);
+    if (keys.length > budget.nodes) throw new Error('schema_bound');
+    const result = Object.create(null);
+    for (const key of keys) {
+      spend(key.length * 3 + 4);
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || !('value' in descriptor)) throw new Error('schema_accessor');
+      result[key] = copySchema(descriptor.value, budget, depth + 1);
+    }
+    return result;
+  }
+
+  function pluginSnapshot() {
+    const route = /^#settings\/Plugins\/plugin_(asdk_app_[a-zA-Z0-9_-]+)$/.exec(location.hash);
+    if (!route) return null;
+    const panels = [...document.querySelectorAll('[role="tabpanel"]')].filter(panel =>
+      panel.getAttribute('aria-labelledby')?.endsWith('-trigger-Plugins') && !panel.hidden);
+    if (panels.length !== 1) return null;
+    const buttons = [...panels[0].querySelectorAll('button')].slice(0, 100);
+    let result = null, control = null, observedActions = null, observedCard = null;
+    for (const button of buttons) {
+      let fiber = fiberOf(button);
+      for (let up = 0; fiber && up < 24; up++, fiber = fiber.return) {
+        const props = fiber.memoizedProps;
+        if (!props) continue;
+        if (props.reportEntity?.entityType === 'connector' && props.reportEntity.id === route[1] &&
+            Array.isArray(props.details) && props.details.some(detail => detail.value === route[1]) &&
+            button.getClientRects().length > 0) {
+          if (observedCard && observedCard !== props) return null;
+          observedCard = props;
+          if (props.headerTrailingContent) {
+            if (control && control !== button) return null;
+            control = button;
+          }
+        }
+        if (props.connector?.id !== route[1] || !Array.isArray(props.actions) || props.isLoadingActions === true) continue;
+        if (props.actions === observedActions) continue;
+        if (observedActions) return null;
+        observedActions = props.actions;
+        if (!props.actions.length || props.actions.length > 16 || typeof props.connector.name !== 'string') return null;
+        const budget = { bytes: 280000, nodes: 20000 };
+        const tools = props.actions.map(action => ({ name: action.name, description: copySchema(action.description_model ?? action.description, budget), inputSchema: copySchema(action.params, budget) }));
+        if (tools.some(tool => !NAME.test(tool.name) || typeof tool.description !== 'string' || !tool.inputSchema || tool.inputSchema.type !== 'object') ||
+            new Set(tools.map(tool => tool.name)).size !== tools.length) return null;
+        result = { appId: route[1], connectorName: props.connector.name.slice(0, 100),
+          versionId: str(props.connector.app_metadata?.version_id), tools };
+      }
+    }
+    if (!result || !observedCard) return null;
+    // Stamp only the native button wired to this connector's header action. Never
+    // invoke page callbacks; the isolated world still owns the durable claim and click.
+    if (control && control.getAttribute('data-clf-plugin-refresh') !== route[1]) control.setAttribute('data-clf-plugin-refresh', route[1]);
+    return { ...result, refreshAvailable: !!control };
   }
 
   const listener = (event) => {
     // Only this window, only our own request shape. Anything else is not ours to answer.
     if (event.source !== window) return;
     const data = event.data;
-    if (!data || typeof data !== 'object' || data.source !== ASK) return;
+    if (!data || typeof data !== 'object' || ![ASK, 'clf-picker-ask', 'clf-plugin-ask'].includes(data.source)) return;
     const nonce = typeof data.nonce === 'string' ? data.nonce.slice(0, 64) : '';
     if (!nonce) return;
+    if (data.source === 'clf-plugin-ask') {
+      let plugin = null;
+      try { plugin = pluginSnapshot(); } catch { /* Unrecognized installed settings. */ }
+      post({ source: 'clf-plugin-reply', nonce, v: 1, plugin }, location.origin);
+      return;
+    }
+    if (data.source === 'clf-picker-ask') {
+      let picker = null;
+      try { picker = pickerSnapshot(); } catch { /* Unknown provider shape fails closed. */ }
+      post({ source: 'clf-picker-reply', nonce, v: 1, picker }, location.origin);
+      return;
+    }
     try {
       scan(nonce);
     } catch {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Chat On Steroids companion",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Records your ChatGPT session into the local Chat On Steroids app and labels its MCP tool calls with what they actually did.",
   "minimum_chrome_version": "116",
   "permissions": [

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -623,17 +623,6 @@ input:focus-visible + .track {
   cursor: default;
 }
 
-.reload-action {
-  margin: 0 0 6px;
-}
-
-.reload-status {
-  margin: 0 4px 16px;
-  color: var(--faint);
-  font-size: 11px;
-  line-height: 1.4;
-}
-
 button:focus-visible {
   outline: 2px solid var(--muted);
   outline-offset: 2px;

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -27,12 +27,10 @@
         <h1>Chat On Steroids</h1>
       </header>
 
-      <p class="pill" id="pill"><span class="dot"></span><span id="state">Looking for the app</span></p>
-      <div class="actions reload-action">
-        <button id="reloadBtn" type="button" aria-describedby="reloadStatus">Reload companion</button>
-      </div>
-      <p id="reloadStatus" class="reload-status" role="status">Restarts this extension. Then reopen this popup to check its connection.</p>
+      <p class="pill off" id="pill"><span class="dot"></span><span id="state">Looking for the app</span></p>
 
+
+      <p class="alert" id="alert" hidden></p>
       <p class="caption">Session capture</p>
       <section class="card">
         <div class="row" id="r-tab">
@@ -77,7 +75,6 @@
       </details>
     </section>
 
-    <p class="alert" id="alert" hidden></p>
 
     <p class="caption">Augment ChatGPT</p>
     <section class="card">

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -12,21 +12,6 @@
  */
 
 const $ = (id) => document.getElementById(id);
-// This explicit action runs in the freshly opened popup, never through the worker
-// it is meant to replace. It therefore remains usable when that worker is stale
-// or its status/connection requests never return.
-$('reloadBtn').addEventListener('click', () => {
-  const button = $('reloadBtn');
-  if (button.disabled) return;
-  button.disabled = true;
-  $('reloadStatus').textContent = 'Reload requested. Reopen this popup to verify the connection.';
-  try {
-    chrome.runtime.reload();
-  } catch (error) {
-    button.disabled = false;
-    $('reloadStatus').textContent = `Reload failed: ${error instanceof Error ? error.message : String(error)}`;
-  }
-});
 const RENDER_STREAM_KEY = 'renderStreamEnabled';
 const SHOW_TIMES_KEY = 'showStreamTimes';
 const POLL_MS = 1500;
@@ -112,7 +97,7 @@ function pipeline(info, ready) {
       read: readStage,
       sent: ['failed', pending ? `${pending} held` : ''],
       proc: ['off'],
-      why: ['bad', 'The app is not reachable. Nothing is leaving this browser.']
+      why: ['bad', 'Delivery is blocked until the app is connected and protocol compatibility is confirmed.']
     };
   }
   if (sent && sent.ok === false) {
@@ -223,7 +208,7 @@ function paintHeader(status) {
   // connection that has not finished yet, which is what it looked like back when the next
   // poll would silently undo it.
   const off = status && status.disconnected === true && !paired;
-  const ready = connected && paired && !incompatible;
+  const ready = connected && paired && status.compatible === true;
 
   $('pill').className = `pill ${ready ? '' : incompatible ? 'bad' : 'off'}`;
   $('state').textContent = incompatible
@@ -248,7 +233,7 @@ function paintAlert(status, info) {
   const pairError = status && status.pairError;
   const error = page && page.lastError;
   const text = incompatible
-    ? 'The app and this extension speak different bridge protocols.'
+    ? `App v${status.appVersion || '?'} (protocol ${status.appProtocol ?? '?'}); companion v${status.extensionVersion || '?'} (protocol ${status.extensionProtocol ?? '?'}). Open your browser's Extensions page, enable Developer mode, then Update / Reload this companion. If the mismatch remains, use Open extension folder in Chat On Steroids and load that folder. Reload ChatGPT tabs when their active work is finished.`
     : pairError && pairError.message
       ? pairError.message
       : pairError && pairError.error === 'secure_storage_unavailable'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chat-on-steroids",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chat-on-steroids",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chat-on-steroids",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Local coding bridge for ChatGPT over MCP, with native desktop control and approved-folder capability limits.",
   "license": "MIT",
   "author": "Chat On Steroids",

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -1,9 +1,11 @@
+import { conversationProgress } from './session/progress.js';
 import { pendingChatModelRequest, observeChatModels } from './chat-models.js';
 import { isProModel } from '../shared/chat-models.js';
 import type { SessionSummary } from '../shared/session.js';
 import { publishBrowserDecision, authorizeBrowserInput, sessionInputPolicy } from './session/input.js';
-import { pluginRefreshPublications, pendingPluginRefreshes, claimPluginRefresh, completePluginRefresh, failPluginRefresh } from './plugin-refresh.js';
+import { pluginRefreshPublications, pendingPluginRefreshes, claimPluginRefresh, requireManualPluginRefresh, completePluginRefresh, failPluginRefresh } from './plugin-refresh.js';
 import { attachBrowserWake, wakeBrowserWork } from './browser-wake.js';
+import { wakeBrowserUrl } from './browser-startup.js';
 let browserWake: ReturnType<typeof attachBrowserWake> | null = null;
 let browserWorkArea: (() => { x: number; y: number; width: number; height: number }) | null = null;
 /** Desktop display geometry stays owned by Electron; the companion needs no display permission. */
@@ -53,7 +55,7 @@ import {
   goalKeyPresent,
   registerGoalDecisionChat,
   isGoalDecisionChat,
-  goalBackendFor,
+  goalProgressFor,
   goalDraftBusy,
   goalArmedFor,
   goalObjectiveFor,
@@ -152,10 +154,11 @@ import {
   CONTINUATION_TTL_MS,
   continuationByToken,
   continuationForSession,
-  pendingAutomaticContinuations,
+  pendingContinuations,
   supersededSourceConversations,
   dispatchContinuationDestinationSendNow,
   dispatchContinuationSourceSendNow,
+  normalizeProjectId,
   openContinuationNow,
   releaseContinuationDestinationSendNow,
   repairPrimeFromResumeShadow,
@@ -223,27 +226,8 @@ const RATE_LIMIT = 900;
  * after everybody had stopped expecting them.
  */
 export const COMMAND_DEADLINE_MS = 90_000;
-/**
- * The two clocks a worker bootstrap lives under before it is a failure rather than a wait.
- *
- * `REDEEM` is how long the chat this app opened gets to pick up its instruction. That is the
- * browser's whole round trip — create the tab, load ChatGPT, run the content script, redeem —
- * and it takes four to six seconds when it works at all; twenty is the same allowance the
- * placement offer gives it. A page that has not redeemed by then is not slow, it is dead: a tab
- * that loaded and never ran the marker (worker-4 on 2026-09-02 sat as an empty New chat for the
- * full ninety seconds, and the two workers queued behind it opened only after it was failed).
- * So the chat is opened once more, once, and a second silence fails the slot. This is safe
- * because `/commands/redeem` is single-owner: whichever page redeems first types, the other is
- * told there is nothing for it, and the worst case is one blank tab. It is bounded because the
- * retry is spent once and `LIMIT` is absolute, measured from the moment the broker invited the
- * worker, so no combination of a late hand-out and a fresh lease keeps a slot `invited` past it
- * — which is what happened to a worker whose command sat unleased for nine minutes holding the
- * last free slot.
- *
- * Once a page owns the command the attempt is one-shot again: it has `COMMAND_DEADLINE_MS` to
- * type and name its chat, and a page that redeemed and never typed is a failure, not a prompt
- * to open another chat.
- */
+/** A missing redemption ends this one opening attempt; it never licenses another tab.
+ * The absolute invitation lifetime also bounds commands waiting behind another bootstrap. */
 export const WORKER_REDEEM_MS = 20_000;
 export const WORKER_BOOTSTRAP_LIMIT_MS = 120_000;
 /** A worker may occupy the broker's `waking` state for one short, absolute attempt. */
@@ -433,14 +417,8 @@ interface Command {
    * already on it.
    */
   claimedAt: number | null;
-  /**
-   * When a worker bootstrap's one re-open was spent, so it is spent once. Memory only.
-   *
-   * Not persisted: after a restart the absolute limit is still measured from the persisted
-   * `createdAt`, so the worst a forgotten retry can cost is one more open of the same
-   * single-owner command inside a window that ends at the same instant either way.
-   */
-  retriedAt: number | null;
+  /** Transient uncollected placement, owned by this command and removed on handout. */
+  placement?: { conversationId: string | null; background: boolean };
   /**
    * The one-shot that ends this command when its deadline passes. Memory only.
    *
@@ -1192,7 +1170,15 @@ async function fileCompactionTicket(sessionId: string, id: string, automatic = f
   return { opened, started: !existing };
 }
 export async function compactSession(sessionId: string): Promise<SessionControlsView> {
-  await fileCompactionTicket(sessionId, await controlledConversation(sessionId));
+  const { opened } = await fileCompactionTicket(sessionId, await controlledConversation(sessionId));
+  const lifecycle = bridgeLifecycleEpoch;
+  await wakeBrowserUrl(chatUrl(opened.from), true, getConfig().ui.backgroundChats === true, {
+    requireProcessAbsence: true,
+    current: () => bridgeLifecycleEpoch === lifecycle && !bridgeShutdownRequested &&
+      !isChatBlocked(opened.from) && !stopRequestedFor(opened.from) &&
+      continuationForSession(sessionId)?.token === opened.token &&
+      continuationForSession(sessionId)?.state === 'awaiting-summary'
+  });
   return sessionControlsFor(sessionId);
 }
 export async function cancelSessionCompaction(sessionId: string): Promise<SessionControlsView> {
@@ -1388,12 +1374,15 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
   if (route === '/plugin-refresh' && req.method === 'POST') {
     const raw = await readBody(req);
     const body = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
-    if (body.action === 'pending') return json(res, 200, { requests: await pendingPluginRefreshes() }, origin);
+    if (body.action === 'pending') return json(res, 200, { requests: getConfig().ui.autoRefreshPlugins === true ? await pendingPluginRefreshes() : [] }, origin);
+    // Turning the setting off also revokes a request already handed to the page.
+    if (body.action === 'claim' && getConfig().ui.autoRefreshPlugins !== true) return json(res, 409, { ok: false, error: 'automatic_refresh_disabled' }, origin);
     if (typeof body.id !== 'string' || !/^[a-f0-9-]{36}$/i.test(body.id)) return json(res, 400, { error: 'invalid_request' }, origin);
     let ok = false;
     if (body.action === 'fail' && typeof body.error === 'string') ok = await failPluginRefresh({ id: body.id, error: body.error.slice(0, 200) });
     else if (typeof body.appId === 'string' && /^asdk_app_[a-zA-Z0-9_-]{1,160}$/.test(body.appId)) {
       if ((body.action === 'claim' || body.action === 'current') && typeof body.connectorName === 'string') ok = await claimPluginRefresh({ id: body.id, appId: body.appId, connectorName: body.connectorName, tools: body.tools, alreadyCurrent: body.action === 'current' });
+      if (body.action === 'manual' && typeof body.connectorName === 'string' && typeof body.error === 'string') ok = await requireManualPluginRefresh({ id: body.id, appId: body.appId, connectorName: body.connectorName, tools: body.tools, error: body.error.slice(0, 200) });
       if (body.action === 'complete') ok = await completePluginRefresh({ id: body.id, appId: body.appId, tools: body.tools, versionId: typeof body.versionId === 'string' ? body.versionId.slice(0, 200) : undefined });
     }
     if (ok) changed();
@@ -1439,14 +1428,17 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
         conversations: live,
         stopTurns: await pendingStopCommands(),
         modelCatalogRequest: pendingChatModelRequest(),
-        pluginRefreshRequests: pluginRefreshPublications().map(({ surface, schemaId, connectorName }) => ({ surface, schemaId, connectorName })),
+        pluginRefreshRequests: getConfig().ui.autoRefreshPlugins === true ? pluginRefreshPublications().map(({ surface, schemaId, connectorName }) => ({ surface, schemaId, connectorName })) : [],
         browserPreferenceRequest: pendingBrowserPreferenceRequest(),
+        inputOpeningIds: inputRows.filter(row => !['sent', 'failed', 'cancelled'].includes(row.state)).map(row => row.id),
         inputs: [...(await pendingBrowserInputs()).filter(input => !input.conversationId || runningToolCalls(input.conversationId) === 0),
           ...inputRows.filter(row => row.lifetime === 'temporary-planner' && ['sent', 'cancelled', 'failed'].includes(row.state))
             .map(row => ({ id: row.id, owner: row.owner, lifetime: row.lifetime, close: true,
+              retire: true,
               replacements: inputRows.filter(next => next.createdAt > row.createdAt && next.purpose !== 'decision')
                 .map(next => ({ id: next.id, conversationId: next.conversationId })) }))],
         background: getConfig().ui.backgroundChats === true,
+        browserOnly: getConfig().ui.browserOnly === true,
         browserWorkArea: browserWorkArea?.(),
         commands: commands.length,
         revival,
@@ -1469,10 +1461,17 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
     } catch { return json(res, 400, { error: 'invalid_usage' }, origin); }
   }
 
-  if (['/input/claim', '/input/bind', '/input/ack', '/input/fail', '/input/answer', '/input/progress'].includes(route) && req.method === 'POST') {
+  if (['/input/claim', '/input/bind', '/input/ack', '/input/fail', '/input/answer', '/input/progress', '/input/attachment'].includes(route) && req.method === 'POST') {
     const body = await readBody(req) as Record<string, unknown>;
     if (!body || typeof body.id !== 'string' || !/^[a-f0-9-]{36}$/i.test(body.id) || typeof body.owner !== 'string' || body.owner.length > 160) {
       return json(res, 400, { error: 'invalid_input_claim' }, origin);
+    }
+    if (route === '/input/attachment') {
+      const entry = (await listInputs()).find(row => row.id === body.id && row.owner === body.owner && row.state === 'browser' && row.sendAuthorizedAt === undefined);
+      const attachment = entry?.attachments?.find(file => file.id === body.attachmentId);
+      if (!attachment || entry?.conversationId !== body.conversationId || typeof body.offset !== 'number') return json(res, 409, { error: 'attachment_not_owned' }, origin);
+      const { readInputAttachmentChunk } = await import('./session/input-attachments.js');
+      return json(res, 200, { chunk: await readInputAttachmentChunk(attachment, body.offset) }, origin);
     }
     if (route === '/input/fail') return json(res, 200, { ok: await failBrowserInput(body.id, body.owner, typeof body.error === 'string' ? body.error : 'Unable to prepare ChatGPT') }, origin);
     if (route === '/input/progress') {
@@ -1797,16 +1796,17 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
     const astraSession = await findSessionByConversation(id, { requireUnique: true });
     const finishOnly = !!astraSession && await astraFinishOnly(astraSession.id, id);
     const silenceSuppressed = finishOnly || await suppressProSilence(id);
-    const goalView = async () => ({
+    const goalView = async () => {
+      const draft = superseded || silenceSuppressed ? null : goalViewFor(id, goalClient);
+      return ({
       enabled: !superseded && !finishOnly && goalEnabledFor(id),
       // Has this chat answered for itself? The page reads the switch and the saved goal as
       // one state — see goalArmedFor() — and cannot tell an Off somebody chose here from an
       // Off merely inherited from the app-wide setting without being told which it is.
       own: superseded || finishOnly || goalFencedChat(id) || goalSwitchFor(id).own,
       mode: goalModeFor(id),
-      backend: goalBackendFor(goalModeFor(id)),
+      ...goalProgressFor(goalModeFor(id), draft),
       hasKey: await goalKeyPresent(goalModeFor(id)),
-      model: getConfig().goal.model,
       // This chat's own goal, and never a worker's: the loop is off there whatever is
       // stored, and reporting one would let the page offer to drive a chat the prime owns.
       objective: superseded || finishOnly || goalWorkerChat(id) ? '' : goalObjectiveFor(id),
@@ -1820,8 +1820,9 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
       // A blocked chat's owed decision is withheld too, so the page cannot pick it up and
       // draft into a chat whose tools are refused.
       pending: superseded || goalFencedChat(id) || silenceSuppressed ? null : goalPendingReplyFor(id),
-      draft: superseded || silenceSuppressed ? null : goalViewFor(id, goalClient)
+      draft
     });
+    };
     // Every open ChatGPT tab polls this for its own conversation every few seconds, so
     // this is the app's primary first-hand evidence of which chats exist right now.
     let live = liveConversations().find((entry) => entry.conversationId === id);
@@ -1844,6 +1845,7 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
           userAnchors: [],
           nextSince: Number.isFinite(since) ? Math.max(0, since) : 0,
           job: null,
+          progress: conversationProgress(id),
           goal: await goalView(),
           ...(goalFencedChat(id) || superseded
             ? {
@@ -2073,7 +2075,10 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
         // it is the handoff brief or the worker bootstrap this app typed. The page uses
         // it to fold that message away. Read off the session record rather than remembered
         // in the tab, so it still holds after a reload, days later.
-        bootstrap: summary?.origin?.kind ?? null,
+        // Session origin survives A -> B. The atomic rebind records which handoff
+        // became this current chat; a desktop-origin session can therefore be resumed.
+        bootstrap: summary?.conversationId === id && summary.lastCommittedResumeHandoffId
+          ? 'resume' : summary?.origin?.kind ?? null,
         // Which worker this chat is, for the page's fold of the bootstrap. From the durable
         // origin, so a reloaded worker tab — which no longer holds its command — still knows.
         bootstrapAgent: summary?.origin?.kind === 'worker' ? summary.origin.agentId ?? null : null,
@@ -2097,6 +2102,7 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
         // REQUEST_ID_GRACE_MS to file its history cannot change the workspace and must not add
         // a cross-chat 15-second tax to the machine-settle barrier.
         pendingTools: runningToolCalls(live.conversationId),
+        progress: conversationProgress(live.conversationId),
         // Diagnostic only. A finished unattributed call is still being placed into durable
         // history; unknown ownership is conservatively projected onto every chat until that
         // attribution finishes, but this number never gates the compaction prompt.
@@ -2224,7 +2230,8 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
     if (body['sourceAttempt'] === true) {
       const entry = continuationByToken(checkpointToken);
       if (!entry || entry.from !== id) return json(res, 409, { error: 'no_such_continuation' }, origin);
-      const result = await beginContinuationSourceSendNow(checkpointToken);
+      const result = await beginContinuationSourceSendNow(checkpointToken,
+        Object.hasOwn(body, 'project') ? normalizeProjectId(body['project']) : undefined);
       return result
         ? json(
             res,
@@ -2237,7 +2244,8 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
     if (typeof body['sourceMessageId'] === 'string') {
       const entry = continuationByToken(checkpointToken);
       if (!entry || entry.from !== id) return json(res, 409, { error: 'no_such_continuation' }, origin);
-      const bound = await bindContinuationSourceMessageNow(checkpointToken, body['sourceMessageId'].slice(0, 200));
+      const bound = await bindContinuationSourceMessageNow(checkpointToken, body['sourceMessageId'].slice(0, 200),
+        typeof body['sourceProgress'] === 'number' ? body['sourceProgress'] : undefined);
       return bound
         ? json(res, 200, { bound: true, job: resumeJobFor(entry.sessionId) }, origin)
         : json(res, 409, { error: 'source_message_conflict' }, origin);
@@ -2508,7 +2516,7 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
 
     let opened;
     try {
-      opened = await openContinuationNow(sessionId, id);
+      opened = await openContinuationNow(sessionId, id, false);
     } catch (err) {
       logWarn(`bridge: could not durably open Compact & Resume for ${sessionId} — ${err instanceof Error ? err.message : String(err)}`);
       return json(res, 503, { error: 'continuation_not_durable', retryable: true, sessionId }, origin);
@@ -2795,9 +2803,8 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
           // has never said anything inherits.
           own: false,
           mode: goalModeFor(),
-          backend: goalBackendFor(goalModeFor()),
+          ...goalProgressFor(goalModeFor()),
           hasKey: await goalKeyPresent(),
-          model: getConfig().goal.model,
           objective: '',
           blocked: ''
         }
@@ -2946,13 +2953,49 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
           // read as an inherited one until then.
           own: chatSwitch !== null,
           mode: chatSwitch ? chatSwitch.mode : next.goal.mode,
-          backend: goalBackendFor(chatSwitch ? chatSwitch.mode : next.goal.mode),
-          hasKey: await goalKeyPresent(chatSwitch ? chatSwitch.mode : next.goal.mode),
-          model: next.goal.model
+          ...goalProgressFor(chatSwitch ? chatSwitch.mode : next.goal.mode),
+          hasKey: await goalKeyPresent(chatSwitch ? chatSwitch.mode : next.goal.mode)
         }
       },
       origin
     );
+  }
+
+  // Browser-restart recovery keeps only inert command ids in extension storage. Before the
+  // extension is allowed to recreate any ChatGPT tab, let it reconcile those ids against the
+  // app's current durable command state in one read-only batch. This route deliberately exposes
+  // no command text and acquires no owner/lease: it is only a freshness fence for recovery
+  // markers that can outlive the command they once referred to.
+  if (route === '/commands/revivals/pending' && req.method === 'POST') {
+    let body: Record<string, unknown>;
+    try {
+      body = (await readBody(req)) as Record<string, unknown>;
+    } catch (err) {
+      if ((err as Error).message === 'body_too_large') return tooLarge(res, origin);
+      return json(res, 400, { error: 'bad_request' }, origin);
+    }
+    const rawEntries = Array.isArray(body['entries']) ? body['entries'] : null;
+    if (!rawEntries || rawEntries.length > 100) {
+      return json(res, 400, { error: 'bad_revival_entries' }, origin);
+    }
+
+    tidyCommands();
+    const pending: string[] = [];
+    for (const raw of rawEntries) {
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+      const candidate = raw as Record<string, unknown>;
+      const wanted = typeof candidate['id'] === 'string' ? candidate['id'].slice(0, 128) : '';
+      const reportedConversation = conversationId(candidate['conversationId']);
+      if (!wanted || !reportedConversation) continue;
+
+      const command = commands.find((entry) => entry.id === wanted);
+      if (!command || command.spec.type !== 'revive' || revivalDeliveryProven(command)) continue;
+      if (command.spec.conversationId !== reportedConversation) continue;
+      const revival = revivalFor(command.spec.agent, command.spec.runId);
+      if (!revival || revival.conversationId !== reportedConversation) continue;
+      pending.push(wanted);
+    }
+    return json(res, 200, { pending }, origin);
   }
 
   // The targeted-open path: one page, opened by the app, redeeming the one command the
@@ -4230,7 +4273,6 @@ function queue(spec: CommandSpec): Command {
     spec,
     createdAt: Date.now(),
     claimedAt: null,
-    retriedAt: null,
     timer: null,
     lastError: null,
     owner: null
@@ -4452,7 +4494,8 @@ export async function cancelResumeNow(sessionId: string): Promise<boolean> {
 /** Auto Off owns only threshold-created tickets; manual Compact & Resume remains explicit. */
 async function cancelAutomaticResumesNow(sessionId?: string): Promise<number> {
   let cancelled = 0;
-  for (const entry of pendingAutomaticContinuations()) {
+  for (const entry of pendingContinuations()) {
+    if (!entry.automatic) continue;
     if (sessionId && entry.sessionId !== sessionId) continue;
     if (await cancelResumeNow(entry.sessionId)) cancelled += 1;
     compactionWatch.delete(entry.from);
@@ -4602,7 +4645,12 @@ export function chatUrl(conversationId: string): string {
 }
 
 /** Where the app opens a fresh worker/resume chat. The marker is an id, not a credential. */
-export function commandUrl(id: string, model?: string | null, reasoningEffort?: ReasoningEffort | null): string {
+export function commandUrl(
+  id: string,
+  model?: string | null,
+  reasoningEffort?: ReasoningEffort | null,
+  project?: string | null
+): string {
   // Both a query and a fragment: ChatGPT is a single-page app that rewrites its own URL
   // during boot, and which of the two survives has changed between builds. The content
   // script accepts either, and redeeming still requires the extension's bearer token —
@@ -4613,11 +4661,19 @@ export function commandUrl(id: string, model?: string | null, reasoningEffort?: 
   // declared creation intent, forwarded independently: it never selects or changes the
   // model, and whether ChatGPT applies it is proven by the chat's own picker state, not
   // by this URL.
+  //
+  // A chat created inside a Project has to be started from that Project's own page, because
+  // the address is the only thing that says which Project a new conversation belongs to --
+  // issue #84. `/g/<id>/project` is that page. The id is normalized first, so a display name
+  // that happens to be in a stored value can never reach the path, and anything unrecognised
+  // falls back to the root exactly as before rather than to an address nobody has seen.
   const marker = `clf=${encodeURIComponent(id)}`;
   const params = [marker];
   if (model) params.push(`model=${encodeURIComponent(model)}`);
   if (reasoningEffort) params.push(`reasoning_effort=${encodeURIComponent(reasoningEffort)}`);
-  return `https://chatgpt.com/?${params.join('&')}#${marker}`;
+  const inProject = normalizeProjectId(project);
+  const base = inProject ? `https://chatgpt.com/g/${inProject}/project` : 'https://chatgpt.com/';
+  return `${base}?${params.join('&')}#${marker}`;
 }
 
 /**
@@ -4682,16 +4738,6 @@ function commandHomeConversation(spec: CommandSpec): string | null {
 }
 
 /**
- * How long a placed chat is given to redeem before the OS opener is asked after all.
- *
- * The offer is collected in the very response that produced the command, so this is not a
- * wait for a poll — it is the browser's whole round trip: create the tab, load ChatGPT, run
- * the content script, redeem. Twenty seconds is generous for that and still leaves most of
- * `COMMAND_DEADLINE_MS` for the fallback open to succeed in.
- */
-export const BROWSER_PLACEMENT_MS = 20_000;
-
-/**
  * The chat whose own request is in flight right now.
  *
  * Compact & Resume is produced by chat A's page asking for it, so at the instant the command
@@ -4703,68 +4749,34 @@ export const BROWSER_PLACEMENT_MS = 20_000;
  */
 let placementCollector: string | null = null;
 
-/** The one fresh chat currently offered to its home page, and the fallback that outlives it. */
-let placementOffer: { id: string; conversationId: string | null; model: string | null; reasoningEffort: ReasoningEffort | null } | null = null;
-let placementTimer: NodeJS.Timeout | null = null;
-
-/** Drops the standing offer and its fallback. Called by every path that ends a command. */
-function clearPlacementOffer(): void {
-  placementOffer = null;
-  if (placementTimer) clearTimeout(placementTimer);
-  placementTimer = null;
-}
-
-/**
- * Offers a leased fresh chat to the page of the chat it succeeds.
- *
- * Returns false whenever this app cannot name a home chat that is asking for this command
- * right now, which is every path except a page-driven compaction. Those open through the OS
- * opener exactly as before, because there is genuinely nothing better to know about them.
- */
+/** Transfer opening authority through the companion while it has a live wake connection. */
 function offerPlacement(command: Command): boolean {
   const home = commandHomeConversation(command.spec);
-  const backgroundWorker = command.spec.type === 'worker' && getConfig().ui.backgroundChats && browserWakeConnected();
-  if (!backgroundWorker && (!home || home !== placementCollector)) return false;
-  clearPlacementOffer();
-  placementOffer = {
-    id: command.id,
-    conversationId: backgroundWorker ? null : home,
-    model: command.spec.type === 'worker' ? command.spec.model : null,
-    reasoningEffort: command.spec.type === 'worker' ? command.spec.reasoningEffort : null
-  };
-  placementTimer = setTimeout(() => {
-    placementTimer = null;
-    placementOffer = null;
-    // Still queued and still nobody's: the home page did not open it, so ask the OS after all.
-    const stale = commands.find((entry) => entry.id === command.id && entry.owner === null);
-    // A connected companion owns background placement. Falling back through the OS here
-    // raises Chrome even if its tab is merely still loading. The existing command deadline
-    // reports an unredeemed attempt; only an absent browser needs the cold-start opener.
-    if (stale && !(backgroundWorker && browserWakeConnected())) void openFreshChatInBrowser(stale);
-  }, BROWSER_PLACEMENT_MS);
-  placementTimer.unref?.();
-  if (backgroundWorker) wakeBrowserWork();
-  logInfo(`bridge: offering ${specKey(command.spec)} to ${home}'s own browser window`);
+  const worker = command.spec.type === 'worker' && browserWakeConnected();
+  if (!worker && (!home || home !== placementCollector)) return false;
+  command.placement = { conversationId: home, background: worker && getConfig().ui.backgroundChats === true };
+  if (worker) wakeBrowserWork();
   return true;
 }
 
-/**
- * The one fresh chat this conversation's browser is being asked to open next to itself.
- *
- * Spent on handout. The page that collects it is the page that opens the tab, and a second
- * poll - from another tab of the same chat, or the same tab a moment later - must not create
- * a second one. If that page fails to act, the fallback above is what recovers it, not a
- * repeated offer.
- */
-function pendingBrowserPlacement(conversationId: string | null): { id: string; model: string | null; reasoningEffort: ReasoningEffort | null; background?: true } | null {
-  const offer = placementOffer;
-  if (!offer || offer.conversationId !== conversationId) return null;
-  if (!commands.some((entry) => entry.id === offer.id && entry.owner === null)) {
-    placementOffer = null;
-    return null;
-  }
-  placementOffer = null;
-  return { id: offer.id, model: offer.model, reasoningEffort: offer.reasoningEffort, ...(offer.conversationId === null ? { background: true as const } : {}) };
+/** Handout is the irreversible opening boundary, independent of a later page receipt. */
+function pendingBrowserPlacement(conversationId: string | null): {
+  id: string; model: string | null; reasoningEffort: ReasoningEffort | null;
+  background?: true; active: boolean; homeConversationId: string | null; project: string | null;
+} | null {
+  const command = commands.find(entry => entry.owner === null && entry.placement &&
+    (entry.placement.conversationId === conversationId || (conversationId === null && entry.spec.type === 'worker')));
+  if (!command?.placement) return null;
+  const placement = command.placement;
+  delete command.placement;
+  const spec = command.spec;
+  const worker = spec.type === 'worker';
+  return {
+    id: command.id, model: worker ? spec.model : null,
+    reasoningEffort: worker ? spec.reasoningEffort : null,
+    active: !worker, homeConversationId: placement.conversationId, project: commandProject(command),
+    ...(placement.background ? { background: true as const } : {})
+  };
 }
 
 // -------------------------------------------------------- exact browser recovery
@@ -5374,7 +5386,7 @@ function queueBrowserRecovery(
     reason === 'silence' || reason === 'goal' || reason === 'compaction' || reason === 'no-tab'
       ? now
       : Math.max(now, (lastBrowserRecoveryAt.get(conversationId) ?? 0) + BROWSER_RECOVERY_COOLDOWN_MS);
-  repairsInFlight.set(conversationId, {
+  const repair: Repair = {
     sessionId,
     endedTurns,
     state: 'queued',
@@ -5383,7 +5395,29 @@ function queueBrowserRecovery(
     notBefore,
     token: '',
     progressId: `browser-repair:${randomBytes(9).toString('base64url')}`
-  });
+  };
+  repairsInFlight.set(conversationId, repair);
+  // A queued durable pickup used to wait forever when Chrome itself had exited:
+  // nobody remained to collect /status. This same accepted repair owns one cold
+  // start through the existing startup owner; no new timer or opening retry exists.
+  if ((reason === 'goal' || reason === 'compaction') && getConfig().ui.browserOnly !== true) {
+    const reply = goalPendingReplyFor(conversationId);
+    const ticket = continuationForSession(sessionId);
+    const lifecycle = bridgeLifecycleEpoch;
+    void wakeBrowserUrl(chatUrl(conversationId), true, getConfig().ui.backgroundChats === true, {
+      requireProcessAbsence: true,
+      current: () => bridgeLifecycleEpoch === lifecycle && !bridgeShutdownRequested &&
+        getConfig().ui.browserOnly !== true &&
+        repairsInFlight.get(conversationId) === repair && repair.state === 'queued' &&
+        !isChatBlocked(conversationId) && !stopRequestedFor(conversationId) &&
+        !supersededSourceConversations().includes(conversationId) &&
+        (reason === 'compaction'
+          ? !!ticket && ticket.from === conversationId && continuationForSession(sessionId)?.token === ticket.token &&
+            continuationForSession(sessionId)?.state === 'awaiting-summary'
+          : goalActiveFor(conversationId) && !!reply && goalPendingReplyFor(conversationId)?.replyId === reply.replyId &&
+            !continuationForSession(sessionId))
+    }).catch((error: Error) => logWarn(`bridge: could not start browser for ${reason} recovery: ${error.message}`));
+  }
   return true;
 }
 
@@ -5508,7 +5542,7 @@ async function noteRecoveryObservations(
     // under the same bound — is brought forward to the next sweep instead of waiting out its five
     // minutes. That wait is how the 2026-09-02 prime showed "Connection interrupted" for nine
     // minutes while its model went on calling tools behind the dead page.
-    if (pendingAutomaticContinuations().some((entry) => entry.from === conversationId)) {
+    if (pendingContinuations().some((entry) => entry.from === conversationId)) {
       if (expediteCompactionPickup(conversationId)) {
         logInfo(`bridge: assistant transport failure — bringing the compaction pickup for ${conversationId} forward`);
       }
@@ -5561,6 +5595,14 @@ async function browserTabPolicy(openConversations: Set<string>) {
   // running tools, automation/broker obligation and fresh page proof protect pruning.
   for (const [id, grant] of activeUntil) if (grant.until > Date.now()) protectedChats.add(id);
   const inputs = await listInputs();
+  // A cancelled send remains a tombstone, not a renderer lease. Only the durable
+  // dedicated-helper role and exact claim permit retirement. Opening helpers have no
+  // source yet; established helpers must still name a distinct existing source.
+  const cancelledDecisionClaims = inputs.filter(row => row.purpose === 'decision' && !row.lifetime &&
+    row.state === 'cancelled' && row.owner && row.conversationId && openConversations.has(row.conversationId) &&
+    isGoalDecisionChat(row.conversationId) && (!row.decisionSourceSessionId ||
+      summaries.some(source => source.id === row.decisionSourceSessionId && source.conversationId !== row.conversationId)));
+  for (const row of cancelledDecisionClaims) managed.add(row.conversationId!);
   for (const row of inputs) if (!row.sessionId && row.purpose !== 'decision' && row.deliveredAt !== undefined && row.conversationId && openConversations.has(row.conversationId)) managed.add(row.conversationId);
   for (const id of managed) if (runningToolCalls(id) > 0 || goalActiveFor(id)) protectedChats.add(id);
   for (const row of inputs) if (row.conversationId && ['queued', 'browser', 'decision'].includes(row.state)) protectedChats.add(row.conversationId);
@@ -5575,7 +5617,9 @@ async function browserTabPolicy(openConversations: Set<string>) {
     note(row.conversationId, row.lastTurnEndAt);
     note(row.conversationId, row.lastAssistantFinalAt);
   }
-  for (const agent of swarmState().agents) {
+  for (const id of managed) {
+    const agent = agentInfoForOwnedConversation(id);
+    if (!agent) continue;
     // lastSeenAt includes unchanged page presence, including sleeping workers.
     // It is reachability, never proof of new work that can extend tab retention.
     note(agent.conversationId, agent.createdAt);
@@ -5584,6 +5628,7 @@ async function browserTabPolicy(openConversations: Set<string>) {
     note(agent.conversationId, agent.sleptAt);
   }
   for (const row of inputs) note(row.conversationId, row.deliveredAt);
+  for (const row of cancelledDecisionClaims) note(row.conversationId, row.sendAuthorizedAt ?? row.offeredAt ?? row.createdAt);
   const blocked = [...managed].filter(isChatBlocked);
   for (const id of blocked) {
     protectedChats.delete(id);
@@ -5593,10 +5638,17 @@ async function browserTabPolicy(openConversations: Set<string>) {
     if (at !== null) lastActivity.set(id, at);
   }
   const idle = [...managed].filter(id => !protectedChats.has(id) &&
-    lastActivity.has(id) && Date.now() - lastActivity.get(id)! >= 60_000);
+    lastActivity.has(id) && Date.now() - lastActivity.get(id)! >= 120_000);
   return {
-    idleCloseAfterMs: 60_000,
+    idleCloseAfterMs: 120_000,
+    cancelledDecisionClaims: cancelledDecisionClaims.map(row => ({ id: row.id, owner: row.owner, conversationId: row.conversationId })),
+    // Worker reuse is broker state, not a reason to retain an idle browser renderer.
+    // A later explicit message reopens that same conversation through existing delivery.
+    retiredConversations: [...new Set([...idle, ...supersededSourceConversations()])]
+      .filter(id => openConversations.has(id) && !protectedChats.has(id)).sort(),
     tabsToKeepOpen: getConfig().multiAgent.maxWorkers,
+    workerConversations: [...managed].filter(isWorkerConversation).sort(),
+    sleepingWorkerConversations: closableWorkerConversations(0).filter(id => managed.has(id) && !protectedChats.has(id)),
     conversationActivityAt: Object.fromEntries(lastActivity),
     managedConversations: [...managed].sort(),
     nonDiscardableConversations: [...protectedChats].sort(),
@@ -5641,7 +5693,7 @@ async function inspectSilentChats(now: number): Promise<{ queued: boolean; spent
   let queued = false;
   let deferred = false;
   const spent: string[] = [];
-  const compacting = new Set(pendingAutomaticContinuations().map((entry) => entry.from));
+  const compacting = new Set(pendingContinuations().map((entry) => entry.from));
   for (const [conversationId, grant] of activeUntil) {
     if (compacting.has(conversationId)) continue;
     if (grant.until > now) continue;
@@ -5748,7 +5800,7 @@ const GOAL_WATCH_BACKOFF_MS = [2, 2, 5, 10, 15].map((minutes) => minutes * 60_00
 const goalWatch = new Map<string, { replyId: string; dueAt: number; attempts: number }>();
 
 /**
- * The browser pickups an automatic ticket gets, by what the ticket is waiting for.
+ * The browser pickups a compaction ticket gets, by what the ticket is waiting for.
  *
  * Three clocks, one per phase, and the phase is read off the ticket's durable position every
  * sweep. A page holds the ticket only while it is the page doing the work; the moment it stops
@@ -5790,14 +5842,14 @@ function compactionPhaseOf(entry: ContinuationView): CompactionPhase {
 }
 
 /**
- * Makes a ticket's next automatic pickup due on the next sweep, within the same bound.
+ * Makes a ticket's next pickup due on the next sweep, within the same bound.
  *
  * The schedule is not otherwise moved by page activity, and this adds no attempts: a pickup
- * brought forward is one of the phase's own. False when there is no automatic ticket for the
+ * brought forward is one of the phase's own. False when there is no open ticket for the
  * chat, the ticket predates this process, or its pickups are exhausted.
  */
 function expediteCompactionPickup(conversationId: string): boolean {
-  const entry = pendingAutomaticContinuations().find((candidate) => candidate.from === conversationId);
+  const entry = pendingContinuations().find((candidate) => candidate.from === conversationId);
   if (!entry || compactionWatchFloor === null || entry.openedAt < compactionWatchFloor) return false;
   const phase = compactionPhaseOf(entry);
   const watch = compactionWatch.get(conversationId);
@@ -5932,15 +5984,16 @@ async function inspectOwedGoals(now: number): Promise<boolean> {
 }
 
 /**
- * Gives durable auto-compaction tickets their bounded browser pickups — see COMPACTION_PICKUPS.
+ * Gives durable compaction tickets their bounded browser pickups — see COMPACTION_PICKUPS.
  *
  * Only the asking phase has a failure verdict: a prompt that could not be sent in ten minutes
  * is abandoned. Past the send the ticket has no clock here; it remains collectable by any later
- * page until Auto Off, explicit cancel, or the marked bootstrap's durable commit in chat B.
+ * page until explicit cancel or the marked bootstrap's durable commit in chat B.
+ * Auto Off additionally cancels threshold-created tickets, never manual requests.
  */
 async function inspectOwedCompactions(now: number): Promise<boolean> {
   if (compactionWatchFloor === null) return false;
-  const owed = new Map(pendingAutomaticContinuations().map((entry) => [entry.from, entry]));
+  const owed = new Map(pendingContinuations().map((entry) => [entry.from, entry]));
   for (const [conversationId, watch] of compactionWatch) {
     if (owed.get(conversationId)?.token === watch.token) continue;
     compactionWatch.delete(conversationId);
@@ -5949,7 +6002,7 @@ async function inspectOwedCompactions(now: number): Promise<boolean> {
 
   let queued = false;
   for (const entry of owed.values()) {
-    if (!automaticCompactionAllowed(await getSession(entry.sessionId))) {
+    if (entry.automatic && !automaticCompactionAllowed(await getSession(entry.sessionId))) {
       await cancelAutomaticResumesNow(entry.sessionId);
       continue;
     }
@@ -5976,11 +6029,11 @@ async function inspectOwedCompactions(now: number): Promise<boolean> {
       try {
         await abortContinuationNow(entry.token, 'handoff_never_sent');
         logWarn(
-          `bridge: auto-compaction ticket ${entry.token.slice(0, 8)} for ${entry.from} was never sent after ${schedule.attempts} pickups — giving up; the next working turn opens a fresh one`
+          `bridge: compaction ticket ${entry.token.slice(0, 8)} for ${entry.from} was never sent after ${schedule.attempts} pickups — giving up`
         );
         changed();
       } catch (err) {
-        logWarn(`bridge: could not abandon auto-compaction ticket ${entry.token.slice(0, 8)} — ${err instanceof Error ? err.message : String(err)}`);
+        logWarn(`bridge: could not abandon compaction ticket ${entry.token.slice(0, 8)} — ${err instanceof Error ? err.message : String(err)}`);
       }
       continue;
     }
@@ -6014,7 +6067,7 @@ async function inspectOwedCompactions(now: number): Promise<boolean> {
     watch.since = now;
     queued = true;
     logInfo(
-      `bridge: auto-compaction ticket ${entry.token.slice(0, 8)} ${phase} pickup ${watch.attempts} of ${schedule.attempts}`
+      `bridge: compaction ticket ${entry.token.slice(0, 8)} ${phase} pickup ${watch.attempts} of ${schedule.attempts}`
     );
   }
   return queued;
@@ -6177,6 +6230,10 @@ function noteCallAttribution(
   filedSession: SessionSummary | null = null
 ): void {
   if (conversationId) {
+    // MCP truth can grow while a Pro page emits no new observation. The just-filed
+    // canonical summary, not a later browser poll, owns the worker's context meter.
+    if (currentConversation && filedSession?.id === sessionId && filedSession.conversationId === conversationId)
+      noteAgentContextTokens(conversationId, filedSession.contextTokens);
     if (currentConversation && !endsActivity) lastAttributedCallAt.set(conversationId, Date.now());
     // The recorder has just withdrawn a completed end the page reported: the same server turn
     // went on calling tools. Whatever Goal was drafting for that end — or had filed as owed —
@@ -6651,6 +6708,19 @@ async function deliverOne(): Promise<void> {
  * running. It is also the fallback for an offer nobody collected, which is why it is reachable
  * from the placement timer as well as from delivery.
  */
+/**
+ * The Project a command's fresh chat belongs in, or null for the site root.
+ *
+ * Read from the continuation rather than from the live observation, because this is the path
+ * taken when the browser did not place the chat -- the tab is gone, or this process restarted
+ * and the map is empty. The continuation is what was written down at open time and is the only
+ * thing here that survives either.
+ */
+function commandProject(command: Command): string | null {
+  if (command.spec.type !== 'resume') return null;
+  return continuationByToken(command.spec.token)?.project ?? null;
+}
+
 async function openFreshChatInBrowser(command: Command): Promise<void> {
   if (!openInBrowser) {
     drop(command, 'this app has no way to open a browser window');
@@ -6664,7 +6734,7 @@ async function openFreshChatInBrowser(command: Command): Promise<void> {
     await openInBrowser(
       command.spec.type === 'worker'
         ? commandUrl(command.id, command.spec.model, command.spec.reasoningEffort)
-        : commandUrl(command.id)
+        : commandUrl(command.id, null, null, commandProject(command))
     );
   } catch (err) {
     // One command is one browser-open attempt. A rejected opener can never produce an ACK,
@@ -6717,7 +6787,7 @@ function commandDeadlineDelay(command: Command, now = Date.now()): number {
   }
   if (command.spec.type === 'resume' && command.owner !== null) {
     const continuation = continuationByToken(command.spec.token);
-    if (continuation?.state === 'claimed') return continuation.openedAt + CONTINUATION_TTL_MS - now;
+    if (continuation?.state === 'claimed') return continuation.touchedAt + CONTINUATION_TTL_MS - now;
   }
   if (command.spec.type === 'worker') {
     // Absolute, from the invitation. Whatever else this command is waiting for, the slot it
@@ -6821,20 +6891,6 @@ function expire(command: Command): void {
     retire(command, 'its worker is bound and running');
     return;
   }
-  // The chat opened for it never redeemed the marker. Open it once more, once: the command is
-  // single-owner, so the page that does redeem is the only one that ever types.
-  if (
-    spec.type === 'worker' &&
-    command.claimedAt !== null &&
-    command.owner === null &&
-    command.retriedAt === null &&
-    Date.now() < command.createdAt + WORKER_BOOTSTRAP_LIMIT_MS
-  ) {
-    command.retriedAt = Date.now();
-    logWarn(`bridge: the chat opened for ${specKey(spec)} never picked up its instruction — opening it once more`);
-    void reopenWorkerChat(command);
-    return;
-  }
   if (spec.type === 'revive' && !revivalFor(spec.agent, spec.runId)) {
     retire(command, 'its worker is no longer waiting to be woken');
     return;
@@ -6843,35 +6899,11 @@ function expire(command: Command): void {
   deliver();
 }
 
-/**
- * The one re-open of a worker chat that opened and never redeemed.
- *
- * A fresh lease first, so the redeem window and the durable record both restart from this
- * open; a lease that cannot be written ends the command instead, exactly as a first delivery
- * would. Straight to the OS opener rather than the placement offer: the home page already had
- * its chance to place this one.
- */
-async function reopenWorkerChat(command: Command): Promise<void> {
-  if (!(await persistCommandLease(command, null, Date.now()))) {
-    if (commands.includes(command)) {
-      drop(command, 'the chat this app opened did not report back in time');
-      await deliver();
-    }
-    return;
-  }
-  armDeadline(command);
-  changed();
-  await openFreshChatInBrowser(command);
-}
-
 /** Finishes a command that has nothing left to do, timer and all. */
 function retire(command: Command, why: string): void {
   if (command.timer) clearTimeout(command.timer);
   command.timer = null;
-  // A standing placement offer belongs to this command alone. Handout already re-checks that
-  // the command is still queued, so this is not what makes a retired offer inert — it is what
-  // stops the fifteen-second fallback outliving the thing it was covering for.
-  if (placementOffer?.id === command.id) clearPlacementOffer();
+  delete command.placement;
   if (!commands.includes(command)) return;
   commands = commands.filter((entry) => entry !== command);
   logInfo(`bridge: ${specKey(command.spec)} is done — ${why}`);
@@ -7433,8 +7465,7 @@ function planCommandRestore(
       spec,
       createdAt,
       claimedAt,
-      retriedAt: null,
-      timer: null,
+        timer: null,
       lastError: typeof raw.lastError === 'string' ? raw.lastError : null,
       owner: leased && typeof raw.owner === 'string' ? raw.owner.slice(0, 64) : null
     });
@@ -7580,7 +7611,6 @@ export function resetBridgeForTests(): void {
   if (browserLaunchTimer) clearTimeout(browserLaunchTimer);
   browserLaunchTimer = null;
   lastBrowserLaunchAt = 0;
-  clearPlacementOffer();
   lastSeenAt = null;
   extensionVersion = null;
   versionWarned = false;

--- a/src/main/browser-startup.ts
+++ b/src/main/browser-startup.ts
@@ -1,0 +1,37 @@
+/** One browser startup owner for explicit work and durable recovery. */
+import { bridgeStatus, browserWakeConnected } from './bridge.js';
+import { isPreferredBrowserRunning, openInPreferredBrowser } from './browser.js';
+import { getConfig } from './config.js';
+
+let waking: { lastSeenAt: number | null; selected: string; work: Promise<void>; failed: boolean; finished: boolean } | null = null;
+/** One browser startup per absence episode, shared by authored sends, discovery and owed recovery. */
+export async function wakeBrowserUrl(url: string, retry = false, backgroundStartup = false,
+  authority?: { current(): boolean; requireProcessAbsence: boolean }): Promise<void> {
+  if (authority && !authority.current()) return;
+  const browser = await bridgeStatus();
+  if (browserWakeConnected()) { waking = null; return; }
+  const selected = getConfig().ui.chatBrowser ?? 'chrome';
+  // Explicit work may disprove cached HTTP presence or an old successful launch.
+  // Socket suspension alone grants nothing, and an in-flight launch stays shared.
+  const prior = waking;
+  const absent = (authority?.requireProcessAbsence || browser.present || (retry && prior?.finished && !prior.failed)) &&
+    await isPreferredBrowserRunning() === false;
+  // A settings change while the probe yielded revokes that browser's absence evidence.
+  if (selected !== (getConfig().ui.chatBrowser ?? 'chrome')) return;
+  // The process query yields. Off, a collected reply or a new navigation can revoke
+  // the exact recovery meanwhile; a missing socket alone never proves Chrome exited.
+  if (authority && (!authority.current() || (authority.requireProcessAbsence && !absent))) return;
+  if (browserWakeConnected()) { waking = null; return; }
+  if (browser.present && !absent) { waking = null; return; }
+  if (retry && waking === prior && (waking?.failed || (absent && waking?.finished))) waking = null;
+  // Until the extension registers, another explicit send belongs to the same startup.
+  // A changed browser choice starts a distinct attempt without adopting the old family.
+  if (waking?.lastSeenAt === browser.lastSeenAt && waking.selected === selected) return waking.work;
+  const work = (async () => {
+    await (backgroundStartup ? openInPreferredBrowser(url, { backgroundStartup: true }) : openInPreferredBrowser(url));
+  })();
+  const attempt = { lastSeenAt: browser.lastSeenAt, selected, work, failed: false, finished: false };
+  waking = attempt;
+  try { await work; } catch (error) { attempt.failed = true; throw error; } finally { attempt.finished = true; }
+}
+export function resetBrowserStartupForTests(): void { waking = null; }

--- a/src/main/browser.ts
+++ b/src/main/browser.ts
@@ -2,11 +2,32 @@ import { accessSync, constants, existsSync, statSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { launchCommand, runPowerShell } from './exec.js';
+import { getConfig } from './config.js';
+import type { ChatBrowser } from '../shared/types.js';
 
 type Exists = (candidate: string) => boolean;
 type Launch = typeof launchCommand;
 
+/** A successful OS handoff is not a live browser. Unknown probes never grant opening authority. */
+export async function isPreferredBrowserRunning(
+  platform: NodeJS.Platform = process.platform,
+  powershell: typeof runPowerShell = runPowerShell,
+  browser: ChatBrowser = getConfig().ui.chatBrowser ?? 'chrome'
+): Promise<boolean | null> {
+  if (platform !== 'win32') return null;
+  try {
+    // Probe only the selected family; another browser cannot prove its presence or absence.
+    // Enumerate names only, never user command lines or profile data. Both names are constants.
+    const processName = browser === 'edge' ? 'msedge' : 'chrome';
+    const result = await powershell(`$ErrorActionPreference='Stop'; if (@(Get-Process | Where-Object ProcessName -eq '${processName}').Count) { 'running' } else { 'absent' }`, os.tmpdir(), 5000);
+    if (result.timedOut || result.exitCode !== 0) return null;
+    return result.stdout.trim() === 'absent' ? false : result.stdout.trim() === 'running' ? true : null;
+  } catch { return null; }
+}
+
 export interface PreferredBrowserOpenOptions {
+  /** Defaults to the saved ChatGPT browser choice. */
+  browser?: ChatBrowser;
   /** Start the owned helper without activating its Windows startup window. */
   backgroundStartup?: boolean;
   platform?: NodeJS.Platform;
@@ -31,46 +52,49 @@ function isExecutableBrowser(candidate: string, platform: NodeJS.Platform): bool
 }
 
 /**
- * Browsers which can run the unpacked companion extension, in preference order.
+ * Installations of the selected companion browser, in preference order.
  *
  * Nothing here can choose *which running instance* of that browser the URL reaches: the
  * platform resolves it to the one that last had focus. A chat that must be opened beside
  * another chat is therefore not opened from this module at all — the browser holding the
  * source chat opens it. See `bridge.ts::offerPlacement`.
  *
- * Worker/resume URLs are not ordinary links: the extension must redeem the command marker
- * embedded in them. Sending those URLs to Safari/Firefox merely opens a dead ChatGPT tab, so
- * browser-backed orchestration deliberately prefers the Chrome installation the setup guide
- * tells the user to load the extension into.
+ * Worker/resume URLs require the companion and the user's ChatGPT account. Browser family
+ * is a saved user choice, not inferred from executable availability or the OS URL handler.
+ * Never cross that choice just because another installed browser is easier to launch.
  */
 export function preferredBrowserCandidates(
   platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
-  home = env.HOME ?? env.USERPROFILE ?? os.homedir()
+  home = env.HOME ?? env.USERPROFILE ?? os.homedir(),
+  browser: ChatBrowser = 'chrome'
 ): string[] {
   if (platform === 'win32') {
     const p = path.win32;
-    return [
-      env.LOCALAPPDATA && p.join(env.LOCALAPPDATA, 'Google', 'Chrome', 'Application', 'chrome.exe'),
-      env.ProgramFiles && p.join(env.ProgramFiles, 'Google', 'Chrome', 'Application', 'chrome.exe'),
-      env['ProgramFiles(x86)'] && p.join(env['ProgramFiles(x86)'], 'Google', 'Chrome', 'Application', 'chrome.exe')
-    ].filter((candidate): candidate is string => Boolean(candidate));
+    const parts = browser === 'edge'
+      ? ['Microsoft', 'Edge', 'Application', 'msedge.exe']
+      : ['Google', 'Chrome', 'Application', 'chrome.exe'];
+    return [env.LOCALAPPDATA, env.ProgramFiles, env['ProgramFiles(x86)']]
+      .filter((root): root is string => Boolean(root))
+      .map(root => p.join(root, ...parts));
   }
 
   if (platform === 'darwin') {
-    // Chrome's release channels are separate .app bundles on macOS. A Beta/Dev/Canary-only
-    // install is still a perfectly valid place to load this unpacked Chrome extension, and the
-    // setup UI never requires Stable specifically. If orchestration only knows the Stable bundle,
-    // a worker/resume command falls through to the system default browser (commonly Safari) even
-    // though the compatible Chrome instance is sitting right there with the extension loaded.
-    const chromeChannels = [
+    // Release channels have separate bundles. Keep Beta/Dev/Canary-only installs usable
+    // without crossing the user's chosen browser family.
+    const channels = browser === 'edge' ? [
+      ['Microsoft Edge.app', 'Microsoft Edge'],
+      ['Microsoft Edge Beta.app', 'Microsoft Edge Beta'],
+      ['Microsoft Edge Dev.app', 'Microsoft Edge Dev'],
+      ['Microsoft Edge Canary.app', 'Microsoft Edge Canary']
+    ] : [
       ['Google Chrome.app', 'Google Chrome'],
       ['Google Chrome Beta.app', 'Google Chrome Beta'],
       ['Google Chrome Dev.app', 'Google Chrome Dev'],
       ['Google Chrome Canary.app', 'Google Chrome Canary'],
       ['Chromium.app', 'Chromium']
     ] as const;
-    return chromeChannels.flatMap(([bundle, executable]) => [
+    return channels.flatMap(([bundle, executable]) => [
       path.posix.join('/Applications', bundle, 'Contents', 'MacOS', executable),
       ...(home ? [path.posix.join(home, 'Applications', bundle, 'Contents', 'MacOS', executable)] : [])
     ]);
@@ -78,11 +102,8 @@ export function preferredBrowserCandidates(
 
   if (platform === 'linux') {
     const pathValue = env.PATH ?? '';
-    // Google ships Beta and Dev as separate Linux packages/binaries, just as it ships
-    // separate .app bundles on macOS. A user can legitimately have the companion loaded in
-    // one of those channels with Stable absent, so keep all Chrome channels ahead of the
-    // Chromium fallbacks rather than handing an orchestration marker to the default browser.
-    const names = [
+    // Search release-channel launchers too: the companion need not be installed in Stable.
+    const names = browser === 'edge' ? ['microsoft-edge', 'microsoft-edge-stable', 'microsoft-edge-beta', 'microsoft-edge-dev'] : [
       'google-chrome',
       'google-chrome-stable',
       'google-chrome-beta',
@@ -94,6 +115,11 @@ export function preferredBrowserCandidates(
       .split(':')
       .filter(Boolean)
       .flatMap((dir) => names.map((name) => path.posix.join(dir, name)));
+    if (browser === 'edge') return [...new Set([
+      ...fromPath,
+      ...names.map(name => path.posix.join('/usr/bin', name)),
+      '/opt/microsoft/msedge/msedge', '/opt/microsoft/msedge-beta/msedge', '/opt/microsoft/msedge-dev/msedge'
+    ])];
     // Chrome and Chromium are both widely installed through Flatpak on immutable Linux
     // desktops. Flatpak exports host launchers for installed applications under these
     // `exports/bin` directories (the exported Chrome desktop file uses the same path as
@@ -137,32 +163,33 @@ export function findPreferredBrowser(
 }
 
 /**
- * Opens an orchestration URL in the first Chromium browser that can actually be launched.
+ * Opens an orchestration URL in the saved browser family.
  *
  * Existence/executable checks are intentionally not the arbitration cut. A stale wrapper or a
  * damaged first Chrome install can pass those checks and still fail at spawn time; worker/resume
- * URLs must then try the next compatible Chromium candidate rather than falling straight through
- * to Safari/Firefox via the system default browser.
+ * URLs may try another installation of that family, never the system default or another family.
  */
 export async function openInPreferredBrowser(
   url: string,
   options: PreferredBrowserOpenOptions = {}
-): Promise<string | null> {
+): Promise<string> {
   const platform = options.platform ?? process.platform;
   const env = options.env ?? process.env;
   const usable = options.usable ?? ((candidate: string) => isExecutableBrowser(candidate, platform));
   const launch = options.launch ?? launchCommand;
+  const selected = options.browser ?? getConfig().ui.chatBrowser ?? 'chrome';
+  const label = selected === 'edge' ? 'Microsoft Edge' : 'Google Chrome / Chromium';
   // These switches only affect a newly started Chrome process; handing a URL to an
   // existing instance cannot change its policy. Memory Saver exclusions alone do not
   // prevent background timer/renderer throttling of long-running orchestration tabs.
   const args = [
     ...(platform === 'win32' ? ['--disable-renderer-backgrounding', '--disable-background-timer-throttling'] : []),
-    ...(options.backgroundStartup ? ['--start-maximized'] : []),
+    ...(options.backgroundStartup ? ['--window-size=1100,800'] : []),
     url
   ];
   let lastError: unknown = null;
 
-  for (const browser of preferredBrowserCandidates(platform, env, options.home)) {
+  for (const browser of new Set(preferredBrowserCandidates(platform, env, options.home, selected))) {
     if (!usable(browser)) continue;
     try {
       // A windowless Chrome exits once extensions load unless the profile has a
@@ -189,6 +216,6 @@ export async function openInPreferredBrowser(
     }
   }
 
-  if (lastError) throw lastError;
-  return null;
+  if (lastError) throw new Error(`${label} could not start: ${(lastError as Error).message}. Check Settings > Browser & history > ChatGPT browser.`);
+  throw new Error(`${label} was not found. Install it or change Settings > Browser & history > ChatGPT browser.`);
 }

--- a/src/main/chat-models.ts
+++ b/src/main/chat-models.ts
@@ -10,17 +10,17 @@ const observation = z.object({
   error: z.enum(['picker_unavailable', 'model_unconfirmed', 'power_unknown', 'power_unconfirmed', 'power_changed', 'restore_failed', 'inspection_failed']).optional(),
   models: z.array(z.object({
     id: z.string().min(1).max(80).regex(/^[a-zA-Z0-9._-]+$/),
-    label: z.string().trim().min(1).max(80).regex(/^[a-zA-Z0-9 ._-]+$/),
+    label: z.string().trim().min(1).max(80),
     efforts: z.array(z.enum(REASONING_EFFORTS)).max(REASONING_EFFORTS.length)
   }).strict()).min(1).max(20).nullable()
 }).strict();
 let catalog: ChatModelCatalog = { state: 'unknown', requestedAt: null, observedAt: null, models: [] };
-let request: { nonce: string; expiresAt: number } | null = null;
+let request: { nonce: string; expiresAt: number; allowOpen: boolean } | null = null;
 let deadline: ReturnType<typeof setTimeout> | null = null;
-let launch: { nonce: string; work: Promise<void>; finished: boolean } | null = null;
+let launch: { nonce: string; allowOpen: boolean; work: Promise<void> } | null = null;
 let changed = (): void => {};
-let wake: ((nonce: string) => Promise<void>) | null = null;
-export function configureChatModelDiscovery(options: { changed: () => void; wake: (nonce: string) => Promise<void> }): void { changed = options.changed; wake = options.wake; }
+let wake: ((nonce: string, allowOpen: boolean) => Promise<void>) | null = null;
+export function configureChatModelDiscovery(options: { changed: () => void; wake: (nonce: string, allowOpen: boolean) => Promise<void> }): void { changed = options.changed; wake = options.wake; }
 function scheduleDeadline(at: number): void {
   if (deadline) clearTimeout(deadline);
   deadline = setTimeout(() => { deadline = null; expire(); changed(); wakeBrowserWork(); }, Math.max(0, at - Date.now()));
@@ -32,25 +32,38 @@ function expire(): void {
 export function getChatModels(): ChatModelCatalog {
   expire(); return structuredClone(catalog);
 }
-export function requestChatModels(): ChatModelCatalog {
+export function requestChatModels(allowOpen = true): ChatModelCatalog {
   expire();
   if (!request) {
-    const now = Date.now(); request = { nonce: randomUUID(), expiresAt: now + 120000 };
+    const now = Date.now(); request = { nonce: randomUUID(), expiresAt: now + 120000, allowOpen };
     logInfo(`model discovery requested id=${request.nonce}`);
     catalog = { state: 'pending', requestedAt: now, observedAt: null, models: [] };
     scheduleDeadline(request.expiresAt);
+    wakeBrowserWork();
+  } else if (allowOpen && !request.allowOpen) {
+    // Explicit refresh promotes the existing nonce; it cannot create a competing request.
+    request.allowOpen = true;
     wakeBrowserWork();
   }
   return getChatModels();
 }
 /** An explicit UI request starts only the local browser bridge, never MCP/tunnel exposure. */
-export async function startChatModelDiscovery(): Promise<ChatModelCatalog> {
-  requestChatModels();
+export async function startChatModelDiscovery(allowOpen = true): Promise<ChatModelCatalog> {
+  // Showing an existing app window is neither a refresh nor permission to open Chrome.
+  if (!allowOpen && catalog.state !== 'unknown') return getChatModels();
+  requestChatModels(allowOpen);
   const nonce = request!.nonce;
-  if (!launch || (launch.finished && launch.nonce !== nonce)) {
-    const attempt = { nonce, work: Promise.resolve(), finished: false };
+  if (!launch || launch.nonce !== nonce || (request!.allowOpen && !launch.allowOpen)) {
+    const previous = launch?.work;
+    const attempt = { nonce, allowOpen: request!.allowOpen, work: Promise.resolve() };
     const work = (async () => {
-      try { if (!wake) throw new Error('Model discovery is not ready'); await wake(nonce); logInfo(`model discovery browser wake completed id=${nonce}`); }
+      try {
+        if (previous) await previous;
+        if (request?.nonce !== nonce) return;
+        if (!wake) throw new Error('Model discovery is not ready');
+        await wake(nonce, attempt.allowOpen);
+        logInfo(`model discovery browser wake completed id=${nonce}`);
+      }
       catch (error) {
         if (request?.nonce !== nonce) return;
         request = null;
@@ -59,13 +72,17 @@ export async function startChatModelDiscovery(): Promise<ChatModelCatalog> {
         changed(); wakeBrowserWork();
       }
     })();
-    attempt.work = work.finally(() => { attempt.finished = true; });
+    attempt.work = work;
     launch = attempt;
   }
-  await launch.work;
+  const attempt = launch;
+  await attempt.work;
+  // A completed OS handoff is not browser lifetime. A later explicit opening
+  // must reach the shared startup owner again if Chrome exited in the meantime.
+  if (launch === attempt) launch = null;
   return getChatModels();
 }
-export function pendingChatModelRequest(): { nonce: string; expiresAt: number } | null {
+export function pendingChatModelRequest(): { nonce: string; expiresAt: number; allowOpen: boolean } | null {
   expire(); return request ? { ...request } : null;
 }
 export function observeChatModels(raw: unknown): boolean {
@@ -75,7 +92,10 @@ export function observeChatModels(raw: unknown): boolean {
   if (models && (new Set(models.map(model => model.id)).size !== models.length ||
     models.some(model => new Set(model.efforts).size !== model.efforts.length))) return false;
   logInfo(`model discovery observed id=${request.nonce} models=${models?.length ?? 0} elapsed_ms=${Date.now() - (catalog.requestedAt ?? Date.now())} error=${parsed.data.error ?? 'none'}`);
-  catalog = { ...catalog, state: models ? 'ready' : 'unavailable', models: models ?? [], observedAt: Date.now(), ...(models ? {} : { error: 'ChatGPT model choices could not be read. Check sign-in and retry.' }) };
+  const error = parsed.data.error === 'picker_unavailable'
+    ? 'ChatGPT\'s native model picker could not be read. If your account shows only Think and no model picker, model discovery is not supported for that interface yet.'
+    : 'ChatGPT model choices could not be read. Open ChatGPT in the selected browser and check its model picker, then retry.';
+  catalog = { ...catalog, state: models ? 'ready' : 'unavailable', models: models ?? [], observedAt: Date.now(), ...(models ? {} : { error }) };
   request = null;
   if (deadline) clearTimeout(deadline); deadline = null;
   changed(); wakeBrowserWork(); return true;

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -12,12 +12,15 @@ import path from 'node:path';
 import { z } from 'zod';
 import {
   CAPABILITIES,
+  CHAT_BROWSERS,
   DEFAULT_CAPABILITIES,
   GOAL_MODES,
+  GOAL_PROVIDERS,
   GOAL_REASONING_LEVELS,
   WRITE_CAPABILITIES,
   type Capabilities,
   DESKTOP_CAPABILITIES,
+  type ArtifactSettings,
   type CompactionSettings,
   type Config,
   type GoalSettings,
@@ -26,6 +29,7 @@ import {
   type SessionSettings
 } from '../shared/types.js';
 import {
+  DEFAULT_GOAL_MODEL,
   DEFAULT_GOAL_LOOP_SYSTEM_PROMPT,
   DEFAULT_GOAL_OBJECTIVE_SYSTEM_PROMPT,
   DEFAULT_GOAL_SYSTEM_PROMPT,
@@ -113,6 +117,17 @@ const DEFAULT_COMPACTION: CompactionSettings = {
   autoTokens: DEFAULT_SESSIONS.advisoryTokens
 };
 /**
+ * Default bound for `download_artifact`.
+ *
+ * 20 MiB covers generated images, PDFs and small archives without letting one call
+ * fill the disk or blow the MCP result budget. Enforced before, during and after
+ * the stream (see artifact-fetch/artifact-target), so a lying Content-Length helps nothing.
+ */
+const DEFAULT_ARTIFACTS: ArtifactSettings = {
+  maxFileBytes: 20 * 1024 * 1024
+};
+
+/**
  * The goal loop's defaults.
  *
  * Off, because it types into somebody's chat on its own and because it cannot work at all
@@ -126,7 +141,7 @@ const DEFAULT_COMPACTION: CompactionSettings = {
  * protocol behaviour the Goal loop is validating. Existing user-selected models remain stored
  * verbatim; this value is only the fresh/repair default.
  */
-export const DEFAULT_GOAL_MODEL = 'z-ai/glm-5.3';
+export { DEFAULT_GOAL_MODEL } from '../shared/goal.js';
 const DEFAULT_GOAL: GoalSettings = {
   backend: 'chatgpt',
   loopBackend: 'chatgpt',
@@ -139,6 +154,9 @@ const DEFAULT_GOAL: GoalSettings = {
   // the one that can end by itself: a loop that never stops is a deliberate choice, not a
   // default anybody should discover by turning something on.
   mode: 'goal',
+  // OpenRouter stays the default provider so an upgrade changes nothing for anyone who
+  // never touches the switch; a hand-written config predating the field parses the same way.
+  provider: { kind: 'openrouter', baseUrl: '' },
   model: DEFAULT_GOAL_MODEL,
   reasoning: 'default',
   prompt: DEFAULT_GOAL_SYSTEM_PROMPT,
@@ -238,6 +256,16 @@ const capabilitiesSchema = z
   )
   .transform((caps) => ({ ...DEFAULT_CAPABILITIES, ...caps }) as Capabilities);
 
+/**
+ * The user's own MCP instructions.
+ *
+ * Empty by default, and deliberately so: the connector instructions are how the app explains
+ * its own tools, and inventing text on the user's behalf there would put words the app cannot
+ * honour in front of the model.
+ */
+export const MAX_MCP_INSTRUCTIONS_CHARS = 4000;
+const DEFAULT_MCP = { instructions: '' } as const;
+
 const configSchema = z.object({
   // A config written by hand — or by a build before `/skills` was reserved — must not be
   // able to claim a reserved virtual root. Renamed rather than rejected: a single bad root
@@ -258,15 +286,19 @@ const configSchema = z.object({
     binaryPath: z.string().max(4096)
   }),
   ui: z.object({
+    chatBrowser: z.enum(CHAT_BROWSERS).optional().default('chrome'),
     developerMode: z.boolean().optional(),
     finishTool: z.boolean().optional(),
     planBackend: z.enum(['chatgpt', 'api']).optional(),
     finishAction: z.enum(['notify', 'goal']).optional(),
     finishLeadMinutes: z.number().int().min(3).max(5).optional(),
     backgroundChats: z.boolean().optional().default(false),
+    browserOnly: z.boolean().optional().default(false),
+    autoRefreshPlugins: z.boolean().optional().default(false),
     tabsToKeepOpen: z.number().int().min(1).max(50).optional(),
     minimizeToTray: z.boolean(),
     autoConnect: z.boolean(),
+    startAtLogin: z.boolean().optional().default(false),
     privacyScreenshots: z.boolean().optional().default(false),
     // Dark is the design the app is drawn for, and a config written before the theme
     // existed has no stored answer to override — so it is the default rather than the
@@ -317,6 +349,18 @@ const configSchema = z.object({
     })
     .optional()
     .default({ ...DEFAULT_MULTI_AGENT }),
+  artifacts: z
+    .object({
+      maxFileBytes: z
+        .number()
+        .int()
+        .min(1)
+        .max(256 * 1024 * 1024)
+        .optional()
+        .default(DEFAULT_ARTIFACTS.maxFileBytes)
+    })
+    .optional()
+    .default({ ...DEFAULT_ARTIFACTS }),
   // An empty model id is repaired rather than rejected: the id is free text from a
   // provider listing that changes weekly, and a config that lost it must still load with
   // every root and permission in it intact.
@@ -333,6 +377,18 @@ const configSchema = z.object({
       // written by a version that knows one more mode than this one must not send every root
       // and permission in the file through conservative recovery over a single word.
       mode: z.enum(GOAL_MODES).optional().default(DEFAULT_GOAL.mode).catch(DEFAULT_GOAL.mode),
+      provider: z
+        .object({
+          // Repaired rather than rejected like `mode` above: a config written by a version
+          // that knows one more provider than this one must not invalidate every root and
+          // permission in the file over a single word.
+          kind: z.enum(GOAL_PROVIDERS).optional().default('openrouter').catch('openrouter'),
+          // Stored verbatim and validated at draft time: a URL cannot be repaired the way an
+          // enum can, and silently rewriting it would point a key at a host nobody chose.
+          baseUrl: z.string().max(2048).optional().default('')
+        })
+        .optional()
+        .default({ ...DEFAULT_GOAL.provider }),
       model: z
         .string()
         .max(160)
@@ -382,7 +438,22 @@ const configSchema = z.object({
         .catch(DEFAULT_GOAL.loopPrompt)
     })
     .optional()
-    .default({ ...DEFAULT_GOAL, backend: 'chatgpt', loopBackend: 'chatgpt', impulseMinutes: 0, includeToolCalls: false, helperModel: 'gpt-5.6-sol', helperReasoning: 'high' })
+    .default({ ...DEFAULT_GOAL, backend: 'chatgpt', loopBackend: 'chatgpt', impulseMinutes: 0, includeToolCalls: false, helperModel: 'gpt-5.6-sol', helperReasoning: 'high' }),
+  mcp: z
+    .object({
+      // Repaired rather than rejected, like the Goal prompts above: this is free text a person
+      // typed, and one over-long or malformed field must not send the whole config — every
+      // root, every permission — through conservative recovery.
+      instructions: z
+        .string()
+        .optional()
+        .default(DEFAULT_MCP.instructions)
+        .transform((value) => value.slice(0, MAX_MCP_INSTRUCTIONS_CHARS).trim())
+        .catch(DEFAULT_MCP.instructions)
+    })
+    .optional()
+    .default({ ...DEFAULT_MCP })
+    .catch({ ...DEFAULT_MCP })
 });
 
 /**
@@ -404,11 +475,13 @@ export function defaultConfig(platform: NodeJS.Platform = process.platform, rele
     capabilities: firstLaunchCapabilities(platform, release),
     readOnly: false,
     tunnel: { kind: 'openai', tunnelId: '', desktopTunnelId: '', binaryPath: '' },
-    ui: { minimizeToTray: true, autoConnect: false, privacyScreenshots: false, theme: 'dark' },
+    ui: { minimizeToTray: true, autoConnect: false, startAtLogin: false, privacyScreenshots: false, theme: 'dark', autoRefreshPlugins: false },
     sessions: { ...DEFAULT_SESSIONS },
     compaction: { ...DEFAULT_COMPACTION },
     multiAgent: { ...FIRST_LAUNCH_MULTI_AGENT },
-    goal: { ...DEFAULT_GOAL }
+    artifacts: { ...DEFAULT_ARTIFACTS },
+    goal: { ...DEFAULT_GOAL },
+    mcp: { ...DEFAULT_MCP }
   };
 }
 

--- a/src/main/connection.ts
+++ b/src/main/connection.ts
@@ -154,6 +154,7 @@ function toolsFor(id: SurfaceId): string[] {
   if (!caps.command && caps.search) tools.push('find');
   if (caps.create || caps.edit || caps.move || caps.deleteFile) tools.push('apply_patch');
   if (caps.command) tools.push('exec_command', 'write_stdin');
+  if (caps.saveArtifact) tools.push('download_artifact');
   if (config.sessions.record) tools.push('session');
   if (config.multiAgent.enabled) tools.push('agents');
   return tools;

--- a/src/main/goal.ts
+++ b/src/main/goal.ts
@@ -71,7 +71,7 @@ import {
   GOAL_SYSTEM_TRAILER,
   goalObjectiveMessage
 } from '../shared/goal.js';
-import type { GoalMode } from '../shared/types.js';
+import type { GoalMode, GoalProviderKind, GoalReasoning } from '../shared/types.js';
 
 /** Where OpenRouter lives. One host, both routes. */
 const OPENROUTER_BASE = 'https://openrouter.ai/api/v1';
@@ -84,6 +84,49 @@ const ATTRIBUTION_HEADERS: Record<string, string> = {
   'HTTP-Referer': 'https://github.com/chat-on-steroids',
   'X-Title': 'Chat On Steroids'
 };
+
+/** Which LLM endpoint the Goal/Loop second model runs on, resolved per call from config. */
+export interface GoalEndpoint {
+  kind: GoalProviderKind;
+  /** Raw configured base URL for custom; OPENROUTER_BASE for openrouter. */
+  baseUrl: string;
+}
+
+export function goalEndpoint(): GoalEndpoint {
+  const provider = getConfig().goal.provider;
+  if (provider?.kind === 'custom') return { kind: 'custom', baseUrl: provider.baseUrl };
+  return { kind: 'openrouter', baseUrl: OPENROUTER_BASE };
+}
+
+/**
+ * Base URL checked at use time, not at save time.
+ *
+ * A URL cannot be repaired the way an enum can, so settings keep the user's text verbatim
+ * and a typo fails loudly here as settled `invalid_provider` instead of pointing a key at
+ * a host nobody chose. Loopback http is allowed for local servers (Ollama's default is
+ * `http://localhost:11434/v1`); anything else must be https, never with credentials in it.
+ */
+export function resolveGoalBaseUrl(endpoint: GoalEndpoint): string {
+  if (endpoint.kind === 'openrouter') return OPENROUTER_BASE;
+  const raw = endpoint.baseUrl.trim().replace(/\/+$/, '');
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error('invalid_provider: custom provider URL is invalid');
+  }
+  const host = url.hostname.toLowerCase();
+  const loopback = host === 'localhost' || host === '127.0.0.1' || host === '[::1]';
+  if ((url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) || url.username !== '' || url.password !== '' || url.search !== '' || url.hash !== '') {
+    throw new Error('invalid_provider: custom provider URL must be https, or http on localhost');
+  }
+  return url.toString().replace(/\/+$/, '');
+}
+
+/** The credential for one provider kind. Custom endpoints are often keyless local servers. */
+export function goalProviderKey(kind: GoalProviderKind): Promise<string | null> {
+  return getSecret(kind === 'custom' ? 'customProviderApiKey' : 'openRouterApiKey');
+}
 
 /** How many messages of history the goal model is given, newest kept. */
 const MAX_CONTEXT_MESSAGES = 120;
@@ -106,7 +149,7 @@ const REQUEST_TIMEOUT_MS = 180_000;
  * belongs to the page's Goal loop, which is the only place that can tell whether the turn is
  * still the one being answered. This is what that loop reads, published as `retryable`.
  */
-const SETTLED_FAILURE = /^(?:auth_rejected|out_of_credit|unknown_model|no_api_key|no_conversation|no_objective|goal_marker_missing|goal_browser_cancelled|goal_browser_send_unconfirmed|goal_browser_send_failed)(?:$|:)/;
+const SETTLED_FAILURE = /^(?:auth_rejected|out_of_credit|unknown_model|no_api_key|no_conversation|no_objective|invalid_provider|goal_marker_missing|goal_browser_cancelled|goal_browser_send_unconfirmed|goal_browser_send_failed)(?:$|:)/;
 
 /** One failure classification shared by ordinary drafts and the conversation-less opening request. */
 function retryableGoalFailure(error: string): boolean {
@@ -269,6 +312,7 @@ export interface GoalDraftView {
   /** The generation this draft answers. One draft per generation, ever. */
   turnId: string;
   stage: GoalStage;
+  backend: GoalBackend;
   model: string;
   /** What the model has written so far, for the panel above the composer. */
   text: string;
@@ -290,8 +334,9 @@ export interface GoalDraftView {
 // `retryable` is left out on purpose: it is read off the failure every time it is asked for,
 // so there is no second place where a draft can be described as retryable and be wrong.
 interface GoalDraft extends Omit<GoalDraftView, 'retryable'> {
-  backend: GoalBackend;
   sessionId: string;
+  endpoint: GoalEndpoint;
+  reasoning: GoalReasoning;
   /** Frozen with the draft, just like its model, so one request never mixes two settings saves. */
   systemPrompt: string;
   /** The driver instruction, frozen for the same reason. Used only when `objective` is set. */
@@ -912,9 +957,26 @@ export function goalBackendFor(mode: GoalMode): GoalBackend {
   const settings = getConfig().goal;
   return mode === 'loop' ? settings.loopBackend ?? 'chatgpt' : settings.backend ?? 'chatgpt';
 }
+/** Progress names the active draft, or the configured driver before a draft exists. */
+export function goalProgressFor(mode: GoalMode, draft?: GoalDraftView | null): {
+  backend: GoalBackend; model: string; provider: GoalEndpoint['kind'];
+} {
+  const settings = getConfig().goal;
+  const backend = draft?.backend ?? goalBackendFor(mode);
+  return {
+    backend,
+    model: draft?.model ?? (backend === 'chatgpt' ? settings.helperModel ?? 'gpt-5.6-sol'
+      : backend === 'templates' ? 'Offline templates' : settings.model),
+    provider: settings.provider.kind
+  };
+}
 export async function goalKeyPresent(mode: GoalMode = goalDrivingMode()): Promise<boolean> {
   if (goalBackendFor(mode) !== 'api') return true;
-  return (await getSecret('openRouterApiKey')) !== null;
+  const endpoint = goalEndpoint();
+  // A custom endpoint is often a keyless local server, so there is nothing to require:
+  // reachability and auth are proven by the first call, not by the presence of a secret.
+  if (endpoint.kind === 'custom') return true;
+  return (await goalProviderKey('openrouter')) !== null;
 }
 
 function view(draft: GoalDraft): GoalDraftView {
@@ -923,6 +985,7 @@ function view(draft: GoalDraft): GoalDraftView {
     conversationId: draft.conversationId,
     turnId: draft.turnId,
     stage: draft.stage,
+    backend: draft.backend,
     model: draft.model,
     text: draft.text,
     // The reply is handed over only while it is still the thing to do. Once acknowledged it
@@ -1191,6 +1254,8 @@ export function startGoalDraft(input: StartGoalDraftInput): GoalDraftView {
     conversationId: input.conversationId,
     sessionId: input.sessionId,
     backend,
+    endpoint: goalEndpoint(),
+    reasoning: settings.reasoning,
     systemPrompt: settings.prompt,
     objectiveSystemPrompt: settings.objectivePrompt,
     loopSystemPrompt: settings.loopPrompt,
@@ -1260,7 +1325,9 @@ interface GoalRequest {
   lifetime?: 'temporary-planner';
   sourceSessionId?: string;
   backend?: GoalBackend;
-  reasoning?: 'none';
+  reasoning: GoalReasoning | 'none';
+  /** Captured together with the credential before any async work; never reread its destination. */
+  endpoint: GoalEndpoint;
   key: string;
   model: string;
   /**
@@ -1335,6 +1402,13 @@ async function requestGoalDecision(request: GoalRequest): Promise<GoalDecision |
     }
     return decision;
   }
+  let baseUrl: string;
+  try {
+    baseUrl = resolveGoalBaseUrl(request.endpoint);
+  } catch (error) {
+    return { action: 'http', error: (error as Error).message };
+  }
+  const custom = request.endpoint.kind === 'custom';
   const body: Record<string, unknown> = {
     model: request.model,
     // Stream only to a real progress consumer. Partial text remains presentation;
@@ -1347,24 +1421,34 @@ async function requestGoalDecision(request: GoalRequest): Promise<GoalDecision |
       { role: 'system', content: request.trailer }
     ],
     response_format: request.mode === 'loop' ? LOOP_RESPONSE_FORMAT : GOAL_RESPONSE_FORMAT,
-    ...(!request.publish ? { plugins: [{ id: 'response-healing' }] } : {}),
+    ...(!request.publish && !custom ? { plugins: [{ id: 'response-healing' }] } : {}),
     // OpenRouter otherwise may route to a provider that silently ignores response_format.
-    provider: { require_parameters: true }
+    // A custom endpoint speaks plain OpenAI-compatible chat completions and must not
+    // receive vendor fields it never defined.
+    ...(custom ? {} : { provider: { require_parameters: true } })
   };
   // Reasoning may still be used, but it is never part of the response body this app parses.
   // OpenRouter documents `exclude` as supported across models even when effort selection is
   // not. `default` therefore means "provider-selected effort", not "return its scratchpad".
-  body['reasoning'] = {
-    ...(request.reasoning ? { effort: request.reasoning } : settings.reasoning === 'default' ? {} : { effort: settings.reasoning }),
-    exclude: true
-  };
+  // Chat Completions uses reasoning_effort; `reasoning.exclude` belongs to OpenRouter.
+  // The default omits this optional field for endpoints without reasoning support.
+  if (!custom) {
+    body['reasoning'] = {
+      ...(request.reasoning === 'default' ? {} : { effort: request.reasoning }),
+      exclude: true
+    };
+  } else if (request.reasoning !== 'default') {
+    body['reasoning_effort'] = request.reasoning;
+  }
 
-  const response = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
+  const response = await fetch(`${baseUrl}/chat/completions`, {
     method: 'POST',
+    // A redirect must not hand conversation content or credentials to a different endpoint.
+    redirect: 'error',
     headers: {
-      authorization: `Bearer ${request.key}`,
+      ...(request.key ? { authorization: `Bearer ${request.key}` } : {}),
       'content-type': 'application/json',
-      ...ATTRIBUTION_HEADERS
+      ...(custom ? {} : ATTRIBUTION_HEADERS)
     },
     body: JSON.stringify(body),
     signal: request.signal
@@ -1408,9 +1492,14 @@ async function requestDrivingDecision(
 
 async function run(draft: GoalDraft): Promise<void> {
   if (await astraFinishOnly(draft.sessionId, draft.conversationId)) return settle(draft, 'no-reply');
-  const key = await getSecret('openRouterApiKey');
+  const { endpoint, reasoning } = draft;
+  const key = draft.backend === 'api' ? await goalProviderKey(endpoint.kind) : null;
   if (draft.acknowledged || drafts.get(draft.conversationId) !== draft) return;
-  if (draft.backend === 'api' && !key) return settle(draft, 'failed', 'no_api_key');
+  // Only the OpenRouter api backend fails here without a key. A custom endpoint may be a
+  // keyless local server (key arrives as '' and no Authorization header is sent), and the
+  // other backends never needed one. The destination and reasoning were captured with
+  // the model before the reservation could yield to a settings change.
+  if (draft.backend === 'api' && !key && endpoint.kind === 'openrouter') return settle(draft, 'failed', 'no_api_key');
   const messages = await conversationMessages(draft.sessionId);
   if (draft.acknowledged || drafts.get(draft.conversationId) !== draft) return;
   // Goal Mode is supposed to continue *the user's objective*. A partially recovered recorder
@@ -1431,6 +1520,8 @@ async function run(draft: GoalDraft): Promise<void> {
   try {
     const decision = draft.backend === 'templates' ? templateGoalDecision(messages.filter((message) => message.role === 'assistant').at(-1)?.content ?? '', Math.floor(Math.random() * 200), Math.floor(Math.random() * 200)) : await requestDrivingDecision({
       backend: draft.backend,
+      endpoint,
+      reasoning,
       sourceSessionId: draft.sessionId,
       key: key ?? '',
       model: draft.model,
@@ -1528,8 +1619,11 @@ async function run(draft: GoalDraft): Promise<void> {
 /** Finish asks the existing Loop driver for the next instruction; its caller owns delivery. */
 export async function draftFastFollowup(sessionId: string, signal: AbortSignal = AbortSignal.timeout(180000), preparedMessages?: ChatMessage[], publish?: GoalRequest['publish'], mode: GoalMode = 'loop'): Promise<string | null> {
   const backend = goalBackendFor(mode);
-  const key = await getSecret('openRouterApiKey');
-  if (backend === 'api' && !key) throw new Error('Configure the Goal API key for automatic finish follow-ups, or choose Notify me');
+  const settings = getConfig().goal;
+  const endpoint = goalEndpoint();
+  const key = backend === 'api' ? await goalProviderKey(endpoint.kind) : null;
+  // Custom endpoints may be keyless; only OpenRouter fails here without one.
+  if (backend === 'api' && !key && endpoint.kind === 'openrouter') throw new Error('Configure the Goal API key for automatic finish follow-ups, or choose Notify me');
   const session = await getSession(sessionId);
   if (!session?.conversationId) throw new Error('This session has no current conversation');
   const objective = goalObjectiveFor(session.conversationId);
@@ -1539,19 +1633,24 @@ export async function draftFastFollowup(sessionId: string, signal: AbortSignal =
     ['tool', 'sent'].includes(entry.state)).slice(-5).map(entry => entry.text);
   const messages = preparedMessages ?? await conversationMessages(sessionId, appInput, new Set(inputs.filter(entry => entry.finishOwner).map(entry => entry.id)));
   if (!objective && !messages.some(message => message.role === 'user')) throw new Error('No recorded user request is available for Goal');
-  const settings = getConfig().goal;
   const prompt = mode === 'loop' ? settings.loopPrompt : objective ? settings.objectivePrompt : settings.prompt;
   const decision = backend === 'templates'
     ? templateGoalDecision(messages.filter(message => message.role === 'assistant').at(-1)?.content ?? '', Math.floor(Math.random() * 200), Math.floor(Math.random() * 200))
-    : await requestDrivingDecision({ sourceSessionId: sessionId, backend, key: key ?? '', model: settings.model, mode,
+    : await requestDrivingDecision({ sourceSessionId: sessionId, backend, endpoint, reasoning: settings.reasoning, key: key ?? '', model: settings.model, mode,
     system: objective ? [prompt, goalObjectiveMessage(objective)] : [prompt],
     messages,
-    trailer: mode === 'loop' ? GOAL_LOOP_TRAILER : objective ? GOAL_OBJECTIVE_TRAILER : GOAL_SYSTEM_TRAILER, signal, publish });
+    trailer: mode === 'loop' ? GOAL_LOOP_TRAILER : objective ? GOAL_OBJECTIVE_TRAILER : GOAL_SYSTEM_TRAILER, signal, publish })
+      .catch(error => {
+        if (signal.aborted && signal.reason?.name === 'TimeoutError') throw nativeGoalFailure('timeout_or_cancelled: Goal request timed out', backend);
+        signal.throwIfAborted();
+        throw nativeGoalFailure(`request_failed: ${error instanceof Error ? error.message : error}`, backend);
+      });
   if (decision.action === 'stop') {
     if (mode === 'loop') throw new Error('loop_stop_refused');
     return null;
   }
-  if (decision.action !== 'continue') throw new Error('error' in decision ? decision.error : 'Goal did not return a usable follow-up');
+  if (decision.action !== 'continue') throw nativeGoalFailure('error' in decision ? decision.error : 'Goal did not return a usable follow-up', backend,
+    'retryAfterMs' in decision ? decision.retryAfterMs : undefined);
   return decision.reply;
 }
 
@@ -1559,10 +1658,13 @@ export async function draftFastFollowup(sessionId: string, signal: AbortSignal =
 export async function draftTaskPlan(prompt: string, backend: 'api' | 'chatgpt', onProgress?: (progress: TaskProgressUpdate) => void, signal?: AbortSignal): Promise<string[]> {
   onProgress?.({ phase: 'preparing', text: '' });
   if (!prompt.trim() || prompt.length > 16000) throw new Error('Enter a task of at most 16000 characters');
-  const key = backend === 'api' ? await getSecret('openRouterApiKey') : null;
-  if (backend === 'api' && !key) throw new Error('Configure a Goal API key or choose ChatGPT');
+  const settings = getConfig().goal;
+  const endpoint = goalEndpoint();
+  const key = backend === 'api' ? await goalProviderKey(endpoint.kind) : null;
+  // Custom endpoints may be keyless; only OpenRouter fails here without one.
+  if (backend === 'api' && !key && endpoint.kind === 'openrouter') throw new Error('Configure a Goal API key or choose ChatGPT');
   onProgress?.({ phase: 'generating', text: '' });
-  const result = await requestGoalDecision({ backend, lifetime: 'temporary-planner', key: key ?? '', model: getConfig().goal.model, mode: 'goal', publish: text => onProgress?.({ phase: 'generating', text: planProgressText(text) }),
+  const result = await requestGoalDecision({ backend, endpoint, reasoning: settings.reasoning, lifetime: 'temporary-planner', key: key ?? '', model: settings.model, mode: 'goal', publish: text => onProgress?.({ phase: 'generating', text: planProgressText(text) }),
     system: ['You are a task planner, not the executor. Divide the user request into 2 to 12 sequential, self-contained stages. Preserve all requirements and constraints. Include implementation and meaningful verification phases, with a final full acceptance check. Do not invent unrelated work. Return action continue; its reply must be a JSON string encoding {"stages":["first task", "next task"]}. Keep the entire plan below 12000 characters. Each stage is sent to the same working conversation only after it finishes the previous stage.'],
     messages: [{ role: 'user', content: prompt.trim() }], trailer: 'Produce the staged plan now. Do not execute the task.', signal: signal ? AbortSignal.any([signal, AbortSignal.timeout(REQUEST_TIMEOUT_MS)]) : AbortSignal.timeout(REQUEST_TIMEOUT_MS) })
     .catch(error => { throw nativeGoalFailure(`request_failed: ${error instanceof Error ? error.message : error}`, backend); });
@@ -1586,22 +1688,27 @@ export async function draftOpeningMessage(
   signal?.throwIfAborted();
   onProgress?.({ phase: 'preparing', text: '' });
   if (!goal) return { error: 'no_objective' };
-  const key = await getSecret('openRouterApiKey');
+  const settings = getConfig().goal;
+  const endpoint = goalEndpoint();
   const backend = goalBackendFor(named ?? goalDrivingMode());
   if (backend === 'templates') return { reply: goal + GOAL_MARKER_INSTRUCTION, model: 'Offline Goal' };
-  if (backend === 'api' && !key) return { error: 'no_api_key' };
-  const model = backend === 'chatgpt' ? getConfig().goal.helperModel ?? 'gpt-5.6-sol' : getConfig().goal.model;
+  const key = backend === 'api' ? await goalProviderKey(endpoint.kind) : null;
+  // Custom endpoints may be keyless; only OpenRouter fails here without one.
+  if (backend === 'api' && !key && endpoint.kind === 'openrouter') return { error: 'no_api_key' };
+  const model = backend === 'chatgpt' ? settings.helperModel ?? 'gpt-5.6-sol' : settings.model;
   const abort = new AbortController();
   const timer = setTimeout(() => abort.abort(), REQUEST_TIMEOUT_MS);
   try {
     const mode = named ?? goalDrivingMode();
     const decision = await requestDrivingDecision({
       backend,
+      endpoint,
+      reasoning: settings.reasoning,
       key: key ?? '',
       model,
       mode,
       system: [
-        mode === 'loop' ? getConfig().goal.loopPrompt : getConfig().goal.objectivePrompt,
+        mode === 'loop' ? settings.loopPrompt : settings.objectivePrompt,
         goalObjectiveMessage(goal)
       ],
       messages: [{ role: 'user', content: GOAL_OBJECTIVE_OPENING_TURN }],
@@ -2347,12 +2454,19 @@ export async function listGoalModels(offset = 0, limit = MODEL_PAGE_SIZE): Promi
 }
 
 async function allGoalModels(): Promise<GoalModel[]> {
-  const key = await getSecret('openRouterApiKey');
+  const endpoint = goalEndpoint();
+  const custom = endpoint.kind === 'custom';
+  const key = await goalProviderKey(endpoint.kind);
   // OpenRouter may return a key-restricted catalogue. A cache filled under key A is therefore
   // not valid under key B. Keep only a one-way fingerprint beside the models rather than the
   // credential itself; replacing a key immediately changes the cache scope without retaining
-  // either secret for the five-minute listing TTL.
-  const keyScope = key ? createHash('sha256').update(key).digest('hex') : 'public';
+  // either secret for the five-minute listing TTL. A custom endpoint joins the scope by URL,
+  // so switching servers never serves the previous server's catalogue.
+  const keyScope = custom
+    ? `custom:${endpoint.baseUrl.trim()}:${key ? createHash('sha256').update(key).digest('hex') : 'public'}`
+    : key
+      ? createHash('sha256').update(key).digest('hex')
+      : 'public';
   if (modelCache && modelCache.keyScope === keyScope && Date.now() - modelCache.at < MODEL_CACHE_MS) {
     return modelCache.models;
   }
@@ -2360,24 +2474,35 @@ async function allGoalModels(): Promise<GoalModel[]> {
   const timer = setTimeout(() => abort.abort(), MODEL_LIST_TIMEOUT_MS);
   let response: Response;
   let parsed: unknown;
+  // A custom catalogue is best-effort UI data: most local servers answer `/models` in the
+  // vanilla OpenAI shape, some answer nothing at all, and either way the model stays a
+  // hand-typed field. A failure here returns an empty list rather than an error, while the
+  // OpenRouter catalogue keeps its throwing behaviour so a broken default stays visible.
+  const label = custom ? 'custom provider' : 'OpenRouter';
   try {
-    response = await fetch(`${OPENROUTER_BASE}/models`, {
+    const baseUrl = resolveGoalBaseUrl(endpoint);
+    response = await fetch(`${baseUrl}/models`, {
+      redirect: 'error',
       headers: {
         // The listing is public; the key is sent when there is one so a key with a restricted
         // model set sees its own set rather than the catalogue.
         ...(key ? { authorization: `Bearer ${key}` } : {}),
-        ...ATTRIBUTION_HEADERS
+        ...(custom ? {} : ATTRIBUTION_HEADERS)
       },
       signal: abort.signal
     });
-    if (!response.ok) throw new Error(`OpenRouter would not list its models (HTTP ${response.status})`);
+    if (!response.ok) throw new Error(`${label} would not list its models (HTTP ${response.status})`);
     const raw = await boundedResponseText(response, MAX_MODEL_LIST_BODY_BYTES);
     try {
       parsed = raw ? JSON.parse(raw) : null;
     } catch {
-      throw new Error('OpenRouter returned a model list this app could not read');
+      throw new Error(`${label} returned a model list this app could not read`);
     }
   } catch (error) {
+    if (custom) {
+      clearTimeout(timer);
+      return [];
+    }
     if (abort.signal.aborted) throw new Error('OpenRouter model list request timed out');
     if (error instanceof Error && error.message === 'response_body_too_large') {
       throw new Error('OpenRouter model list response body was too large');
@@ -2387,7 +2512,10 @@ async function allGoalModels(): Promise<GoalModel[]> {
     clearTimeout(timer);
   }
   const raw = parsed && typeof parsed === 'object' ? (parsed as { data?: unknown }).data : null;
-  if (!Array.isArray(raw)) throw new Error('OpenRouter returned a model list this app could not read');
+  if (!Array.isArray(raw)) {
+    if (custom) return [];
+    throw new Error('OpenRouter returned a model list this app could not read');
+  }
   const models: GoalModel[] = [];
   for (const entry of raw) {
     if (models.length >= MAX_MODELS) break;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,7 +4,7 @@ import { requestSessionFinishGoal, setFinishNotifier } from './session/finish.js
  */
 
 import path from 'node:path';
-import { app, Notification, BrowserWindow, Menu, Tray, nativeImage, nativeTheme, screen, session, shell } from 'electron';
+import { app, Notification, BrowserWindow, Menu, Tray, nativeImage, nativeTheme, screen, session } from 'electron';
 import { getConfig, initConfigPath, loadConfig } from './config.js';
 import { connect, disconnect, getStatus, onStatusChange, shutdownConnection } from './connection.js';
 import { registerIpc } from './ipc.js';
@@ -12,7 +12,7 @@ import { startChatModelDiscovery } from './chat-models.js';
 import { initLogFile, logError, logInfo, logWarn } from './logger.js';
 import { unifiedExecManager } from './codex/manager.js';
 import { initSecretsPath } from './secrets.js';
-import { setBrowserOpener, setBrowserWorkArea, shutdownBridge, startBridge } from './bridge.js';
+import { bridgeStatus, setBrowserOpener, setBrowserWorkArea, shutdownBridge, startBridge } from './bridge.js';
 import { flushSessions, initSessionStore, pruneSessions } from './session/store.js';
 import {
   flushRecorder,
@@ -63,6 +63,8 @@ import { applyStagedUpdate, startUpdateChecks } from './update.js';
 import { UI_BASE_ZOOM, windowLayoutForWorkArea } from './window-layout.js';
 import { openInPreferredBrowser } from './browser.js';
 import {
+  applyLoginStartup,
+  isBackgroundLaunch,
   createWindowActivationGate,
   ownsAppRuntime,
   registerNativeWindowActivation,
@@ -117,10 +119,12 @@ function createWindow(): void {
     }
   });
 
-  // A tray close keeps this process alive. Warm the same account-owned catalog
-  // whenever the window actually becomes visible, not just on process startup.
+  // Observe once through an already open browser. Reopening a window never opens
+  // Chrome or refreshes a ready catalog; explicit Reload models owns that action.
   window.on('show', () => {
-    if (!quitting) void startChatModelDiscovery().catch(error => logWarn(`model discovery on window open: ${error.message}`));
+    if (!quitting) void bridgeStatus().then(status => {
+      if (!quitting && status.present) return startChatModelDiscovery(false);
+    }).catch(error => logWarn(`model discovery on window open: ${error.message}`));
   });
   window.once('ready-to-show', () => {
     // A renderer can finish loading after Cmd+Q has already entered bounded teardown. Never let
@@ -265,7 +269,9 @@ function refreshTray(): void {
   );
 }
 
-app.on('second-instance', windowActivation.request);
+app.on('second-instance', (_event, argv) => {
+  if (!isBackgroundLaunch(argv)) windowActivation.request();
+});
 
 void app.whenReady().then(async () => {
   // This guard is intentionally before even app.getPath/init* calls. A secondary instance, or a
@@ -279,6 +285,8 @@ void app.whenReady().then(async () => {
   initDurableStore(userData);
   await loadConfig();
   if (windowActivation.isDisabled()) return;
+  try { applyLoginStartup(app, getConfig().ui.startAtLogin === true); }
+  catch (error) { logWarn(`Windows login startup: ${error instanceof Error ? error.message : String(error)}`); }
   // The renderer has its own explicit light/dark palette, so native chrome must follow the same
   // user choice instead of Electron's default `system` theme. On macOS this controls the window
   // frame, application menus and OS dialogs; on Linux/Windows it covers Electron-native UI.
@@ -319,17 +327,8 @@ void app.whenReady().then(async () => {
   // a browser without this extension in it — from the one holding chat A. That decision belongs
   // to the browser that owns the source chat; see bridge.ts::offerPlacement.
   setBrowserOpener(async (url) => {
-    try {
-      const browser = await openInPreferredBrowser(url);
-      if (browser) return;
-    } catch (error) {
-      logWarn(`could not open ChatGPT in the preferred Chromium browser: ${(error as Error).message}`);
-    }
-    logWarn(
-      'Chrome/Chromium was not found for a browser-backed worker/resume command; falling back to the default browser. ' +
-        'If that browser does not have the Chat On Steroids extension loaded, open the generated ChatGPT URL in Chrome instead.'
-    );
-    await shell.openExternal(url);
+    // Let the command owner report launch failure; another browser may belong to another account.
+    await openInPreferredBrowser(url);
   });
 
   // Persistence is a process-lifetime dependency of the broker, not a feature-toggle
@@ -397,7 +396,7 @@ void app.whenReady().then(async () => {
     }
   );
   windowActivation.enable();
-  windowActivation.request();
+  if (!isBackgroundLaunch(process.argv)) windowActivation.request();
   // macOS `activate` can fire on first launch, so do not wire it at module load where it could
   // create a BrowserWindow before Electron is ready. Once the initial window path is established,
   // Dock activation/re-launch can safely recreate or focus it.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,9 +1,12 @@
+import { applyLoginStartup, supportsLoginStartup } from './window-lifecycle.js';
 import { noteChatOrigin } from './session/recorder.js';
 import { REASONING_EFFORTS } from '../shared/session.js';
+import { wakeBrowserWork } from './browser-wake.js';
 import { getChatModels, startChatModelDiscovery, configureChatModelDiscovery } from './chat-models.js';
 import { releaseSessionFinish, requestSessionFinishGoal } from './session/finish.js';
 import { GOAL_MARKER_INSTRUCTION } from '../shared/goal-templates.js';
-import { prepareInputImage, validateInputImages } from './session/input-images.js';
+import { validateInputImages } from './session/input-images.js';
+import { stageInputAttachment, type AttachmentSource } from './session/input-attachments.js';
 import { recordDeliveredInput, recordedInputImage } from './session/input-history.js';
 import { UI_BASE_ZOOM } from './window-layout.js';
 import { usageOverview } from './session/usage.js';
@@ -13,7 +16,8 @@ import { cancelTaskRequest, runTaskRequest } from './task-request.js';
 import { randomUUID } from 'node:crypto';
 import { retryGoalBrowserHelper } from './goal.js';
 import { requestBrowserPreferences } from './browser-preferences.js';
-import { sendDesktopInput, cancelDesktopInput, retryQueuedInputBrowser, wakeBrowserUrl } from './session/start-input.js';
+import { sendDesktopInput, cancelDesktopInput, retryQueuedInputBrowser } from './session/start-input.js';
+import { wakeBrowserUrl } from './browser-startup.js';
 /**
  * IPC surface.
  *
@@ -28,7 +32,9 @@ import { app, BrowserWindow, clipboard, dialog, ipcMain, nativeTheme, shell } fr
 import { z } from 'zod';
 import {
   CAPABILITIES,
+  CHAT_BROWSERS,
   GOAL_MODES,
+  GOAL_PROVIDERS,
   GOAL_REASONING_LEVELS,
   RELEASES_PAGE,
   type AppState,
@@ -36,7 +42,7 @@ import {
 } from '../shared/types.js';
 import { MAX_GOAL_SYSTEM_PROMPT_CHARS } from '../shared/goal.js';
 import { applySettings, connect, disconnect, getStatus, onStatusChange } from './connection.js';
-import { effectiveCapabilities, getConfig, updateConfig } from './config.js';
+import { effectiveCapabilities, getConfig, updateConfig, MAX_MCP_INSTRUCTIONS_CHARS } from './config.js';
 import { clearAllGoalSwitches, draftTaskPlan, listGoalModels, MODEL_PAGE_SIZE, retireGoalDrafts, goalBackendFor, goalSwitchFor, setGoalSwitchNow, setGoalReplyActiveNow, setGoalObjectiveNow } from './goal.js';
 import { forgetExposedSurface } from './mcp/server.js';
 import { runDiagnostics } from './diagnostics.js';
@@ -139,15 +145,19 @@ const settingsPatch = z.object({
     binaryPath: z.string().max(4096)
   }),
   ui: z.object({
+    chatBrowser: z.enum(CHAT_BROWSERS).optional(),
     developerMode: z.boolean().optional(),
     finishTool: z.boolean().optional(),
     planBackend: z.enum(['chatgpt', 'api']).optional(),
     finishAction: z.enum(['notify', 'goal']).optional(),
     finishLeadMinutes: z.number().int().min(3).max(5).optional(),
     backgroundChats: z.boolean().optional(),
+    browserOnly: z.boolean().optional(),
+    autoRefreshPlugins: z.boolean().optional(),
     tabsToKeepOpen: z.number().int().min(1).max(50).optional(),
     minimizeToTray: z.boolean(),
     autoConnect: z.boolean(),
+    startAtLogin: z.boolean().optional(),
     privacyScreenshots: z.boolean(),
     theme: z.enum(['light', 'dark'])
   }),
@@ -171,6 +181,7 @@ const settingsPatch = z.object({
     allowUnattributedCalls: z.boolean(),
     recoverAgentTabs: z.boolean()
   }),
+  mcp: z.object({ instructions: z.string().trim().max(MAX_MCP_INSTRUCTIONS_CHARS) }).strict().optional(),
   goal: z.object({
     impulseMinutes: z.number().int().min(0).max(60).optional(),
     includeToolCalls: z.boolean().optional(),
@@ -182,24 +193,35 @@ const settingsPatch = z.object({
     // Which of the two standing modes the switch runs. One field, so the renderer has no way
     // to describe a state where Goal and Loop are both on.
     mode: z.enum(GOAL_MODES),
-    // An OpenRouter model id, and validated only as a shape: the catalogue changes weekly,
-    // and an allow-list here would mean this app deciding which models exist.
+    // Which LLM endpoint Goal/Loop drafts run on, plus the custom endpoint's base URL.
+    // The URL is stored verbatim and validated at draft time (see resolveGoalBaseUrl):
+    // a shape check here would either duplicate that logic or silently rewrite the address.
+    provider: z.object({
+      kind: z.enum(GOAL_PROVIDERS),
+      baseUrl: z.string().max(2048)
+    }),
+    // An OpenRouter model id while the provider is openrouter, validated only as a shape:
+    // the catalogue changes weekly, and an allow-list here would mean this app deciding
+    // which models exist.
     // The leading `~` is OpenRouter's own marker for an alias that always resolves to the
     // newest model in a family — `~deepseek/deepseek-v4-flash-latest` and eleven others. The
     // picker lists them because the listing does, so refusing them here meant the one kind
     // of entry most worth choosing was the one kind that could not be saved.
-    model: z
-      .string()
-      .min(1)
-      .max(160)
-      .regex(
-        /^~?[a-z0-9._\-]+\/[a-z0-9._\-]+(:[a-z0-9._\-]+)?$/i,
-        'Expected an OpenRouter model id like vendor/model'
-      ),
+    // A custom endpoint names its own models (`llama3.1`, a deployment id), so while custom
+    // it is any non-empty id instead.
+    model: z.string().min(1).max(160),
     reasoning: z.enum(GOAL_REASONING_LEVELS),
     prompt: z.string().trim().min(1).max(MAX_GOAL_SYSTEM_PROMPT_CHARS),
     objectivePrompt: z.string().trim().min(1).max(MAX_GOAL_SYSTEM_PROMPT_CHARS),
     loopPrompt: z.string().trim().min(1).max(MAX_GOAL_SYSTEM_PROMPT_CHARS)
+  }).superRefine((goal, ctx) => {
+    if (goal.provider.kind !== 'custom' && !/^~?[a-z0-9._-]+\/[a-z0-9._-]+(:[a-z0-9._-]+)?$/i.test(goal.model)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['model'],
+        message: 'Expected an OpenRouter model id like vendor/model'
+      });
+    }
   })
 });
 
@@ -224,6 +246,7 @@ function mergeSettings(current: Config, base: SettingsSnapshot, wanted: Settings
     ])
   ) as Config['capabilities'];
   return {
+    mcp: wanted.mcp ? { instructions: pick(current.mcp.instructions, base.mcp?.instructions ?? '', wanted.mcp.instructions) } : current.mcp,
     capabilities,
     readOnly: pick(current.readOnly, base.readOnly, wanted.readOnly),
     tunnel: {
@@ -237,15 +260,19 @@ function mergeSettings(current: Config, base: SettingsSnapshot, wanted: Settings
       binaryPath: pick(current.tunnel.binaryPath, base.tunnel.binaryPath, wanted.tunnel.binaryPath)
     },
     ui: {
+      chatBrowser: pick(current.ui.chatBrowser, base.ui.chatBrowser, wanted.ui.chatBrowser),
       developerMode: pick(current.ui.developerMode, base.ui.developerMode, wanted.ui.developerMode),
       finishTool: pick(current.ui.finishTool, base.ui.finishTool, wanted.ui.finishTool),
       planBackend: pick(current.ui.planBackend, base.ui.planBackend, wanted.ui.planBackend),
       finishAction: pick(current.ui.finishAction, base.ui.finishAction, wanted.ui.finishAction),
       finishLeadMinutes: pick(current.ui.finishLeadMinutes, base.ui.finishLeadMinutes, wanted.ui.finishLeadMinutes),
       backgroundChats: pick(current.ui.backgroundChats, base.ui.backgroundChats, wanted.ui.backgroundChats),
+      browserOnly: pick(current.ui.browserOnly, base.ui.browserOnly, wanted.ui.browserOnly),
+      autoRefreshPlugins: pick(current.ui.autoRefreshPlugins, base.ui.autoRefreshPlugins, wanted.ui.autoRefreshPlugins),
       tabsToKeepOpen: pick(current.ui.tabsToKeepOpen, base.ui.tabsToKeepOpen, wanted.ui.tabsToKeepOpen),
       minimizeToTray: pick(current.ui.minimizeToTray, base.ui.minimizeToTray, wanted.ui.minimizeToTray),
       autoConnect: pick(current.ui.autoConnect, base.ui.autoConnect, wanted.ui.autoConnect),
+      startAtLogin: pick(current.ui.startAtLogin, base.ui.startAtLogin, wanted.ui.startAtLogin),
       privacyScreenshots: pick(
         current.ui.privacyScreenshots,
         base.ui.privacyScreenshots,
@@ -292,6 +319,10 @@ function mergeSettings(current: Config, base: SettingsSnapshot, wanted: Settings
       helperReasoning: pick(current.goal.helperReasoning, base.goal.helperReasoning, wanted.goal.helperReasoning),
       enabled: pick(current.goal.enabled, base.goal.enabled, wanted.goal.enabled),
       mode: pick(current.goal.mode, base.goal.mode, wanted.goal.mode),
+      provider: {
+        kind: pick(current.goal.provider.kind, base.goal.provider.kind, wanted.goal.provider.kind),
+        baseUrl: pick(current.goal.provider.baseUrl, base.goal.provider.baseUrl, wanted.goal.provider.baseUrl)
+      },
       model: pick(current.goal.model, base.goal.model, wanted.goal.model),
       reasoning: pick(current.goal.reasoning, base.goal.reasoning, wanted.goal.reasoning),
       prompt: pick(current.goal.prompt, base.goal.prompt, wanted.goal.prompt),
@@ -329,9 +360,11 @@ async function buildState(): Promise<AppState> {
     config,
     status: getStatus(),
     platform: hostPlatformInfo(),
+    loginStartupAvailable: supportsLoginStartup(process.platform, app.isPackaged),
     secureStorage: await secureStorageStatus(),
     hasApiKey: await hasSecret('openaiApiKey'),
     hasGoalKey: await hasSecret('openRouterApiKey'),
+    hasCustomProviderKey: await hasSecret('customProviderApiKey'),
     resolvedBinary: resolvedBinary(config),
     bundledTunnelVersion: bundledVersion(),
     bridge: await bridgeStatus(),
@@ -401,6 +434,8 @@ export function registerIpc(getWindow: () => BrowserWindow | null, quitToInstall
       before.goal.backend !== next.goal.backend ||
       before.goal.loopBackend !== next.goal.loopBackend ||
       before.goal.helperModel !== next.goal.helperModel || before.goal.helperReasoning !== next.goal.helperReasoning ||
+      before.goal.provider.kind !== next.goal.provider.kind ||
+      before.goal.provider.baseUrl !== next.goal.provider.baseUrl ||
       before.goal.reasoning !== next.goal.reasoning ||
       before.goal.includeToolCalls !== next.goal.includeToolCalls ||
       before.goal.prompt !== next.goal.prompt ||
@@ -449,12 +484,21 @@ export function registerIpc(getWindow: () => BrowserWindow | null, quitToInstall
     // tunnel id left the connector unpublished until the user happened to reconnect, with
     // the card still saying "not published" and nothing explaining why.
     await applySettings();
+    if (before.ui.autoRefreshPlugins !== next.ui.autoRefreshPlugins) wakeBrowserWork();
     logInfo('settings updated');
     // The config and runtime side effects above still complete so the app does not stay half-on,
     // but the UI must not be told the pause was safely accepted when its retained authority
     // snapshot failed to cross disk. Startup with the feature off restores and canonicalizes
     // that same history instead of deleting it.
+    // Login registration is an independent OS preference. Cosmetic saves do not rewrite
+    // it, and its failure cannot interrupt permission publication or Goal/worker teardown.
+    let loginStartupError: unknown;
+    if ((before.ui.startAtLogin === true) !== (next.ui.startAtLogin === true)) {
+      try { applyLoginStartup(app, next.ui.startAtLogin === true); }
+      catch (error) { loginStartupError = error; }
+    }
     if (authorityPersistError) throw authorityPersistError;
+    if (loginStartupError) throw loginStartupError;
     return buildState();
   });
 
@@ -542,7 +586,7 @@ export function registerIpc(getWindow: () => BrowserWindow | null, quitToInstall
   });
 
   /**
-   * Stores one of the two keys the app holds, by name.
+   * Stores one of the defined provider keys by name.
    *
    * The name is an enum rather than a string, so the renderer can choose *which* credential
    * it is writing but cannot name a slot nobody defined — and the value still only ever
@@ -550,14 +594,18 @@ export function registerIpc(getWindow: () => BrowserWindow | null, quitToInstall
    */
   handle('secret:set', async (payload) => {
     const { value, key } = z
-      .object({ value: z.string().max(500), key: z.enum(['openaiApiKey', 'openRouterApiKey']).default('openaiApiKey') })
+      .object({
+        value: z.string().max(500),
+        key: z.enum(['openaiApiKey', 'openRouterApiKey', 'customProviderApiKey']).default('openaiApiKey')
+      })
       .parse(payload);
     if (!(await isEncryptionAvailable())) {
       throw new Error('Secure OS credential storage is unavailable, so the key cannot be stored safely.');
     }
     await setSecret(key, value);
-    if (key === 'openRouterApiKey') retireGoalDrafts();
-    const what = key === 'openRouterApiKey' ? 'openrouter key' : 'api key';
+    const activeGoalKey = getConfig().goal.provider.kind === 'custom' ? 'customProviderApiKey' : 'openRouterApiKey';
+    if (key === activeGoalKey) retireGoalDrafts();
+    const what = key === 'openRouterApiKey' ? 'openrouter key' : key === 'customProviderApiKey' ? 'custom provider key' : 'api key';
     logInfo(value.trim() === '' ? `${what} cleared` : `${what} stored`);
     return buildState();
   });
@@ -720,19 +768,28 @@ export function registerIpc(getWindow: () => BrowserWindow | null, quitToInstall
     return { summary, events, total: summary.events, nextFrom };
   });
 
-  handle('sessions:images', async () => {
-    const chosen = await dialog.showOpenDialog({ title: 'Attach images', properties: ['openFile', 'multiSelections'], filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'webp', 'gif'] }] });
+  const stageFiles = async (sources: AttachmentSource[]) => {
+    const retained = new Set((await listInputs()).filter(row => !['sent', 'failed', 'cancelled'].includes(row.state)).flatMap(row => row.attachments?.map(file => file.id) ?? []));
+    const result = [];
+    for (const source of sources) result.push(await stageInputAttachment(source, retained));
+    return result;
+  };
+  handle('sessions:files', async () => {
+    const chosen = await dialog.showOpenDialog({ title: 'Attach files', properties: ['openFile', 'multiSelections'] });
     if (chosen.canceled) return [];
-    if (chosen.filePaths.length > 4) throw new Error('Attach up to four images at a time');
-    const images = [];
-    for (const file of chosen.filePaths) images.push(await prepareInputImage(file));
-    return images;
+    if (chosen.filePaths.length > 20) throw new Error('Attach up to 20 files per message');
+    return stageFiles(chosen.filePaths);
   });
-  handle('sessions:dropImages', async payload => {
-    const { paths } = z.object({ paths: z.array(z.string().min(1).max(32768)).min(1).max(4) }).parse(payload);
-    const images = [];
-    for (const file of paths) images.push(await prepareInputImage(file));
-    return images;
+  handle('sessions:dropFiles', async payload => {
+    const { files } = z.object({ files: z.array(z.union([
+      z.string().min(1).max(32768),
+      z.object({ name: z.string().min(1).max(255), bytes: z.instanceof(Uint8Array).refine(bytes => bytes.byteLength > 0 && bytes.byteLength <= 12 * 1024 * 1024) }).strict()
+    ])).min(1).max(20) }).strict().parse(payload);
+    return stageFiles(files);
+  });
+  handle('sessions:attachText', async payload => {
+    const { text } = z.object({ text: z.string().min(1).max(4 * 1024 * 1024) }).parse(payload);
+    return (await stageFiles([{ text }]))[0]!;
   });
   handle('sessions:stopTurn', async payload => {
     const { id, expectedTurnId } = sessionIdArg.extend({ expectedTurnId: z.string().min(1).max(256) }).parse(payload);
@@ -806,8 +863,7 @@ export function registerIpc(getWindow: () => BrowserWindow | null, quitToInstall
     if (!conversationId || !/^[0-9a-z-]{8,64}$/i.test(conversationId)) {
       throw new Error('This session has no valid ChatGPT conversation');
     }
-    const browser = await openInPreferredBrowser(chatUrl(conversationId));
-    if (!browser) throw new Error('Chrome or Chromium was not found');
+    await openInPreferredBrowser(chatUrl(conversationId));
     return true;
   });
 
@@ -1015,7 +1071,8 @@ export function registerIpc(getWindow: () => BrowserWindow | null, quitToInstall
   };
   onStatusChange(pushState);
   onBridgeChange(pushState);
-  onGoalChange(pushState);
+  // Draft stages belong to session controls; state:changed only refreshes settings.
+  onGoalChange(() => push('session:changed'));
   handle('tasks:cancel', async payload => cancelTaskRequest(z.object({ requestId: z.string().uuid() }).parse(payload).requestId));
   handle('sessions:goalOpening', async payload => {
     const { text, mode, requestId } = z.object({ text: z.string().trim().min(1).max(16000),
@@ -1030,9 +1087,9 @@ export function registerIpc(getWindow: () => BrowserWindow | null, quitToInstall
       return drafted;
     }, publish);
   });
-  configureChatModelDiscovery({ changed: pushState, wake: async (nonce) => {
+  configureChatModelDiscovery({ changed: pushState, wake: async (nonce, allowOpen) => {
     if (!await startBridge()) throw new Error('The browser bridge could not start');
-    await wakeBrowserUrl(`https://chatgpt.com/?cos-model-catalog=${nonce}`, true, true);
+    if (allowOpen) await wakeBrowserUrl(`https://chatgpt.com/?cos-model-catalog=${nonce}`, true, true);
   } });
   onUpdateChange(pushState);
   onMacOSDesktopAccessChange(pushState);

--- a/src/main/mcp/artifact-download.ts
+++ b/src/main/mcp/artifact-download.ts
@@ -1,0 +1,94 @@
+/**
+ * Orchestration for `download_artifact`: resolve → fetch → write → publish.
+ *
+ * Mirrors devspace `downloadIncomingArtifact` (src/artifact-tools.ts:127-218) with two
+ * local adaptations: path resolution goes through `resolveIn` (approved roots +
+ * per-chat workspace, the sandbox remaining the single authority), and the secure
+ * target is the koffi-free `artifact-target.ts`.
+ */
+
+import { createHash } from 'node:crypto';
+import nodePath from 'node:path';
+import { rawPromises as fs } from '../rawfs.js';
+import { resolveIn } from './kernel.js';
+import type { Root } from '../../shared/types.js';
+import {
+  ArtifactFetchError,
+  normalizeOpenAIFileReference,
+  validateOpenAIFileUrl,
+  openArtifactFile,
+  type OpenAIFileAdapterOptions
+} from './artifact-fetch.js';
+import { ArtifactTargetError, openArtifactTarget } from './artifact-target.js';
+
+export interface SavedArtifact {
+  /** Normalised virtual path, always "/root/..." with forward slashes. */
+  virtual: string;
+  size: number;
+  sha256: string;
+}
+
+export interface DownloadArtifactOptions extends OpenAIFileAdapterOptions {
+  maxFileBytes: number;
+}
+
+/**
+ * Stream one ChatGPT-injected file value to `requestedPath` inside an approved root.
+ * The destination must name a file in an existing directory and must not already exist.
+ * Throws ArtifactFetchError / ArtifactTargetError / SandboxError on refusal;
+ * the caller maps those to model-facing failures without leaking real paths.
+ */
+export async function downloadArtifactFile(
+  roots: readonly Root[],
+  requestedPath: string,
+  file: unknown,
+  options: DownloadArtifactOptions
+): Promise<SavedArtifact> {
+  const { maxFileBytes } = options;
+  if (!Number.isSafeInteger(maxFileBytes) || maxFileBytes < 1) {
+    throw new ArtifactTargetError('Artifact file-size limit must be a positive integer.');
+  }
+  if (typeof requestedPath !== 'string' || requestedPath.trim() === '') {
+    throw new ArtifactTargetError('Artifact destination is invalid.');
+  }
+  if (/[/\\]$/.test(requestedPath.trim())) {
+    throw new ArtifactTargetError('Artifact destination must name a file, not a folder.');
+  }
+
+  const reference = normalizeOpenAIFileReference(file);
+  validateOpenAIFileUrl(reference.download_url);
+  if (reference.size !== undefined && reference.size > maxFileBytes) throw new ArtifactFetchError('ChatGPT file exceeds the configured per-file limit.');
+  const resolved = await resolveIn(roots as Parameters<typeof resolveIn>[0], requestedPath, {
+    allowMissing: true
+  });
+  const parentReal = nodePath.dirname(resolved.real);
+  const name = nodePath.basename(resolved.real);
+  const rootReal = await fs.realpath(resolved.root.path);
+  const target = await openArtifactTarget({ parentReal, rootReal, name, maxFileBytes });
+  let opened: Awaited<ReturnType<typeof openArtifactFile>> | undefined;
+  const hash = createHash('sha256');
+  let size = 0;
+  try {
+    opened = await openArtifactFile(file, options);
+    if (opened.size !== undefined && opened.size > maxFileBytes) throw new ArtifactFetchError('ChatGPT file exceeds the configured per-file limit.');
+    for await (const value of opened.stream) {
+      const chunk =
+        typeof value === 'string' ? Buffer.from(value) : Buffer.from(value as Uint8Array);
+      if (size + chunk.length > maxFileBytes) {
+        throw new ArtifactFetchError('ChatGPT file exceeds the configured per-file limit.');
+      }
+      await target.writeAll(chunk, size);
+      hash.update(chunk);
+      size += chunk.length;
+    }
+    if (opened.size !== undefined && opened.size !== size) {
+      throw new ArtifactFetchError('ChatGPT file metadata did not match the downloaded content.');
+    }
+    await target.syncAndVerify(size);
+    await target.publish();
+    return { virtual: resolved.virtual, size, sha256: `sha256:${hash.digest('hex')}` };
+  } finally {
+    opened?.stream.destroy();
+    await target.close().catch(() => undefined);
+  }
+}

--- a/src/main/mcp/artifact-fetch.ts
+++ b/src/main/mcp/artifact-fetch.ts
@@ -1,0 +1,179 @@
+/** Validates bounded native-file references and streams from an exact file-host allowlist.
+ * The schema requests ChatGPT native-file injection; a URL shape is not proof of who
+ * authored a reference. Host/path checks and the approved-root write policy still apply.
+ */
+
+import { Readable } from 'node:stream';
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
+
+const OPENAI_FILE_HOSTS = new Set(['files.oaiusercontent.com']);
+// A customer-chosen Azure account prefix is not proof of OpenAI ownership. Regional
+// hosts need exact verified entries; never trust a wildcard over that shared namespace.
+const OPENAI_FILE_ID_MAX_LENGTH = 512;
+const OPENAI_FILE_ID_CONTROL_PATTERN = /[\u0000-\u001F\u007F]/u;
+const OPENAI_FILE_KEYS = new Set([
+  'download_url',
+  'file_id',
+  'mime_type',
+  'file_name',
+  'name',
+  'size'
+]);
+const OPENAI_FILE_REDIRECT_LIMIT = 3;
+const OPENAI_FILE_DOWNLOAD_TIMEOUT_MS = 30_000;
+
+export class ArtifactFetchError extends Error {}
+
+export interface ArtifactSource {
+  size?: number;
+  stream: Readable;
+}
+
+export interface OpenAIFileReference {
+  download_url: string;
+  file_id: string;
+  size?: number;
+}
+
+export interface OpenAIFileAdapterOptions {
+  fetch?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export function isOpenAIFileReferenceCandidate(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  return (
+    keys.length >= 2 &&
+    keys.every((key) => OPENAI_FILE_KEYS.has(key)) &&
+    Object.hasOwn(value, 'download_url') &&
+    Object.hasOwn(value, 'file_id')
+  );
+}
+
+export function normalizeOpenAIFileReference(value: unknown): OpenAIFileReference {
+  if (!isOpenAIFileReferenceCandidate(value)) {
+    throw new ArtifactFetchError('ChatGPT file reference is malformed.');
+  }
+  const downloadUrl = value['download_url'];
+  const fileId = value['file_id'];
+  if (typeof downloadUrl !== 'string' || downloadUrl.length > 16_384 || typeof fileId !== 'string' || !isValidOpenAIFileId(fileId)) {
+    throw new ArtifactFetchError('ChatGPT file reference is malformed.');
+  }
+  const mimeType = nullableString(value['mime_type']);
+  const fileName = nullableString(value['file_name']);
+  const nameAlias = nullableString(value['name']);
+  if (mimeType === null || fileName === null || nameAlias === null) {
+    throw new ArtifactFetchError('ChatGPT file reference is malformed.');
+  }
+  let size: number | undefined;
+  const rawSize = value['size'];
+  if (rawSize !== undefined && rawSize !== null) {
+    if (typeof rawSize !== 'number' || !Number.isSafeInteger(rawSize) || rawSize < 0) {
+      throw new ArtifactFetchError('ChatGPT file reference is malformed.');
+    }
+    size = rawSize;
+  }
+  return {
+    download_url: downloadUrl,
+    file_id: fileId,
+    size
+  };
+}
+
+/** Fetch the trusted file URL and return its stream. Every redirect is re-validated. */
+export async function openArtifactFile(
+  value: unknown,
+  options: OpenAIFileAdapterOptions = {}
+): Promise<ArtifactSource> {
+  const fetchFile = options.fetch ?? globalThis.fetch;
+  const timeoutMs = options.timeoutMs ?? OPENAI_FILE_DOWNLOAD_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new ArtifactFetchError('Artifact download timeout must be a positive integer.');
+  }
+  const reference = normalizeOpenAIFileReference(value);
+
+  let downloadUrl = validateOpenAIFileUrl(reference.download_url);
+  const signal = AbortSignal.timeout(timeoutMs);
+  let response: Response | undefined;
+  for (let redirect = 0; redirect <= OPENAI_FILE_REDIRECT_LIMIT; redirect += 1) {
+    try {
+      response = await fetchFile(downloadUrl, {
+        redirect: 'manual',
+        signal
+      });
+    } catch {
+      throw new ArtifactFetchError('ChatGPT file could not be downloaded.');
+    }
+    if (!isRedirectStatus(response.status)) break;
+    const location = response.headers.get('location');
+    await response.body?.cancel().catch(() => undefined);
+    if (!location || redirect === OPENAI_FILE_REDIRECT_LIMIT) {
+      throw new ArtifactFetchError('ChatGPT file download returned an invalid redirect.');
+    }
+    try { downloadUrl = validateOpenAIFileUrl(new URL(location, downloadUrl).toString()); }
+    catch (error) {
+      if (error instanceof ArtifactFetchError) throw error;
+      throw new ArtifactFetchError('ChatGPT file download returned an invalid redirect.');
+    }
+  }
+
+  if (!response?.ok || !response.body) {
+    await response?.body?.cancel().catch(() => undefined);
+    throw new ArtifactFetchError('ChatGPT file download did not return file content.');
+  }
+  const responseSize = responseContentLength(response);
+  if (reference.size !== undefined && responseSize !== undefined && reference.size !== responseSize) {
+    await response.body.cancel().catch(() => undefined);
+    throw new ArtifactFetchError('ChatGPT file metadata did not match the downloaded content.');
+  }
+  return { size: responseSize ?? reference.size,
+    stream: Readable.fromWeb(response.body as unknown as NodeReadableStream) };
+}
+
+function nullableString(value: unknown): string | undefined | null {
+  if (value === undefined || value === null) return undefined;
+  return typeof value === 'string' && value.length <= 1024 ? value : null;
+}
+
+function isValidOpenAIFileId(value: string): boolean {
+  return (
+    value.length > 0 && value.length <= OPENAI_FILE_ID_MAX_LENGTH && !OPENAI_FILE_ID_CONTROL_PATTERN.test(value)
+  );
+}
+
+export function validateOpenAIFileUrl(value: string): string {
+  if (value.length > 16_384) throw new ArtifactFetchError('ChatGPT file download URL is invalid.');
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new ArtifactFetchError('ChatGPT file download URL is invalid.');
+  }
+  if (
+    url.protocol !== 'https:' ||
+    !isTrustedOpenAIFileHost(url.hostname) ||
+    (url.port !== '' && url.port !== '443') ||
+    url.username !== '' ||
+    url.password !== '' ||
+    url.hash !== ''
+  ) {
+    throw new ArtifactFetchError('ChatGPT file download URL is outside the trusted file host.');
+  }
+  return url.toString();
+}
+
+function isTrustedOpenAIFileHost(hostname: string): boolean {
+  return OPENAI_FILE_HOSTS.has(hostname);
+}
+
+function isRedirectStatus(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+function responseContentLength(response: Response): number | undefined {
+  const value = response.headers.get('content-length');
+  if (!value || !/^\d+$/u.test(value)) return undefined;
+  const size = Number(value);
+  return Number.isSafeInteger(size) ? size : undefined;
+}

--- a/src/main/mcp/artifact-target.ts
+++ b/src/main/mcp/artifact-target.ts
@@ -1,0 +1,124 @@
+/** Exclusive partial and no-overwrite publication inside a sandbox-resolved existing directory. */
+import { randomUUID } from 'node:crypto';
+import { constants as fsConstants } from 'node:fs';
+import path from 'node:path';
+import { rawPromises as fs } from '../rawfs.js';
+
+export const ARTIFACT_PARTIAL_PREFIX = '.steroids-download-';
+export const ARTIFACT_PARTIAL_SUFFIX = '.partial';
+export class ArtifactTargetError extends Error {}
+export interface ArtifactTargetOptions {
+  /** Canonical sandbox-resolved paths, not caller spellings (for example /var aliases). */
+  parentReal: string;
+  rootReal: string;
+  name: string;
+  maxFileBytes: number;
+}
+export interface ArtifactTarget {
+  writeAll(buffer: Buffer, position: number): Promise<void>;
+  syncAndVerify(expectedSize: number): Promise<void>;
+  publish(): Promise<void>;
+  close(): Promise<void>;
+  readonly size: number;
+}
+const normalized = (value: string): string => process.platform === 'win32' ? path.resolve(value).toLowerCase() : path.resolve(value);
+const samePath = (a: string, b: string): boolean => normalized(a) === normalized(b);
+type FileStat = Awaited<ReturnType<typeof fs.lstat>>;
+const sameFile = (a: FileStat, b: FileStat): boolean => a.dev === b.dev && a.ino === b.ino;
+
+export function assertSafeFileName(name: string): void {
+  if (!name || name === '.' || name === '..' || /[/\\:\u0000-\u001f]/.test(name)) {
+    throw new ArtifactTargetError('Artifact destination is invalid.');
+  }
+}
+
+export async function openArtifactTarget({ parentReal, rootReal, name, maxFileBytes }: ArtifactTargetOptions): Promise<ArtifactTarget> {
+  assertSafeFileName(name);
+  if (!Number.isSafeInteger(maxFileBytes) || maxFileBytes < 1) throw new ArtifactTargetError('Artifact file-size limit must be a positive integer.');
+  const relative = path.relative(normalized(rootReal), normalized(parentReal));
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new ArtifactTargetError('Artifact destination escapes its approved folder.');
+  }
+  let parent: FileStat;
+  try { parent = await fs.lstat(parentReal); }
+  catch { throw new ArtifactTargetError('Artifact destination parent is not available. Create the destination folder first.'); }
+  if (!parent.isDirectory() || parent.isSymbolicLink()) throw new ArtifactTargetError('Artifact destination parent must be a real directory.');
+
+  async function verifyParent(): Promise<void> {
+    const [current, canonicalParent, canonicalRoot] = await Promise.all([fs.lstat(parentReal), fs.realpath(parentReal), fs.realpath(rootReal)]);
+    if (!current.isDirectory() || current.isSymbolicLink() || !sameFile(current, parent) || !samePath(canonicalParent, parentReal) || !samePath(canonicalRoot, rootReal)) {
+      throw new ArtifactTargetError('Artifact destination parent changed during the download.');
+    }
+  }
+  await verifyParent();
+  const partialPath = path.join(parentReal, `${ARTIFACT_PARTIAL_PREFIX}${randomUUID()}${ARTIFACT_PARTIAL_SUFFIX}`);
+  const candidatePath = path.join(parentReal, name);
+  try { await fs.lstat(candidatePath); throw new ArtifactTargetError('Artifact destination already exists.'); }
+  catch (error) { if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error; }
+  const handle = await fs.open(partialPath, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | (fsConstants.O_NOFOLLOW ?? 0), 0o600);
+  let original: FileStat;
+  try { original = await handle.stat(); }
+  catch (error) { await handle.close(); throw error; }
+  let writtenBytes = 0, verified = false, published = false, closed = false;
+
+  async function ownedFile(file: string): Promise<boolean> {
+    const current = await fs.lstat(file).catch(() => null);
+    return !!current && current.isFile() && !current.isSymbolicLink() && sameFile(current, original);
+  }
+  async function close(): Promise<void> {
+    if (closed) return;
+    closed = true;
+    // A foreign replacement is never ours to remove; do not sweep older calls' partials.
+    try { await verifyParent(); if (await ownedFile(partialPath)) await fs.unlink(partialPath); }
+    catch { /* A moved directory or foreign replacement stays untouched. */ }
+    await handle.close();
+  }
+  async function verifyPartial(): Promise<void> {
+    await verifyParent();
+    const [fd, current] = await Promise.all([handle.stat(), fs.lstat(partialPath)]);
+    if (!fd.isFile() || !current.isFile() || current.isSymbolicLink() || !sameFile(fd, original) || !sameFile(current, original) || fd.size !== writtenBytes || current.size !== writtenBytes) {
+      throw new ArtifactTargetError('Artifact partial changed before publication.');
+    }
+  }
+  try { await verifyPartial(); }
+  catch (error) { await close().catch(() => undefined); throw error; }
+
+  return {
+    get size() { return writtenBytes; },
+    async writeAll(buffer, position) {
+      if (closed || verified || position !== writtenBytes) throw new ArtifactTargetError('Artifact target is not writable at that position.');
+      if (writtenBytes + buffer.length > maxFileBytes) throw new ArtifactTargetError('Artifact file exceeds the configured per-file limit.');
+      await verifyParent();
+      let offset = 0;
+      while (offset < buffer.length) {
+        const result = await handle.write(buffer, offset, buffer.length - offset, position + offset);
+        if (!result.bytesWritten) throw new ArtifactTargetError('Artifact write was interrupted.');
+        offset += result.bytesWritten;
+      }
+      writtenBytes += buffer.length;
+    },
+    async syncAndVerify(expectedSize) {
+      if (closed || writtenBytes !== expectedSize) throw new ArtifactTargetError('Artifact size did not match the downloaded content.');
+      await handle.sync();
+      await verifyPartial();
+      verified = true;
+    },
+    async publish() {
+      if (closed || !verified) throw new ArtifactTargetError('Artifact must be verified before publication.');
+      if (published) return;
+      // Validate directory and open-file identity again after a long download. Portable
+      // Node path I/O cannot pin the directory across the final link syscall; this is
+      // bounded revalidation, not a claim of an openat/linkat implementation.
+      await verifyPartial();
+      try { await fs.link(partialPath, candidatePath); }
+      catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') throw new ArtifactTargetError('Artifact destination already exists.');
+        throw error;
+      }
+      await verifyParent();
+      if (!await ownedFile(candidatePath)) throw new ArtifactTargetError('Artifact destination changed during publication.');
+      published = true;
+    },
+    close
+  };
+}

--- a/src/main/mcp/call-context.ts
+++ b/src/main/mcp/call-context.ts
@@ -144,6 +144,12 @@ export function runningToolCalls(conversationId: string | null = null): number {
   return countFor(running, conversationId);
 }
 
+/** Presentation requires exact ownership; anonymous safety counts are not this chat's work. */
+export function runningToolProgress(conversationId: string): { count: number; since: number } | null {
+  const owned = [...running].filter(call => call.caller.conversationId === conversationId);
+  return owned.length ? { count: owned.length, since: Math.min(...owned.map(call => call.startedAt)) } : null;
+}
+
 /** Finished tool work whose unattributed durable record is still landing. */
 export function settlingToolCalls(conversationId: string | null = null): number {
   return countFor(settling, conversationId);

--- a/src/main/mcp/instructions.ts
+++ b/src/main/mcp/instructions.ts
@@ -11,7 +11,7 @@
  */
 
 import { LAUNCHES_WINDOWS_POWERSHELL_5 } from '../codex/tool-specs.js';
-import { getConfig } from '../config.js';
+import { getConfig, MAX_MCP_INSTRUCTIONS_CHARS } from '../config.js';
 import { isGitRepository } from '../toolchain.js';
 import type { ToolContext } from './kernel.js';
 import { surfaceDefinition, type SurfaceId } from './surfaces.js';
@@ -22,6 +22,23 @@ export function serverInstructions(
   platform: NodeJS.Platform = process.platform
 ): string {
   return surface === 'desktop' ? desktopInstructions(ctx, platform) : coreInstructions(ctx, platform);
+}
+
+/**
+ * The user's own additions, appended to whichever connector is being described.
+ *
+ * Last, and fenced under a heading that says whose words these are. Both matter. Last, because
+ * everything above is what the app can actually promise about its own tools, and a preference
+ * must not quietly redefine one of them. Attributed, because the model should be able to tell a
+ * standing instruction from this user apart from the connector's description of itself -- they
+ * carry different authority, and running them together hides that.
+ *
+ * Empty is the normal case and adds nothing at all, not even the heading.
+ */
+function userInstructions(): string[] {
+  const text = getConfig().mcp.instructions.trim();
+  if (!text) return [];
+  return ['', "The user's own standing instructions for this connector:", text.slice(0, MAX_MCP_INSTRUCTIONS_CHARS)];
 }
 
 function coreInstructions(ctx: ToolContext, platform: NodeJS.Platform): string {
@@ -99,7 +116,12 @@ function coreInstructions(ctx: ToolContext, platform: NodeJS.Platform): string {
     // The one exception to the virtual-path rule above, and the model has to be told: cmd
     // is a program, not a path, so it reaches the shell exactly as written.
     'exec_command’s workdir is virtual, but its cmd is not translated — set workdir and write paths inside the command relative to it.',
-    'Output is capped. When a result says it was truncated, narrow the request instead of repeating it.'
+    'Output is capped. When a result says it was truncated, narrow the request instead of repeating it.',
+    ...(ctx.caps.saveArtifact
+      ? [
+          'When the user supplies or ChatGPT generates a file that is not on this computer, save it with download_artifact using its native file value and a destination path inside an approved folder. The tool refuses to overwrite and returns the saved path. Never recreate such files with apply_patch or exec_command, and never place signed URLs, file objects or base64 content in shell commands or logs.'
+        ]
+      : [])
   ];
 
   if (desktop && (ctx.caps.screen || ctx.caps.control || ctx.caps.clipboardRead || ctx.caps.clipboardWrite)) {
@@ -155,6 +177,8 @@ function coreInstructions(ctx: ToolContext, platform: NodeJS.Platform): string {
     );
   }
 
+  lines.push(...userInstructions());
+
   return lines.join('\n');
 }
 
@@ -202,6 +226,8 @@ function desktopInstructions(ctx: ToolContext, platform: NodeJS.Platform): strin
     `Files, patches and commands live in a separate connector, "${surfaceDefinition('core').connectorName}".`,
     'This one cannot read or change files. If a task needs that and it is not available here, say so.'
   );
+
+  lines.push(...userInstructions());
 
   return lines.join('\n');
 }

--- a/src/main/mcp/kernel.ts
+++ b/src/main/mcp/kernel.ts
@@ -671,13 +671,13 @@ async function dispatchTracked(
         : retiredLeaseAmbiguous
         ? Promise.resolve(
             fail(
-              'CALLER_IDENTITY_REQUIRED: a recently retired worker tab may still be open, and the connector could not prove this call belongs to a different chat. No local tool was run. Reload the extension evidence path or wait for the retired lease to expire.'
+              'CALLER_IDENTITY_REQUIRED: a recently retired worker tab may still be open, and the connector could not prove this call belongs to a different chat. No local tool was run. For a browser chat, restore the companion connection and retry. Scheduled or headless runs may have no browser identity: the user can enable "Allow unattributed calls" in the app settings to permit self-contained calls recorded as Unattributed. Exact retired-worker restrictions still apply.'
             )
           )
         : dormantLeaseAmbiguous
         ? Promise.resolve(
             fail(
-              'CALLER_IDENTITY_REQUIRED: a dormant worker chat still belongs to its prime history, and the connector could not prove this call belongs to a different conversation. No local tool was run. Restore the browser-extension identity path and retry.'
+              'CALLER_IDENTITY_REQUIRED: a dormant worker chat still belongs to its prime history, and the connector could not prove this call belongs to a different conversation. No local tool was run. For a browser chat, restore the companion connection and retry. Scheduled or headless runs may have no browser identity: the user can enable "Allow unattributed calls" in the app settings to permit self-contained calls recorded as Unattributed. This does not identify the caller or grant access to another chat’s workspace or processes.'
             )
           )
         : !allowUnattributed && swarmRunning() && identitySensitive && !context.caller.conversationId
@@ -980,6 +980,12 @@ export interface SurfaceRegistrar {
       inputSchema: Schema;
       outputSchema?: z.ZodType;
       annotations?: ToolAnnotations;
+      /**
+       * Opaque host metadata advertised verbatim in tools/list.
+       * Used once by download_artifact for {"openai/fileParams": ["file"]},
+       * which tells ChatGPT to inject the native file value. Never interpreted here.
+       */
+      _meta?: Record<string, unknown>;
     },
     handler: (args: z.output<Schema>) => Promise<ToolResult>
   ): void;

--- a/src/main/mcp/surfaces.ts
+++ b/src/main/mcp/surfaces.ts
@@ -91,9 +91,9 @@ export interface SurfaceDefinition {
  *    it here. A dedicated connector for one conditional schema is pure setup overhead with
  *    no discovery benefit.
  *
- * Core declares 8 possible tool names below, but at most 7 schemas are live at once. `find`
- * and the exec pair are mutually exclusive — `find` exists only when command execution is
- * off — so no runtime tools/list reaches all 8 declarations.
+ * Core declares 10 possible tool names below, but at most 9 schemas are live at once.
+ * `find` and the exec pair are mutually exclusive — `find` exists only when command
+ * execution is off — so no runtime tools/list reaches all 10 declarations.
  */
 const CORE: SurfaceDefinition = {
   id: 'core',
@@ -102,12 +102,13 @@ const CORE: SurfaceDefinition = {
   description:
     'Read and edit code and text files on this computer, and run commands in a real terminal. ' +
     'Use for: opening and reading files, searching a repository, applying patches, creating, renaming and deleting files, ' +
-    'running builds, tests, linters, git, npm and shell commands, and continuing long-running or interactive terminal sessions. ' +
+    'running builds, tests, linters, git, npm and shell commands, continuing long-running or interactive terminal sessions, ' +
+    'and saving images and files ChatGPT generates onto this computer. ' +
     'Also searches and reads local recordings of previous or concurrently running ChatGPT work, and — when the user has ' +
     'enabled it — spawns and coordinates worker agents, subagents or a parallel swarm across several ChatGPT conversations.',
   cardSummary: 'Files, patches and the terminal. Required — this is the coding connector.',
   required: true,
-  tools: ['read', 'view_image', 'find', 'apply_patch', 'exec_command', 'write_stdin', 'session', 'agents', 'session_finish']
+  tools: ['read', 'view_image', 'find', 'apply_patch', 'exec_command', 'write_stdin', 'download_artifact', 'session', 'agents', 'session_finish']
 };
 
 /**

--- a/src/main/mcp/tools-core.ts
+++ b/src/main/mcp/tools-core.ts
@@ -4,13 +4,13 @@ import { getConfig } from '../config.js';
 /**
  * The Core connector: reading, changing and running code on this PC.
  *
- * Seven tools at the absolute maximum, and usually five. That number is the design (see
+ * Nine tools at the absolute maximum, and usually seven. That number is the design (see
  * `docs/tool-surface.md` §3): a no-query discovery pull against this connector returns
  * every schema here at once, so the surface is sized for the worst case rather than for
  * the case where the harness happens to ask a narrow question.
  *
- * What used to be forty-five tools did not become seven by dropping capability. It became
- * seven by separating *primitives* from *procedures*: `exec_command` can run git, so `git`
+ * What used to be forty-five tools did not become nine by dropping capability. It became
+ * eight by separating *primitives* from *procedures*: `exec_command` can run git, so `git`
  * is a skill rather than a tool; `read` can open a directory, a text file or an image,
  * because those are three shapes of one question. Anything that reads as "and also, for
  * this special case…" belongs in a skill over these primitives, not in a schema every
@@ -34,6 +34,7 @@ import { SandboxError, isNativeWindowsPath, resolvePath, strayVirtualPath } from
 import { currentWorkspace } from '../workspace.js';
 import type { Capabilities, Root } from '../../shared/types.js';
 import type { FileChange } from '../../shared/session.js';
+import { REASONING_EFFORTS } from '../../shared/session.js';
 import { DEFAULT_EXCLUDES, MAX_CONTENT_FILE_BYTES, globToRegExp, search, searchOneFile } from '../search.js';
 import {
   ApplyPatchError,
@@ -125,6 +126,7 @@ import { repairPrimeFromResumeShadow } from '../session/continuation.js';
 import {
   currentCall,
   currentCaller,
+  noteChange,
   noteChanges,
   noteCount,
   noteDetail,
@@ -153,6 +155,9 @@ import {
   type ToolResult
 } from './kernel.js';
 import { registerSessionTool as registerSessionSearchReadTool } from './session-tool.js';
+import { ArtifactFetchError } from './artifact-fetch.js';
+import { ArtifactTargetError } from './artifact-target.js';
+import { downloadArtifactFile } from './artifact-download.js';
 
 /** Entries one `read` of a directory returns before it says it stopped. */
 const MAX_DIR_ENTRIES = 200;
@@ -972,6 +977,77 @@ export function registerCoreTools(reg: SurfaceRegistrar): void {
     );
   }
 
+  // ------------------------------------------------------- download_artifact
+
+  // Requests ChatGPT native-file injection. The gateway still validates the reference,
+  // exact host and sandbox destination; metadata alone is not provenance proof.
+  if (exposedCaps.saveArtifact) {
+    reg.register(
+      'download_artifact',
+      {
+        title: 'Save ChatGPT file',
+        description:
+          'Save one file ChatGPT generated or attached to a path inside an approved folder. ' +
+          'The file value is supplied by ChatGPT itself — never invent download_url or file_id values. ' +
+          'The destination must not already exist and its parent folder must already exist. ' +
+          'Use for images, PDFs, archives and other files ChatGPT produces; never recreate such files with apply_patch or exec_command.',
+        inputSchema: z
+          .object({
+            file: z
+              .strictObject({
+                download_url: z.string(),
+                file_id: z.string(),
+                mime_type: z.string().nullable().optional(),
+                file_name: z.string().nullable().optional(),
+                name: z.string().nullable().optional(),
+                size: z.number().int().nonnegative().nullable().optional()
+              })
+              .describe('Native file value injected by ChatGPT.'),
+            path: pathArg.describe(
+              'Destination inside an approved folder: a virtual /<root>/... path or an absolute native path. ' +
+                'Relative paths resolve against this chat\'s folder. The destination must name a file that does not already exist.'
+            )
+          })
+          .strict(),
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+        _meta: { 'openai/fileParams': ['file'] }
+      },
+      async ({ file, path: requestedPath }) =>
+        guard('download_artifact', async () => {
+          if (!caps.saveArtifact) {
+            return fail(
+              'TOOL_DISABLED: download_artifact is disabled by the current Chat On Steroids permissions. Ask the user to enable saving ChatGPT files in the app.'
+            );
+          }
+          try {
+            const saved = await downloadArtifactFile(ctx.roots, requestedPath, file, {
+              maxFileBytes: getConfig().artifacts.maxFileBytes
+            });
+            noteChange({ path: saved.virtual, added: 0, removed: 0, approximate: true });
+            logInfo(`tool download_artifact ${saved.virtual} (${formatBytes(saved.size)}, ${saved.sha256})`);
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Saved ${saved.virtual} (${formatBytes(saved.size)}, ${saved.sha256}).`
+                }
+              ],
+              structuredContent: { path: saved.virtual, size: saved.size, sha256: saved.sha256 }
+            };
+          } catch (error) {
+            if (
+              error instanceof ArtifactFetchError ||
+              error instanceof ArtifactTargetError ||
+              error instanceof SandboxError
+            ) {
+              return fail(`download_artifact failed: ${error.message}`);
+            }
+            throw error;
+          }
+        })
+    );
+  }
+
   // ---------------------------------------------------------------- session
 
   if (reg.sessionToolsExposed) registerSessionSearchReadTool(reg);
@@ -1080,7 +1156,20 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
                 .min(1)
                 .max(4000)
                 .describe(
-                  'This worker\'s job: objective, relevant files, constraints and expected handoff. Model and reasoning are predefined by the user in app settings.'
+                  'This worker\'s job: objective, relevant files, constraints and expected handoff.'
+                ),
+              model: z
+                .string()
+                .max(80)
+                .optional()
+                .describe(
+                  'ChatGPT model slug for this worker only, e.g. to keep an expensive model for yourself. Omit for the default set in app settings.'
+                ),
+              reasoning_effort: z
+                .enum(REASONING_EFFORTS)
+                .optional()
+                .describe(
+                  'How much reasoning this worker uses. Independent of model: it never selects or changes one. Omit for the default set in app settings.'
                 )
             }).strict()
           )
@@ -1186,7 +1275,7 @@ function registerAgentsTool(reg: SurfaceRegistrar): void {
           const { created, becamePrime, runId } = staged;
           // Browser tabs are a publication side effect, never part of planning. They become
           // visible only after the exact broker revision above is durable.
-          requestWorkerBootstraps(created.map((worker) => worker.id));
+          requestWorkerBootstraps(created.map((worker) => worker.id), runId);
           await adoptAgent(PRIME_ID);
           const invited = created.filter((worker) => worker.state === 'invited');
           const sleeping = created.filter((worker) => worker.state === 'sleeping' && worker.revivable);

--- a/src/main/plugin-refresh.ts
+++ b/src/main/plugin-refresh.ts
@@ -2,12 +2,12 @@ import { createHash, randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import { readDurable, writeDurableNow } from './durable.js';
 import { wakeBrowserWork } from './browser-wake.js';
-import { logInfo } from './logger.js';
+import { logInfo, logWarn } from './logger.js';
 import { surfaceDefinition } from './mcp/surfaces.js';
 import type { PluginPublication, PluginRefreshRequest, PluginSurface, PluginToolSchema } from '../shared/plugin-refresh.js';
 
 const app = z.string().regex(/^asdk_app_[a-zA-Z0-9_-]{1,160}$/);
-const rowSchema = z.object({ surface: z.enum(['core', 'desktop']), schemaId: z.string(), id: z.string().uuid(), appId: app.nullable(), completedSchemaId: z.string().nullable(), attempted: z.boolean(), error: z.string().max(200).optional(), versionId: z.string().max(200).optional() });
+const rowSchema = z.object({ surface: z.enum(['core', 'desktop']), schemaId: z.string(), id: z.string().uuid(), appId: app.nullable(), completedSchemaId: z.string().nullable(), attempted: z.boolean(), manual: z.boolean().optional().default(false), error: z.string().max(200).optional(), versionId: z.string().max(200).optional() });
 type Row = z.infer<typeof rowSchema>;
 const publications = new Map<PluginSurface, PluginPublication>();
 const settling = new Map<PluginSurface, { schemaId: string; readyAt: number; timer?: ReturnType<typeof setTimeout> }>();
@@ -89,17 +89,17 @@ export function pendingPluginRefreshes(): Promise<PluginRefreshRequest[]> {
     for (const publication of publications.values()) {
       const found = current.find(row => row.surface === publication.surface);
       if (found?.schemaId === publication.schemaId) continue;
-      const next: Row = { surface: publication.surface, schemaId: publication.schemaId, id: randomUUID(), appId: found?.appId ?? null, completedSchemaId: found?.completedSchemaId ?? null, attempted: false };
+      const next: Row = { surface: publication.surface, schemaId: publication.schemaId, id: randomUUID(), appId: found?.appId ?? null, completedSchemaId: found?.completedSchemaId ?? null, attempted: false, manual: false };
       if (found) current[current.indexOf(found)] = next; else current.push(next);
       changed = true;
     }
     if (changed) {
       await writeDurableNow('plugin-refresh', current);
-      logInfo(`plugin refresh pending observed ${current.filter(row => row.completedSchemaId !== row.schemaId).map(row => `surface=${row.surface} schema=${row.schemaId.slice(0, 12)} dueInMs=${Math.max(0, (settling.get(row.surface)?.readyAt ?? 0) - Date.now())}`).join(' ')}`);
+      logInfo(`plugin refresh pending observed ${current.filter(row => !row.manual && row.completedSchemaId !== row.schemaId).map(row => `surface=${row.surface} schema=${row.schemaId.slice(0, 12)} dueInMs=${Math.max(0, (settling.get(row.surface)?.readyAt ?? 0) - Date.now())}`).join(' ')}`);
     }
     return current.flatMap(row => {
       const publication = publications.get(row.surface);
-      return publication && (settling.get(row.surface)?.readyAt ?? 0) <= Date.now() && publication.schemaId === row.schemaId && !row.attempted && row.completedSchemaId !== row.schemaId
+      return publication && (settling.get(row.surface)?.readyAt ?? 0) <= Date.now() && publication.schemaId === row.schemaId && !row.attempted && !row.manual && row.completedSchemaId !== row.schemaId
         ? [{ ...structuredClone(publication), id: row.id, appId: row.appId }] : [];
     });
   });
@@ -113,7 +113,7 @@ function exact(current: Row[], identity: Identity): Row | undefined {
 export function claimPluginRefresh(input: Identity & { connectorName: string; tools: unknown; alreadyCurrent?: boolean }): Promise<boolean> {
   return serial(async () => {
     const current = await rows(); const row = exact(current, input);
-    if (!row || row.attempted || row.completedSchemaId === row.schemaId || !recognizable(input.tools)) return false;
+    if (!row || row.attempted || row.manual || row.completedSchemaId === row.schemaId || !recognizable(input.tools)) return false;
     const publication = publications.get(row.surface)!;
     // Unique-name discovery is initial enrollment only. Stale definitions can still
     // identify the surface; the complete post-refresh declarations must match below.
@@ -129,10 +129,33 @@ export function claimPluginRefresh(input: Identity & { connectorName: string; to
     await writeDurableNow('plugin-refresh', current); return true;
   });
 }
+/**
+ * Records a changed provider snapshot that this ChatGPT workspace cannot refresh in place.
+ *
+ * This is intentionally neither a completed refresh nor an attempted click. The same schema stays
+ * visible as requiring manual recreation/republishing, but automatic browser maintenance stops
+ * reopening its settings page. A later local schema change creates a fresh row and may be tried
+ * again normally.
+ */
+export function requireManualPluginRefresh(input: Identity & { connectorName: string; tools: unknown; error: string }): Promise<boolean> {
+  return serial(async () => {
+    const current = await rows(); const row = exact(current, input);
+    if (!row || row.attempted || row.manual || row.completedSchemaId === row.schemaId || !recognizable(input.tools)) return false;
+    const publication = publications.get(row.surface)!;
+    if (row.appId ? row.appId !== input.appId : input.connectorName !== publication.connectorName || !enrollable(input.tools, publication)) return false;
+    if (current.some(other => other !== row && other.appId === input.appId) || matches(input.tools, publication.tools)) return false;
+    row.appId = input.appId;
+    row.manual = true;
+    row.error = input.error.slice(0, 200);
+    await writeDurableNow('plugin-refresh', current);
+    logWarn(`plugin refresh requires manual action surface=${row.surface}: ${row.error}`);
+    return true;
+  });
+}
 export function completePluginRefresh(input: Identity & { tools: unknown; versionId?: string }): Promise<boolean> {
   return serial(async () => {
     const current = await rows(); const row = exact(current, input);
-    if (!row || !row.attempted || row.appId !== input.appId || !matches(input.tools, publications.get(row.surface)!.tools)) return false;
+    if (!row || row.manual || !row.attempted || row.appId !== input.appId || !matches(input.tools, publications.get(row.surface)!.tools)) return false;
     row.completedSchemaId = row.schemaId; delete row.error;
     if (input.versionId) row.versionId = input.versionId.slice(0, 200);
     await writeDurableNow('plugin-refresh', current); return true;

--- a/src/main/secrets.ts
+++ b/src/main/secrets.ts
@@ -57,11 +57,12 @@ function enqueue<T>(operation: () => Promise<T>): Promise<T> {
  * config.json, the log and the renderer.
  */
 /**
- * `bridgeToken` is not a user credential either way; `openRouterApiKey` is one, and is the
- * only credential in here that a *model* can cause to be spent, so it lives under the same
- * OS-backed encrypted blob as the rest and never leaves the main process.
+ * `bridgeToken` is not a user credential either way; `openRouterApiKey` and
+ * `customProviderApiKey` are the two credentials a *model* can cause to be spent (Goal/Loop
+ * drafts, one per active provider), so they live under the same OS-backed encrypted blob
+ * as the rest and never leave the main process.
  */
-export type SecretKey = 'openaiApiKey' | 'bridgeToken' | 'openRouterApiKey';
+export type SecretKey = 'openaiApiKey' | 'bridgeToken' | 'openRouterApiKey' | 'customProviderApiKey';
 
 export function initSecretsPath(userDataDir: string): void {
   secretsPath = path.join(userDataDir, FILE_NAME);

--- a/src/main/session/continuation.ts
+++ b/src/main/session/continuation.ts
@@ -145,12 +145,45 @@ export interface ContinuationDestinationCheckpoint extends ContinuationSendCheck
 export const sendUnattempted = (checkpoint: ContinuationSendCheckpoint): boolean =>
   checkpoint.state === 'not-attempted' || checkpoint.state === 'attempted-unresolved';
 
+/**
+ * The ChatGPT Project a successor chat must be created in, reduced to its routing identity.
+ *
+ * Matches background.js::projectFromUrl, the browser-side routing rule --
+ * the extension is plain JS and cannot import this. Both accept only `g-p-` followed by 32 hex
+ * digits, because that is the form ChatGPT addresses a Project page by. A Project chat's own
+ * path carries the display name appended to that id, and a renamed Project changes it, so the
+ * name is never part of what is stored or built.
+ *
+ * Anything else is null, and null everywhere means "open at the site root" -- exactly what this
+ * app did before Projects were carried at all. An unrecognised shape therefore degrades to the
+ * previous behaviour rather than to a guessed address.
+ */
+export function normalizeProjectId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const candidate = value.trim().toLowerCase();
+  return /^g-p-[0-9a-f]{32}$/.test(candidate) ? candidate : null;
+}
+
 interface Continuation {
   token: string;
   sessionId: string;
   /** Chat A: where the session is attached until the commit lands. */
   from: string;
   openedAt: number;
+  /**
+   * Last sign that this handoff is still being worked, which is what the manual deadline runs on.
+   *
+   * The ten-minute clock is a limit on *waiting*, and it used to be measured from `openedAt` — so
+   * a brief that ChatGPT was still writing was indistinguishable from one nobody had touched. On a
+   * 730k-token chat under Pro reasoning the brief took longer than that, and issue #21 is what
+   * happened next: the running generation was declared dead and auto-compaction then treated the
+   * compaction itself as an eligible turn, stopped it, and started another one.
+   *
+   * Renewed only by real forward progress. A token that has genuinely gone quiet for a full TTL
+   * still expires, so this lengthens nothing for a stalled handoff.
+   */
+  touchedAt: number;
+  sourceProgress: number;
   /** Auto-compaction ticket: survives page/retry clocks until commit or explicit Off/cancel. */
   automatic: boolean;
   /** When the brief request first went on its way; the automatic clock starts here. */
@@ -175,6 +208,14 @@ interface Continuation {
   claimedBy: string | null;
   /** Chat B while the durable commit is in flight; persisted for restart recovery. */
   to: string | null;
+  /**
+   * The Project chat A belongs to, so chat B is created in it too. Null for a chat at the root.
+   *
+   * Held here rather than only in the browser because the app opens the replacement itself
+   * whenever the extension does not -- an OS fallback, or a recovery after this process
+   * restarted -- and by then the tab that knew the Project may be gone.
+   */
+  project: string | null;
   sourceSend: ContinuationSendCheckpoint;
   destinationSend: ContinuationDestinationCheckpoint;
   error: string | null;
@@ -194,10 +235,15 @@ interface ContinuationRecord {
   from: string;
   to: string | null;
   openedAt: number;
+  /** Absent in snapshots written before the manual deadline counted from activity. */
+  touchedAt?: number;
+  sourceProgress?: number;
   /** Absent in records written before durable auto-compaction tickets existed. */
   automatic?: boolean;
   /** Absent in records written before automatic handovers had a deadline. */
   askedAt?: number | null;
+  /** Absent in records written before Project affinity was carried; null means the site root. */
+  project?: string | null;
   state: ContinuationState;
   summary: string;
   handoffId: string | null;
@@ -223,8 +269,11 @@ function durableRecord(entry: Continuation): ContinuationRecord {
     from: entry.from,
     to: entry.to,
     openedAt: entry.openedAt,
+    touchedAt: entry.touchedAt,
+    sourceProgress: entry.sourceProgress,
     automatic: entry.automatic,
     askedAt: entry.askedAt,
+    project: entry.project,
     state: entry.state,
     summary: entry.summary.slice(0, 512 * 1024),
     handoffId: entry.handoffId,
@@ -270,6 +319,12 @@ function publishRecord(entry: Continuation, record: ContinuationRecord): void {
   // waiting out a window that is already over.
   if (record.state === 'committed' || record.state === 'aborted') endResumeClaim(entry.token);
   entry.to = record.to;
+  entry.project = normalizeProjectId(record.project);
+  // Never let a durable read move the deadline backwards: a snapshot written before this field
+  // existed reports nothing, and reading that as "last touched when it opened" would expire a
+  // handoff that has been progressing since.
+  entry.touchedAt = Math.max(entry.touchedAt, record.touchedAt ?? record.openedAt);
+  entry.sourceProgress = record.sourceProgress ?? 0;
   entry.automatic = record.automatic === true;
   entry.state = record.state;
   entry.summary = record.summary;
@@ -295,6 +350,10 @@ async function transitionNow(
 ): Promise<ContinuationRecord> {
   const current = durableRecord(entry);
   const next = derive(current);
+  // Any semantic transition is forward progress, so it renews the waiting deadline. Without this
+  // the stamp would only ever be set at open and the manual clock would be back to counting from
+  // there — the same bug in a new field.
+  if (JSON.stringify(next) !== JSON.stringify(current)) next.touchedAt = Date.now();
   try {
     // Persist the proposed semantic state before publishing it into the live transaction.
     // If the durable boundary rejects, callers still see the previous state and can retry or
@@ -333,6 +392,7 @@ export function setContinuationRecoveryHooks(hooks: ContinuationRecoveryHooks): 
 }
 
 export interface ContinuationView {
+  touchedAt: number;
   token: string;
   sessionId: string;
   from: string;
@@ -344,11 +404,14 @@ export interface ContinuationView {
   automatic: boolean;
   /** When the brief request first went on its way, or null while it has not. */
   askedAt: number | null;
+  /** The Project the replacement chat belongs in, or null for the site root. */
+  project: string | null;
   sourceSend: ContinuationSendCheckpoint;
   destinationSend: ContinuationDestinationCheckpoint;
 }
 
 const view = (entry: Continuation): ContinuationView => ({
+  touchedAt: entry.touchedAt,
   token: entry.token,
   sessionId: entry.sessionId,
   from: entry.from,
@@ -359,6 +422,7 @@ const view = (entry: Continuation): ContinuationView => ({
   openedAt: entry.openedAt,
   automatic: entry.automatic,
   askedAt: entry.askedAt,
+  project: entry.project,
   sourceSend: { ...entry.sourceSend },
   destinationSend: { ...entry.destinationSend }
 });
@@ -377,7 +441,7 @@ const handoffAsked = (entry: Continuation): boolean =>
 const expired = (entry: Continuation, now = Date.now()): boolean =>
   entry.automatic
     ? entry.askedAt !== null && now - entry.askedAt >= AUTOMATIC_HANDOVER_TTL_MS
-    : now - entry.openedAt >= CONTINUATION_TTL_MS;
+    : now - entry.touchedAt >= CONTINUATION_TTL_MS;
 
 const isOpen = (entry: Continuation): boolean =>
   entry.state !== 'committed' && entry.state !== 'aborted' && !expired(entry);
@@ -393,7 +457,7 @@ function sweep(): void {
     if (entry.state === 'committed' || entry.state === 'aborted') {
       // Kept briefly so a repeated ack can be answered with "already done" rather than with
       // a fresh transaction, then forgotten.
-      if (Date.now() - entry.openedAt > CONTINUATION_TTL_MS * 2) byToken.delete(entry.token);
+      if (Date.now() - entry.touchedAt > CONTINUATION_TTL_MS * 2) byToken.delete(entry.token);
       continue;
     }
     if (expired(entry)) {
@@ -466,10 +530,10 @@ export function supersededSourceConversations(): string[] {
   return [...out].sort();
 }
 
-/** Auto-compaction tickets still owed a real A -> B commit. */
-export function pendingAutomaticContinuations(): ContinuationView[] {
+/** Compaction tickets still owed a real A -> B commit. */
+export function pendingContinuations(): ContinuationView[] {
   sweep();
-  return [...byToken.values()].filter((entry) => entry.automatic && isOpen(entry)).map(view);
+  return [...byToken.values()].filter(isOpen).map(view);
 }
 
 /**
@@ -622,12 +686,15 @@ export async function repairPrimeFromResumeShadow(conversationId: string): Promi
  * one already running. That is deliberate — the previous design let each press become its
  * own handoff and its own fresh tab.
  */
-function makeContinuation(sessionId: string, fromConversationId: string, automatic: boolean): Continuation {
+function makeContinuation(sessionId: string, fromConversationId: string, automatic: boolean, project: string | null): Continuation {
   return {
     token: randomBytes(16).toString('base64url'),
     sessionId,
     from: fromConversationId,
+    project,
     openedAt: Date.now(),
+    touchedAt: Date.now(),
+    sourceProgress: 0,
     automatic,
     askedAt: null,
     state: 'awaiting-summary',
@@ -647,7 +714,8 @@ function makeContinuation(sessionId: string, fromConversationId: string, automat
 export async function openContinuationNow(
   sessionId: string,
   fromConversationId: string,
-  automatic = false
+  automatic = false,
+  project: string | null = null
 ): Promise<ContinuationView> {
   sweep();
   const existing = [...byToken.values()].find((entry) => entry.sessionId === sessionId && isOpen(entry));
@@ -658,7 +726,7 @@ export async function openContinuationNow(
   const work = (async (): Promise<ContinuationView> => {
     const again = [...byToken.values()].find((entry) => entry.sessionId === sessionId && isOpen(entry));
     if (again) return view(again);
-    const entry = makeContinuation(sessionId, fromConversationId, automatic);
+    const entry = makeContinuation(sessionId, fromConversationId, automatic, normalizeProjectId(project));
     try {
       await writeDurableNow(CONTINUATIONS_STATE, snapshotWith(entry.token, durableRecord(entry)));
     } catch (err) {
@@ -705,7 +773,7 @@ async function withCheckpointLock<T>(token: string, work: () => Promise<T>): Pro
  * hold the message, and the only honest ends are its own marker or an explicit cancel.
  */
 export async function beginContinuationSourceSendNow(
-  token: string
+  token: string, project?: string | null
 ): Promise<{ allowed: boolean; checkpoint: ContinuationSendCheckpoint } | null> {
   return withCheckpointLock(token, async () => {
     const entry = byToken.get(token);
@@ -718,6 +786,7 @@ export async function beginContinuationSourceSendNow(
     }
     await transitionNow(entry, (current) => ({
       ...current,
+      ...(project !== undefined ? { project: normalizeProjectId(project) } : {}),
       sourceSend: { state: 'attempted-unresolved', messageId: null }
     }));
     return { allowed: true, checkpoint: { ...entry.sourceSend } };
@@ -744,15 +813,25 @@ export async function dispatchContinuationSourceSendNow(token: string): Promise<
 }
 
 /** Binds the marked source prompt to ChatGPT's stable user-message identity. */
-export async function bindContinuationSourceMessageNow(token: string, messageId: string): Promise<boolean> {
+export async function bindContinuationSourceMessageNow(token: string, messageId: string, progress?: number): Promise<boolean> {
   if (!messageId || messageId.length > 200) return false;
   return withCheckpointLock(token, async () => {
     const entry = byToken.get(token);
     if (!entry || !isOpen(entry) || entry.state !== 'awaiting-summary') return false;
-    if (entry.sourceSend.state === 'sent') return entry.sourceSend.messageId === messageId;
+    if (entry.sourceSend.state === 'sent') {
+      if (entry.sourceSend.messageId !== messageId) return false;
+      // Only growth of this exact marked response renews the manual waiting deadline.
+      // Persist at most twice a minute; unchanged snapshots and a spinner alone buy no time.
+      if (!entry.automatic && Number.isSafeInteger(progress) && progress! > entry.sourceProgress &&
+          progress! <= 4_000_000 && Date.now() - entry.touchedAt >= 30_000) {
+        await transitionNow(entry, current => ({ ...current, sourceProgress: progress! }));
+      }
+      return true;
+    }
     if (entry.sourceSend.state !== 'dispatched-unresolved') return false;
     await transitionNow(entry, (current) => ({
       ...current,
+      sourceProgress: Number.isSafeInteger(progress) && progress! >= 0 && progress! <= 4_000_000 ? progress! : 0,
       sourceSend: { state: 'sent', messageId }
     }));
     return true;
@@ -1367,8 +1446,8 @@ export async function restoreContinuations(snapshot: ContinuationSnapshot | null
       raw.from.length === 0 || raw.from.length > 256 ||
       !validStates.has(raw.state) ||
       !Number.isFinite(raw.openedAt) ||
-      ((raw.state === 'committed' || raw.state === 'aborted') && now - raw.openedAt >= CONTINUATION_TTL_MS * 2) ||
-      (raw.automatic !== true && now - raw.openedAt >= CONTINUATION_TTL_MS * 2)
+      ((raw.state === 'committed' || raw.state === 'aborted') && now - (Number.isFinite(raw.touchedAt) && raw.touchedAt! <= now ? raw.touchedAt! : raw.openedAt) >= CONTINUATION_TTL_MS * 2) ||
+      (raw.automatic !== true && now - (Number.isFinite(raw.touchedAt) && raw.touchedAt! <= now ? raw.touchedAt! : raw.openedAt) >= CONTINUATION_TTL_MS * 2)
     ) {
       continue;
     }
@@ -1378,6 +1457,10 @@ export async function restoreContinuations(snapshot: ContinuationSnapshot | null
       from: raw.from,
       to: typeof raw.to === 'string' && raw.to ? raw.to : null,
       openedAt: raw.openedAt,
+      project: normalizeProjectId(raw.project),
+      // Older snapshots have no touch stamp; the open time is the honest floor for them.
+      sourceProgress: Number.isSafeInteger(raw.sourceProgress) && raw.sourceProgress! >= 0 && raw.sourceProgress! <= 4_000_000 ? raw.sourceProgress! : 0,
+      touchedAt: Number.isFinite(raw.touchedAt) && raw.touchedAt! >= raw.openedAt && raw.touchedAt! <= now ? Number(raw.touchedAt) : raw.openedAt,
       automatic: raw.automatic === true,
       askedAt: null,
       state: raw.state,

--- a/src/main/session/finish.ts
+++ b/src/main/session/finish.ts
@@ -8,6 +8,7 @@ import { draftFastFollowup, conversationMessages, automaticFinishEnabled } from 
 import { hasEligibleToolInput, onInputChange, listInputs, enqueueInput } from './input.js';
 
 import { logWarn } from '../logger.js';
+import { retryTaskRequest } from '../task-request.js';
 
 let notify: ((title: string, body: string, sessionId: string, turnId: string) => boolean | void) | null = null;
 export function setFinishNotifier(listener: typeof notify): void { notify = listener; }
@@ -108,15 +109,36 @@ async function prepareNotice(sessionId: string, summary: string, userRequested =
     }
     const anchor = await recordProgress(sessionId, progressId, 'Checking the newly recorded progress for remaining work.', undefined, turnId, { state: 'decision', conversationId: session.conversationId!, revision, inputRevision, workSeq: session.finishTurn?.workSeq ?? 0 });
     if (!anchor) throw new Error('Goal decision could not be recorded; no provider request was made');
+    // This existing operation owns every attempt. User input and turn release revoke it;
+    // transport waits may finish meanwhile, but only the existing input queue delivers.
+    const controller = new AbortController();
+    const knownInputs = new Set(inputs.map(entry => entry.id));
+    const currentDecision = async () => await stillCurrent() && !(await listInputs()).some(entry =>
+      entry.sessionId === sessionId && !entry.finishOwner && !knownInputs.has(entry.id) &&
+      ['queued', 'browser', 'tool', 'sent'].includes(entry.state));
+    const checkDecision = () => { void currentDecision().then(current => {
+      if (!current) controller.abort(new Error('The turn, settings or user instructions changed; the Goal check was discarded.'));
+    }).catch(error => controller.abort(error)); };
+    const stopInput = onInputChange(checkDecision);
+    const stopSession = onSessionChange(checkDecision);
     try {
       let publishedAt = 0;
-      const reply = await draftFastFollowup(sessionId, AbortSignal.timeout(180000), context, text => {
-        if (Date.now() - publishedAt < 250) return;
-        publishedAt = Date.now();
-        draft.stage = 'answering'; draft.text = text.slice(-8000);
-        void recordProgress(sessionId, progressId, `Generating Goal: ${text.slice(-8000)}`, anchor, turnId);
-      }, mode);
-      if (!(await stillCurrent())) result = 'The turn changed; its old Goal follow-up was discarded.';
+      const reply = await retryTaskRequest(async signal => {
+        if (!(await currentDecision())) controller.abort(new Error('The turn, settings or user instructions changed; the Goal check was discarded.'));
+        signal.throwIfAborted();
+        draft.stage = 'sending'; draft.text = '';
+        return draftFastFollowup(sessionId, AbortSignal.any([signal, AbortSignal.timeout(180000)]), context, text => {
+          if (signal.aborted || Date.now() - publishedAt < 250) return;
+          publishedAt = Date.now();
+          draft.stage = 'answering'; draft.text = text.slice(-8000);
+          void recordProgress(sessionId, progressId, `Generating Goal: ${text.slice(-8000)}`, anchor, turnId);
+        }, mode);
+      }, controller.signal, progress => {
+        draft.stage = 'sending';
+        draft.text = `Goal temporarily unavailable (${progress.error}); retrying in ${Math.ceil(((progress.retryAt ?? Date.now()) - Date.now()) / 1000)} seconds.`;
+        void recordProgress(sessionId, progressId, draft.text, anchor, turnId);
+      });
+      if (!(await currentDecision())) result = 'The turn changed or new user instructions took priority; the old Goal follow-up was discarded.';
       else if (reply) {
         if ((await listInputs()).some(entry => entry.sessionId === sessionId && ['queued', 'browser', 'tool'].includes(entry.state))) {
           result = `${notification} New user instructions took priority; the automatic follow-up was discarded.`;
@@ -130,7 +152,7 @@ async function prepareNotice(sessionId: string, summary: string, userRequested =
       }
     } catch (error) {
       result = `${notification} Goal follow-up was not available: ${(error as Error).message}. ${REMAINING}`;
-    }
+    } finally { stopInput(); stopSession(); }
     await recordProgress(sessionId, progressId, result, anchor, turnId);
     return result;
   })();

--- a/src/main/session/input-attachments.ts
+++ b/src/main/session/input-attachments.ts
@@ -1,0 +1,104 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import sharp from 'sharp';
+import { sessionsRoot } from './store.js';
+import type { InputAttachment } from '../../shared/input.js';
+
+export const MAX_ATTACHMENT_BYTES = 512 * 1024 * 1024;
+export const ATTACHMENT_CHUNK_BYTES = 512 * 1024;
+export const attachmentSchema = z.object({ id: z.string().uuid(), name: z.string().min(1).max(255),
+  size: z.number().int().nonnegative().max(MAX_ATTACHMENT_BYTES), mimeType: z.string().max(120).regex(/^[\w.+-]+\/[\w.+-]+$/),
+  preview: z.string().max(32768).regex(/^data:image\/webp;base64,[A-Za-z0-9+/]+={0,2}$/).optional() });
+function directory(): string {
+  const root = sessionsRoot();
+  if (!root) throw new Error('Session storage is not ready');
+  return path.join(path.dirname(root), 'input-attachments');
+}
+function fileFor(id: string): string { return path.join(directory(), z.string().uuid().parse(id)); }
+/** Only explicit file selection, drop or clipboard paste writes here; bytes never inflate the durable outbox. */
+let staging: Promise<unknown> = Promise.resolve();
+export type AttachmentSource = string | { text: string } | { name: string; bytes: Uint8Array };
+export function stageInputAttachment(source: AttachmentSource, retained: Set<string>): Promise<InputAttachment> {
+  const next = staging.then(() => stage(source, retained));
+  staging = next.catch(() => undefined);
+  return next;
+}
+async function stage(source: AttachmentSource, retained: Set<string>): Promise<InputAttachment> {
+  const dir = directory();
+  await fs.mkdir(dir, { recursive: true });
+  let used = 0;
+  for (const name of await fs.readdir(dir)) {
+    if (!/^[a-f0-9-]{36}$/.test(name)) continue;
+    const file = fileFor(name), stat = await fs.stat(file);
+    if (!retained.has(name) && Date.now() - stat.mtimeMs > 24 * 60 * 60 * 1000) {
+      await fs.unlink(file); await fs.unlink(file + '.json').catch(() => undefined);
+    } else used += stat.size;
+  }
+  const stat = typeof source === 'string' ? await fs.stat(source) : null;
+  const size = typeof source === 'string' ? stat!.size : 'text' in source ? Buffer.byteLength(source.text) : source.bytes.byteLength;
+  if (stat && !stat.isFile()) throw new Error('Attach files individually; folders cannot be uploaded');
+  if (size > MAX_ATTACHMENT_BYTES) throw new Error('Each attachment must be 512 MB or smaller');
+  if (used + size > 2 * 1024 * 1024 * 1024) throw new Error('Attachment storage is full; finish or remove pending messages first');
+  const name = typeof source === 'string' ? path.basename(source) : 'text' in source ? 'Attached text.txt' : path.basename(source.name);
+  const types: Record<string, string> = { '.md': 'text/markdown', '.txt': 'text/plain', '.csv': 'text/csv', '.json': 'application/json', '.pdf': 'application/pdf', '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp', '.gif': 'image/gif', '.mp4': 'video/mp4', '.mp3': 'audio/mpeg' };
+  const attachment = attachmentSchema.parse({ id: randomUUID(), name, size, mimeType: types[path.extname(name).toLowerCase()] ?? 'application/octet-stream' });
+  const destination = fileFor(attachment.id);
+  try {
+    if (typeof source === 'string') {
+      // Stream a fixed snapshot with an explicit byte ceiling even if the source grows.
+      const input = await fs.open(source, 'r'), output = await fs.open(destination, 'wx');
+      try {
+        const buffer = Buffer.alloc(ATTACHMENT_CHUNK_BYTES);
+        let offset = 0;
+        while (offset < size) {
+          const { bytesRead } = await input.read(buffer, 0, Math.min(buffer.length, size - offset), offset);
+          if (!bytesRead) throw new Error('The attachment changed while being read; attach it again');
+          let written = 0;
+          while (written < bytesRead) written += (await output.write(buffer, written, bytesRead - written, offset + written)).bytesWritten;
+          offset += bytesRead;
+        }
+        const after = await input.stat();
+        if (after.size !== size || after.mtimeMs !== stat!.mtimeMs) throw new Error('The attachment changed while being read; attach it again');
+      } finally { await input.close(); await output.close(); }
+    } else await fs.writeFile(destination, 'text' in source ? source.text : source.bytes, { flag: 'wx' });
+    if (attachment.mimeType.startsWith('image/') && size <= 12 * 1024 * 1024) {
+      try {
+        const thumbnail = await sharp(destination, { limitInputPixels: 30_000_000, animated: false }).rotate()
+          .resize({ width: 160, height: 160, fit: 'inside', withoutEnlargement: true }).webp({ quality: 60 }).toBuffer();
+        if (thumbnail.length <= 24000) attachment.preview = `data:image/webp;base64,${thumbnail.toString('base64')}`;
+      } catch { /* Preview is presentation only; the original file remains unchanged for native validation. */ }
+    }
+    await fs.writeFile(destination + '.json', JSON.stringify(attachment), { flag: 'wx' });
+    return attachment;
+  } catch (error) { await fs.unlink(destination).catch(() => undefined); throw error; }
+}
+export function validateInputAttachments(attachments: InputAttachment[]): Promise<void> {
+  const next = staging.then(() => validate(attachments));
+  staging = next.catch(() => undefined);
+  return next;
+}
+async function validate(attachments: InputAttachment[]): Promise<void> {
+  if (attachments.length > 20 || attachments.reduce((sum, file) => sum + file.size, 0) > MAX_ATTACHMENT_BYTES) throw new Error('Attach up to 20 files and 512 MB per message');
+  for (const attachment of attachments) {
+    const file = fileFor(attachment.id);
+    const stored = attachmentSchema.parse(JSON.parse(await fs.readFile(file + '.json', 'utf8')));
+    if (JSON.stringify(stored) !== JSON.stringify(attachmentSchema.parse(attachment)) || (await fs.stat(file)).size !== attachment.size) throw new Error('Attachment is missing or changed; attach it again');
+    // Admission renews the draft age under the same lock as pruning; a fresh
+    // outbox commit cannot lose its bytes to an older concurrent cleanup snapshot.
+    const now = new Date(); await fs.utimes(file, now, now);
+  }
+}
+/** Caller must first prove exact claimed input ownership and membership. */
+export async function readInputAttachmentChunk(attachment: InputAttachment, offset: number): Promise<string> {
+  if (!Number.isSafeInteger(offset) || offset < 0 || offset > attachment.size || offset % ATTACHMENT_CHUNK_BYTES !== 0) throw new Error('Invalid attachment offset');
+  const handle = await fs.open(fileFor(attachment.id), 'r');
+  try {
+    if ((await handle.stat()).size !== attachment.size) throw new Error('Attachment changed');
+    const buffer = Buffer.alloc(Math.min(ATTACHMENT_CHUNK_BYTES, attachment.size - offset));
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, offset);
+    if (bytesRead !== buffer.length) throw new Error('Attachment read incomplete');
+    return buffer.toString('base64');
+  } finally { await handle.close(); }
+}

--- a/src/main/session/input-history.ts
+++ b/src/main/session/input-history.ts
@@ -28,6 +28,7 @@ export async function recordDeliveredInput(entry: Readonly<InputEntry>): Promise
     // Browser delivery uses its exact native key, so a later page echo updates this row.
     // Tool delivery has no native user row and keeps the stable input id as its key.
     messageId, inputId: entry.id, inputDelivery: offered ? 'offered' : 'confirmed', authoredText: entry.text,
+    ...(entry.attachments?.length ? { attachments: entry.attachments } : {}),
     // Injection does not change the running model. Only the native send path verifies
     // picker selection before delivery; a later sparse browser echo keeps this evidence.
     ...(!messageId.startsWith('input:') && entry.model

--- a/src/main/session/input-images.ts
+++ b/src/main/session/input-images.ts
@@ -1,19 +1,6 @@
 import sharp from 'sharp';
-import { promises as fs } from 'node:fs';
-import path from 'node:path';
 import type { InputImage } from '../../shared/input.js';
-const MAX_SOURCE_BYTES = 12 * 1024 * 1024;
-export async function prepareInputImage(file: string): Promise<InputImage> {
-  const stat = await fs.stat(file);
-  if (!stat.isFile() || stat.size > MAX_SOURCE_BYTES) throw new Error('Choose an image smaller than 12 MB');
-  const handle = await fs.open(file, 'r');
-  let raw: Buffer;
-  try { const buffer = Buffer.alloc(MAX_SOURCE_BYTES + 1); const read = await handle.read(buffer, 0, buffer.length, 0); if (read.bytesRead > MAX_SOURCE_BYTES) throw new Error('Image is too large'); raw = buffer.subarray(0, read.bytesRead); }
-  finally { await handle.close(); }
-  const encoded = await sharp(raw, { limitInputPixels: 30_000_000, animated: false }).rotate().resize({ width: 1600, height: 1600, fit: 'inside', withoutEnlargement: true }).webp({ quality: 75 }).toBuffer();
-  if (encoded.length > 384000) throw new Error('This image is too complex; choose a smaller image');
-  return { name: path.basename(file).replace(/\.[^.]+$/, '').slice(0, 100) + '.webp', dataUrl: `data:image/webp;base64,${encoded.toString('base64')}` };
-}
+/** Validation for existing normalized-image outbox rows and their recorded assets. */
 export async function validateInputImages(images: InputImage[]): Promise<void> {
   for (const image of images) {
     if (!/^data:image\/webp;base64,[A-Za-z0-9+/]+={0,2}$/.test(image.dataUrl) || image.dataUrl.length > 512100) throw new Error('Invalid image attachment');

--- a/src/main/session/input.ts
+++ b/src/main/session/input.ts
@@ -18,6 +18,7 @@ import { noteChatOrigin } from './recorder.js';
 import { isAstraModel } from '../../shared/chat-models.js';
 import { automaticFinishEnabled } from '../goal.js';
 import { finishInstruction, finishInputInstruction } from '../../shared/finish.js';
+import { attachmentSchema, validateInputAttachments } from './input-attachments.js';
 
 export const inputArgs = z.object({
   projectId: z.string().uuid().nullable().optional(),
@@ -25,6 +26,7 @@ export const inputArgs = z.object({
   objective: z.string().trim().max(16000).optional(),
   stages: z.array(z.string().trim().min(1).max(16000)).max(11).optional(),
   images: z.array(z.object({ name: z.string().min(1).max(110), dataUrl: z.string().max(512100).regex(/^data:image\/webp;base64,[A-Za-z0-9+/]+={0,2}$/) })).max(4).optional(),
+  attachments: z.array(attachmentSchema).max(20).optional(),
   id: z.string().uuid(),
   sessionId: z.string().min(8).max(64).nullable(),
   text: z.string().trim().min(1).max(16000),
@@ -110,6 +112,7 @@ export function hasEligibleToolInput(sessionId: string, finishBoundary = false):
     if (current.some(row => row.sessionId === sessionId && row.state === 'browser')) return false;
     for (const row of current) {
       if (row.sessionId !== sessionId || row.dueAt > Date.now()) continue;
+      if (row.attachments?.length) continue;
       if (row.mode === 'finish' && !finishBoundary) continue;
       if (row.state === 'tool') return true;
       if (row.state === 'queued') return row.mode === 'auto' || (finishBoundary && row.mode === 'finish');
@@ -176,7 +179,7 @@ async function expireQueued(current: InputEntry[]): Promise<InputEntry[]> {
       return { ...row, state: 'failed', error: 'Not sent: the browser did not pick up this message within 60 seconds.' };
     // Native preparation bounds include the 60s upload and 15s picker hydration.
     // Once Send is authorized, its 30s receipt + 15s fresh-route wait are the entire tail.
-    if (row.state === 'browser' && Date.now() - (row.sendAuthorizedAt ?? row.offeredAt ?? row.createdAt) >= (row.sendAuthorizedAt === undefined ? (row.images?.length ? 120_000 : 60_000) : 45_000))
+    if (row.state === 'browser' && Date.now() - (row.sendAuthorizedAt ?? row.offeredAt ?? row.createdAt) >= (row.sendAuthorizedAt === undefined ? (row.attachments?.length ? 720_000 : row.images?.length ? 120_000 : 60_000) : 45_000))
       return { ...row, state: 'cancelled', error: row.requiresAuthorization && row.sendAuthorizedAt === undefined
         ? 'Not sent: browser preparation timed out. This attempt was cancelled.'
         : 'Stopped waiting for delivery confirmation. The message may already have been sent; it will not be resent.' };
@@ -245,7 +248,8 @@ function append(current: InputEntry[], entry: InputEntry, stackDirect = false): 
   if ([...active, entry].reduce((sum, row) => sum + Buffer.byteLength(JSON.stringify({ ...row, images: undefined, stages: reserved(row) })), 0) > 1024000) {
     throw new Error('The message queue is full');
   }
-  const imageBytes = (row: InputEntry): number => (row.images ?? []).reduce((sum, image) => sum + image.dataUrl.length, 0);
+  const imageBytes = (row: InputEntry): number => (row.images ?? []).reduce((sum, image) => sum + image.dataUrl.length, 0) +
+    (row.attachments ?? []).reduce((sum, file) => sum + (file.preview?.length ?? 0), 0);
   if ([...active, entry].reduce((sum, row) => sum + imageBytes(row), 0) > 4 * 1024 * 1024) throw new Error('The image queue is full');
   const history = current.filter((row) => terminal(row) && !needsHistory(row) && !pendingStages(row)).slice(-50);
   const bytes = (row: InputEntry): number => Buffer.byteLength(row.text) + Buffer.byteLength(row.deliveryText ?? '') + Buffer.byteLength(row.response ?? '') + Buffer.byteLength(JSON.stringify(row.stages ?? [])) + imageBytes(row);
@@ -285,12 +289,17 @@ export function enqueueInput(raw: InputArgs, finishOwner?: InputEntry['finishOwn
     }
     const policy = input.sessionId ? await sessionInputPolicy(input.sessionId) : null;
     const requestedMode = input.mode;
-    if (input.mode === 'after-turn' && policy?.queueAtFinish) input.mode = 'finish';
+    if (input.attachments?.length) {
+      await validateInputAttachments(input.attachments);
+      // Native files belong to the next browser message, never a tool-result injection.
+      if (finishOwner) throw new Error('Automatic finish messages cannot attach files');
+      if (input.mode === 'finish' || (input.mode === 'auto' && policy?.canInject)) input.mode = 'after-turn';
+    } else if (input.mode === 'after-turn' && policy?.queueAtFinish) input.mode = 'finish';
     if (input.mode === 'finish' || input.stages?.length) {
       const session = input.sessionId ? await getSession(input.sessionId) : null;
       if ((input.mode === 'finish' && !session?.conversationId) || session?.origin?.kind === 'worker') throw new Error('Queue staged tasks in a normal chat');
     }
-    const transportIntent = input.mode === 'auto' && !finishOwner ? policy?.canInject ? 'tool' as const : 'browser' as const : undefined;
+    const transportIntent = input.attachments?.length ? 'browser' as const : input.mode === 'auto' && !finishOwner ? policy?.canInject ? 'tool' as const : 'browser' as const : undefined;
     const entry: InputEntry = { ...input, ...(transportIntent ? { transportIntent } : {}), ...(requestedMode !== input.mode ? { requestedMode } : {}), ...(finishOwner ? { finishOwner } : {}), state: 'queued', owner: null, createdAt: Date.now(), conversationId: null };
     if (input.projectId) {
       await projectWorkspace(input.projectId);
@@ -605,6 +614,7 @@ export function offerToolInput(sessionId: string | null | undefined, conversatio
     let payloadFull = false;
     const next = ordered(current).sort((a, b) => Number(a.mode === 'finish' || !!a.finishOwner) - Number(b.mode === 'finish' || !!b.finishOwner)).map((entry): InputEntry => {
       if (entry.sessionId !== sessionId || entry.dueAt > Date.now()) return entry;
+      if (entry.attachments?.length) return entry;
       if (entry.state === 'queued' && entry.mode === 'after-turn') waitingForTurn = true;
       // ChatGPT may reuse one request id for the whole server turn. Receipt follows
       // the actual invocation start, never a change in that grouping id.

--- a/src/main/session/progress.ts
+++ b/src/main/session/progress.ts
@@ -1,0 +1,19 @@
+import { statusForCaller } from '../agents.js';
+import { runningToolProgress } from '../mcp/call-context.js';
+
+/** Minimal presentation on the existing activity feed. No tasks, commands or identities leave the app. */
+export function conversationProgress(conversationId: string) {
+  let workers: { total: number; active: number; finished: number; failed: number; names: string[] } | null = null;
+  try {
+    const snapshot = statusForCaller({ conversationId });
+    if (snapshot.self.role === 'prime') {
+      const list = snapshot.state.agents.filter(agent => agent.role === 'worker');
+      const active = list.filter(agent => ['active', 'waking', 'detached'].includes(agent.state));
+      if (list.length) workers = { total: list.length, active: active.length,
+        finished: list.filter(agent => ['sleeping', 'finished'].includes(agent.state)).length,
+        failed: list.filter(agent => agent.state === 'failed').length,
+        names: active.slice(0, 3).map(agent => (agent.label || 'Worker').slice(0, 60)) };
+    }
+  } catch { /* No enabled, exact broker owner means no worker claim for this conversation. */ }
+  return { tools: runningToolProgress(conversationId), workers };
+}

--- a/src/main/session/recorder.ts
+++ b/src/main/session/recorder.ts
@@ -1036,6 +1036,9 @@ const CREDENTIAL_FIELDS = new Set(['secret']);
 function redactArgs(tool: string, args: unknown): unknown {
   if (!args || typeof args !== 'object') return args;
   const copy: Record<string, unknown> = { ...(args as Record<string, unknown>) };
+  // Native file values carry download credentials, not reproducible tool input.
+  // Keep the destination and result for recovery without persisting the URL or file token.
+  if (tool === 'download_artifact' && Object.hasOwn(copy, 'file')) copy['file'] = '<native file credentials not stored>';
   if (copy['env'] && typeof copy['env'] === 'object') {
     copy['env'] = Object.fromEntries(Object.keys(copy['env'] as object).map((key) => [key, '***']));
   }
@@ -1243,8 +1246,19 @@ async function fileToolCall(input: ToolCallInput, target: Target): Promise<ToolC
     // durable first-hand evidence: the bridge stamped it when this app opened and bound the
     // worker chat. Recover only that worker id, never a guessed prime/current agent.
     let eventAgent = input.agent ?? null;
+    let callModel: Pick<ToolCallRecord, 'model' | 'reasoningEffort'> = {};
     if (target.conversationId) {
       const summary = await getSession(sessionId);
+      const selection = summary?.selectedModel;
+      const live = conversations.get(target.conversationId);
+      // Selection evidence must precede this exact turn, not merely arrive before the
+      // tool result is recorded. A user changing next-turn settings cannot reprice the
+      // model still executing the old turn. Unknown/historical calls stay unattributed.
+      if (selection?.conversationId === target.conversationId && live?.turnId === target.turnId &&
+          live.turnStartedAt !== null && live.turnStartedAt !== undefined &&
+          selection.observedAt <= live.turnStartedAt && selection.observedAt <= input.startedAt) {
+        callModel = { model: selection.model, ...(selection.reasoningEffort ? { reasoningEffort: selection.reasoningEffort } : {}) };
+      }
       const origin = summary?.origin;
       if (origin?.kind === 'worker' && origin.agentId && /^worker-\d+$/.test(origin.agentId)) {
         // Request/session ownership is older and stronger than whatever live broker role this
@@ -1277,6 +1291,7 @@ async function fileToolCall(input: ToolCallInput, target: Target): Promise<ToolC
     });
 
     const call: ToolCallRecord = {
+      ...callModel,
       callId: randomUUID(),
       tool: input.tool,
       attribution: target.attribution,

--- a/src/main/session/start-input.ts
+++ b/src/main/session/start-input.ts
@@ -1,30 +1,10 @@
 /** Explicit desktop sends bring up the existing connection/browser authorities. */
 import { connect, getStatus, onStatusChange } from '../connection.js';
-import { bridgeStatus, browserWakeConnected, startBridge } from '../bridge.js';
-import { openInPreferredBrowser } from '../browser.js';
+import { startBridge } from '../bridge.js';
+import { wakeBrowserUrl, resetBrowserStartupForTests } from '../browser-startup.js';
 import { getConfig } from '../config.js';
 import { enqueueInput, cancelInput, listInputs, noteInputStartupError, type InputArgs, type InputEntry } from './input.js';
 
-let waking: { lastSeenAt: number | null; work: Promise<void>; failed: boolean } | null = null;
-/** One browser startup per absence episode, shared by authored sends and read-only discovery. */
-export async function wakeBrowserUrl(url: string, retry = false, backgroundStartup = false): Promise<void> {
-  const browser = await bridgeStatus();
-  // Closing Chrome (including its last helper window) disconnects the live wake
-  // transport immediately while its last HTTP sighting stays "present" for a minute.
-  // Only an authenticated live transport can receive this newly published work.
-  if (browserWakeConnected()) { waking = null; return; }
-  if (retry && waking?.failed) waking = null;
-  // Until the extension registers, another explicit send belongs to the same startup.
-  // Its outbox entry will be discovered by normal maintenance once Chrome is ready.
-  if (waking?.lastSeenAt === browser.lastSeenAt) return waking.work;
-  const work = (async () => {
-    const opened = await (backgroundStartup ? openInPreferredBrowser(url, { backgroundStartup: true }) : openInPreferredBrowser(url));
-    if (!opened) throw new Error('Chrome or Chromium was not found');
-  })();
-  const attempt = { lastSeenAt: browser.lastSeenAt, work, failed: false };
-  waking = attempt;
-  try { await work; } catch (error) { attempt.failed = true; throw error; }
-}
 function wakeBrowser(entry: InputEntry, retry = false): Promise<void> {
   const marker = `cos-input=${encodeURIComponent(entry.id)}`;
   return wakeBrowserUrl(entry.conversationId ? `https://chatgpt.com/c/${encodeURIComponent(entry.conversationId)}` : `https://chatgpt.com/?${marker}#${marker}`, retry, getConfig().ui.backgroundChats === true);
@@ -88,4 +68,4 @@ export async function retryQueuedInputBrowser(id: string): Promise<InputEntry | 
   const entry = (await listInputs()).find(row => row.id === id);
   return eligible(entry) ? deliver(entry, true) : null;
 }
-export function resetInputStartupForTests(): void { waking = null; starting.clear(); }
+export function resetInputStartupForTests(): void { resetBrowserStartupForTests(); starting.clear(); }

--- a/src/main/session/store.ts
+++ b/src/main/session/store.ts
@@ -1047,6 +1047,7 @@ export function upsertMessageEvent(
           : previous?.kind === 'user_message' && event.kind === 'user_message'
             ? { ...event, inputId: event.inputId ?? previous.inputId,
                 authoredText: event.authoredText ?? previous.authoredText,
+                attachments: event.attachments ?? previous.attachments,
                 inputDelivery: previous.inputDelivery === 'confirmed' ? 'confirmed' : event.inputDelivery ?? previous.inputDelivery,
                 model: event.model ?? previous.model,
                 reasoningEffort: event.reasoningEffort ?? previous.reasoningEffort,
@@ -1085,7 +1086,7 @@ export function upsertMessageEvent(
             previous.goalEligible === nextEvent.goalEligible &&
             previous.providerMessageId === nextEvent.providerMessageId)) &&
         (nextEvent.kind !== 'user_message' || previous.kind !== 'user_message' ||
-          (nextEvent.inputId === previous.inputId && nextEvent.authoredText === previous.authoredText && nextEvent.inputDelivery === previous.inputDelivery && JSON.stringify(nextEvent.assets) === JSON.stringify(previous.assets))) &&
+          (nextEvent.inputId === previous.inputId && nextEvent.authoredText === previous.authoredText && nextEvent.inputDelivery === previous.inputDelivery && JSON.stringify(nextEvent.assets) === JSON.stringify(previous.assets) && JSON.stringify(nextEvent.attachments) === JSON.stringify(previous.attachments))) &&
         (previous.turnId ?? undefined) === settledTurnId &&
         (nextEvent.agent === undefined || previous.agent === nextEvent.agent) &&
         (!preferTime || previous.time === nextEvent.time)

--- a/src/main/task-request.ts
+++ b/src/main/task-request.ts
@@ -11,13 +11,39 @@ export function cancelTaskRequest(id: string): boolean {
   if (!request || request.settled) return false;
   request.controller.abort(); return true;
 }
-function wait(ms: number, signal: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const aborted = () => { clearTimeout(timer); signal.removeEventListener('abort', aborted); reject(new Error('task_cancelled')); };
-    const timer = setTimeout(() => { signal.removeEventListener('abort', aborted); resolve(); }, ms);
-    signal.addEventListener('abort', aborted, { once: true });
-    if (signal.aborted) aborted();
-  });
+async function wait(ms: number, signal: AbortSignal): Promise<void> {
+  // Node clamps an overflowing timeout to 1 ms. Long Retry-After values must wait,
+  // not turn a provider's backoff into an immediate request loop.
+  while (ms > 0) {
+    const interval = Math.min(ms, 2147483647);
+    await new Promise<void>((resolve, reject) => {
+      const aborted = () => { clearTimeout(timer); signal.removeEventListener('abort', aborted); reject(new Error('task_cancelled')); };
+      const timer = setTimeout(() => { signal.removeEventListener('abort', aborted); resolve(); }, interval);
+      signal.addEventListener('abort', aborted, { once: true });
+      if (signal.aborted) aborted();
+    });
+    ms -= interval;
+  }
+}
+/** Retry only classified pre-delivery failures; the caller owns cancellation and publication. */
+export async function retryTaskRequest<T>(work: (signal: AbortSignal) => Promise<T>, signal: AbortSignal,
+  publish: (progress: TaskProgressUpdate) => void,
+  limits: { attempts: number; durationMs: number } = { attempts: Infinity, durationMs: Infinity }): Promise<T> {
+  const startedAt = Date.now();
+  for (let attempt = 1; ; attempt++) {
+    signal.throwIfAborted();
+    try {
+      const result = await work(signal);
+      signal.throwIfAborted();
+      return result;
+    } catch (error) {
+      signal.throwIfAborted();
+      const delay = error instanceof TaskRequestError ? Math.max(1000, error.retryAfterMs ?? 15000) : 0;
+      if (!(error instanceof TaskRequestError) || !error.retryable || attempt >= limits.attempts || Date.now() + delay - startedAt > limits.durationMs) throw error;
+      publish({ phase: 'retrying', text: '', error: error.message, attempt: attempt + 1, retryAt: Date.now() + delay });
+      await wait(delay, signal);
+    }
+  }
 }
 export function runTaskRequest<T>(id: string, fingerprint: string, work: (signal: AbortSignal) => Promise<T>,
   publish: (progress: TaskProgressUpdate) => void): Promise<T> {
@@ -25,27 +51,15 @@ export function runTaskRequest<T>(id: string, fingerprint: string, work: (signal
   if (previous) return previous.fingerprint === fingerprint ? previous.promise as Promise<T> : Promise.reject(new Error('task_request_conflict'));
   for (const [key, request] of requests) { if (requests.size < 64) break; if (request.settled) requests.delete(key); }
   if (requests.size >= 64) return Promise.reject(new Error('too_many_task_requests'));
-  const controller = new AbortController(), startedAt = Date.now();
+  const controller = new AbortController();
   const row: Request = { fingerprint, controller, promise: Promise.resolve(), settled: false };
   requests.set(id, row);
   row.promise = (async () => {
     try {
-      for (let attempt = 1; ; attempt++) {
-        if (controller.signal.aborted) throw new Error('task_cancelled');
-        try {
-          const result = await work(controller.signal);
-          if (controller.signal.aborted) throw new Error('task_cancelled');
-          return result;
-        } catch (error) {
-          if (controller.signal.aborted) throw new Error('task_cancelled');
-          const delay = error instanceof TaskRequestError ? Math.max(1000, error.retryAfterMs ?? 15000) : 0;
-          if (!(error instanceof TaskRequestError) || !error.retryable || attempt >= 3 || Date.now() + delay - startedAt > 180000) throw error;
-          publish({ phase: 'retrying', text: '', error: error.message, attempt: attempt + 1, retryAt: Date.now() + delay });
-          await wait(delay, controller.signal);
-        }
-      }
+      return await retryTaskRequest(work, controller.signal, publish, { attempts: 3, durationMs: 180000 });
     } catch (error) {
       publish({ phase: controller.signal.aborted ? 'cancelled' : 'failed', text: '', error: error instanceof Error ? error.message : 'task_failed' });
+      if (controller.signal.aborted) throw new Error('task_cancelled');
       throw error;
     } finally { row.settled = true; }
   })();

--- a/src/main/tunnel/health.ts
+++ b/src/main/tunnel/health.ts
@@ -54,7 +54,9 @@ export function readMetric(text: string, name: string): number | null {
     // Must be the whole name: `commands_poll_cycles` must not match `..._total`.
     const rest = trimmed.slice(name.length);
     if (rest !== '' && rest[0] !== ' ' && rest[0] !== '{') continue;
-    const value = Number(rest.replace(/^\{[^}]*\}/, '').trim().split(/\s+/)[0]);
+    const sample = rest.replace(/^\{[^}]*\}/, '').trim().split(/\s+/)[0];
+    if (!sample) continue;
+    const value = Number(sample);
     if (!Number.isFinite(value)) continue;
     total = (total ?? 0) + value;
   }
@@ -86,7 +88,9 @@ export function parsePollHealth(metrics: string): PollHealth {
 
 export async function readPollHealth(base: string, timeoutMs = 3000): Promise<PollHealth | null> {
   const text = await fetchText(`${base}/metrics`, timeoutMs);
-  return text === null ? null : parsePollHealth(text);
+  // A readable endpoint without the poll timestamp is still unknown, not the
+  // explicit zero that means a healthy client is awaiting its first poll.
+  return text === null || readMetric(text, 'commands_poll_last_successful_timestamp_seconds') === null ? null : parsePollHealth(text);
 }
 
 export function parseClientStatus(raw: unknown): ClientStatus {

--- a/src/main/tunnel/index.ts
+++ b/src/main/tunnel/index.ts
@@ -104,22 +104,26 @@ const AUTH_FAILURE = /\b(401|403|unauthorized|invalid[_ ]api[_ ]key|invalid_requ
  * a local health check that stays green throughout an outage, because from its point
  * of view nothing local has failed.
  */
-const UNREACHABLE =
-  /poll (?:failed|timed out)|no such host|dial tcp|i\/o timeout|connection (was )?(aborted|refused|reset)|network is (unreachable|down)|no route to host|tls handshake timeout|temporary failure in name resolution|forcibly closed/i;
+const CONTROL_PLANE_POLL = /\bpoll (?:failed|timed out(?:;\s*backing off)?)\b/i;
+const UNREACHABLE_NETWORK =
+  /no such host|dial tcp|i\/o timeout|timed out|context deadline exceeded|connection (was )?(aborted|refused|reset)|network is (unreachable|down)|no route to host|tls handshake timeout|temporary failure in name resolution|forcibly closed/i;
 
 /** Turns a Go network error into something worth showing a person. */
 export function describeNetworkError(raw: string): string {
   if (/no such host|name resolution/i.test(raw)) return 'no internet connection';
   if (/connection (was )?(aborted|reset)|forcibly closed/i.test(raw)) return 'the connection dropped';
   if (/refused/i.test(raw)) return 'the connection was refused';
-  if (/timeout/i.test(raw)) return 'the connection timed out';
+  if (/timeout|timed out|context deadline exceeded/i.test(raw)) return 'the connection timed out';
   if (/network is (unreachable|down)|no route to host/i.test(raw)) return 'the network is unreachable';
   return 'a network error';
 }
 
 /** True when this machine can still resolve OpenAI's control plane. */
 export function isUnreachableError(raw: string): boolean {
-  return UNREACHABLE.test(raw);
+  const text = String(raw || '');
+  // A bare Go timeout can come from the local MCP startup probe too. Only the tunnel
+  // client's control-plane poll context is allowed to classify OpenAI as unreachable.
+  return CONTROL_PLANE_POLL.test(text) && UNREACHABLE_NETWORK.test(text);
 }
 
 export async function startTunnel(opts: TunnelStartOptions): Promise<TunnelHandle> {
@@ -524,7 +528,7 @@ async function startOpenAiTunnel(opts: TunnelStartOptions): Promise<TunnelHandle
         if (level === 'ERROR' || level === 'FATAL' || level === 'WARN') {
           const errText = event['error'] ? String(event['error']) : '';
           run.lastError = `${level} ${message}${errText ? `: ${errText}` : ''}`.slice(0, 400);
-          if (isUnreachableError(message) || isUnreachableError(errText)) {
+          if (isUnreachableError(`${message}: ${errText}`)) {
             // Retry chatter. noteUnreachable logs one plain line per run rather than a
             // socket dump per attempt, and the state it leads to is decided in `watch`.
             noteUnreachable(run, errText || message);
@@ -607,6 +611,7 @@ async function startOpenAiTunnel(opts: TunnelStartOptions): Promise<TunnelHandle
     }
   };
 }
+
 
 async function readHealthUrl(file: string): Promise<string | null> {
   try {

--- a/src/main/version.ts
+++ b/src/main/version.ts
@@ -12,7 +12,7 @@
  * extension does nothing" into a diagnosable mismatch.
  */
 
-export const APP_VERSION = '2.0.6';
+export const APP_VERSION = '2.0.7';
 
 /**
  * Standalone extension recovery must stay on the app's own release. Using GitHub's moving
@@ -64,4 +64,6 @@ export function extensionDownloadUrl(version = APP_VERSION): string {
  *      An 11 peer reads the new field as absent and quietly stops repairing anything at all,
  *      which is exactly the silent failure this fence exists to turn into a 426.
  */
-export const BRIDGE_PROTOCOL = 12;
+// 13 — native file attachments require exact claimed-input chunk delivery and final
+// draft ownership. A 12 companion would silently send text without these files.
+export const BRIDGE_PROTOCOL = 13;

--- a/src/main/window-lifecycle.ts
+++ b/src/main/window-lifecycle.ts
@@ -78,3 +78,22 @@ export function registerNativeWindowActivation(
 ): void {
   if (platform === 'darwin') source.on('activate', showWindow);
 }
+
+/** Login launch is distinct from tunnel auto-connect and ordinary app activation. */
+export function isBackgroundLaunch(argv: readonly string[]): boolean {
+  return argv.includes('--background');
+}
+
+export function supportsLoginStartup(platform: NodeJS.Platform, packaged: boolean): boolean {
+  return platform === 'win32' && packaged;
+}
+
+export function applyLoginStartup(
+  app: { isPackaged: boolean; setLoginItemSettings(settings: { openAtLogin: boolean; path: string; args: string[] }): void },
+  enabled: boolean,
+  platform: NodeJS.Platform = process.platform,
+  executable = process.execPath
+): void {
+  if (!supportsLoginStartup(platform, app.isPackaged)) return;
+  app.setLoginItemSettings({ openAtLogin: enabled, path: executable, args: ['--background'] });
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,7 +2,7 @@ import type { ChatModelCatalog } from '../shared/chat-models.js';
 import type { TaskProgress } from '../shared/task-progress.js';
 import type { BrowserPreferences } from '../shared/browser-preferences.js';
 import type { SessionControlsView } from '../main/bridge.js';
-import type { InputImage } from '../shared/input.js';
+import type { InputAttachment } from '../shared/input.js';
 import type { UsageOverview } from '../shared/usage.js';
 import type { InputArgs, InputEntry } from '../main/session/input.js';
 import type { LocalProject } from '../shared/projects.js';
@@ -39,9 +39,10 @@ export interface SettingsPatch {
   compaction: Config['compaction'];
   multiAgent: Config['multiAgent'];
   goal: Config['goal'];
+  mcp: Config['mcp'];
 }
 
-/** One page of the OpenRouter catalogue, as the model picker asks for it. */
+/** One page of the model catalogue, as the model picker asks for it. */
 export interface GoalModelPage {
   models: Array<{ id: string; name: string; created: number; contextLength: number }>;
   total: number;
@@ -72,8 +73,20 @@ export interface SessionDetail {
 }
 
 const api = {
-  chooseImages: () => call<InputImage[]>('sessions:images'),
-  dropImages: (files: File[]) => call<InputImage[]>('sessions:dropImages', { paths: files.map(file => webUtils.getPathForFile(file)) }),
+  chooseFiles: () => call<InputAttachment[]>('sessions:files'),
+  dropFiles: async (files: File[]): Promise<Reply<InputAttachment[]>> => {
+    if (!files.length || files.length > 20) return { ok: false, error: 'Attach up to 20 files per message' };
+    try {
+      const sources = [];
+      for (const file of files) {
+        const path = webUtils.getPathForFile(file);
+        if (!path && file.size > 12 * 1024 * 1024) return { ok: false, error: 'Pasted images must be 12 MB or smaller' };
+        sources.push(path || { name: file.name, bytes: new Uint8Array(await file.arrayBuffer()) });
+      }
+      return await call<InputAttachment[]>('sessions:dropFiles', { files: sources });
+    } catch { return { ok: false, error: 'Could not read the attachment' }; }
+  },
+  attachText: (text: string) => call<InputAttachment>('sessions:attachText', { text }),
   getUsage: () => call<UsageOverview>('usage:get'),
   getState: () => call<AppState>('state:get'),
   saveSettings: (patch: SettingsPatch, base: SettingsPatch) => call<AppState>('settings:save', { patch, base }),
@@ -85,6 +98,8 @@ const api = {
   setApiKey: (value: string) => call<AppState>('secret:set', { value }),
   // The goal loop's own credential. Same channel, named slot; the value only ever goes in.
   setGoalKey: (value: string) => call<AppState>('secret:set', { value, key: 'openRouterApiKey' }),
+  // The same, for a custom provider endpoint. Optional: keyless local servers need nothing stored.
+  setCustomProviderKey: (value: string) => call<AppState>('secret:set', { value, key: 'customProviderApiKey' }),
   listGoalModels: (offset: number) => call<GoalModelPage>('goal:models', { offset }),
   pickBinary: () => call<AppState>('binary:pick'),
   connect: () => call<AppState>('connection:connect'),

--- a/src/renderer/chat-models.ts
+++ b/src/renderer/chat-models.ts
@@ -34,15 +34,13 @@ export function applyComposerSessionModel(scope: string | null, observation: Obs
   paintComposerContext(); paintStatus();
 }
 
-/** Composer scope is Sol through Astra, with only observed non-Instant power levels. */
+/** Provider order and available efforts define the slider, including newly released models. */
 function composerModels() {
   if (catalog.state !== 'ready') return [];
-  const rank = (label: string) => /^gpt[ -]?5\.6(?:[ -](?:sol|pro))?$/i.test(label) ? 0
-    : /^(?:gpt[ -]?6(?:\.0)?(?:[ -](?:pro|astra))?|astra)$/i.test(label) ? 1 : -1;
-  return catalog.models.filter(model => rank(model.label) >= 0)
+  return catalog.models
+    .filter(model => !/^gpt[ -]?5\.5(?:$|[ -])/i.test(model.label))
     .map(model => ({ ...model, efforts: composerEfforts.filter(effort => model.efforts.includes(effort)) }))
-    .filter(model => model.efforts.length > 0)
-    .sort((a, b) => rank(a.label) - rank(b.label));
+    .filter(model => model.efforts.length > 0);
 }
 
 function options(select: HTMLSelectElement, choices: Array<{ id: string; label: string }>, value: string): void {
@@ -94,7 +92,7 @@ function paintComposerChoices(): void {
   const selected = $<HTMLSelectElement>('composerModel');
   const effort = $<HTMLSelectElement>('composerReasoning');
   const choices = composerModels();
-  const signature = JSON.stringify([choices, selected.value, effort.value]);
+  const signature = JSON.stringify([catalog.state, choices, selected.value, effort.value]);
   if (models.dataset.signature === signature) return;
   models.dataset.signature = signature;
   models.replaceChildren();
@@ -106,8 +104,8 @@ function paintComposerChoices(): void {
   const title = document.getElementById('composerPowerTitle');
   const subtitle = document.getElementById('composerPowerModel');
   if (!steps.length) {
-    if (title) title.textContent = 'No supported choices';
-    if (subtitle) subtitle.textContent = 'Reload models';
+    if (title) title.textContent = catalog.state === 'pending' ? 'Loading models…' : 'Models unavailable';
+    if (subtitle) subtitle.textContent = catalog.state === 'pending' ? 'Reading your ChatGPT account' : 'Reload models';
     return;
   }
   const current = steps.findIndex(step => step.model === selected.value && step.effort === effort.value);
@@ -136,7 +134,7 @@ function paintComposerChoices(): void {
     const step = show();
     paintPair('composerModel', 'composerReasoning', step.model, step.effort);
     paintComposerLabel();
-    models.dataset.signature = JSON.stringify([choices, selected.value, effort.value]);
+    models.dataset.signature = JSON.stringify([catalog.state, choices, selected.value, effort.value]);
   };
   slider.oninput = choose;
   slider.onclick = () => { if (current < 0) choose(); };
@@ -181,7 +179,8 @@ function paintStatus(): void {
   for (const id of ['refreshChatModels', 'refreshComposerModels']) {
     const button = document.getElementById(id) as HTMLButtonElement | null;
     if (button) {
-      button.disabled = catalog.state === 'pending';
+      // Refresh can promote passive discovery; main coalesces repeated explicit clicks.
+      button.disabled = false;
       if (id === 'refreshComposerModels') {
         button.hidden = false;
         button.title = catalog.state === 'pending' ? 'Reading ChatGPT models' : 'Reload ChatGPT models';
@@ -213,7 +212,7 @@ export function applyChatModels(config: Config, previous?: Config): void {
 export function initChatModels(onPaint?: () => void): void {
   onComposerPaint = onPaint;
   document.getElementById('modelMenu')?.addEventListener('toggle', () => {
-    if (($('modelMenu') as HTMLDetailsElement).open && catalog.state !== 'ready' && catalog.state !== 'pending') $('refreshComposerModels').click();
+    if (($('modelMenu') as HTMLDetailsElement).open && catalog.state !== 'ready') $('refreshComposerModels').click();
   });
   for (const [modelId, effortId] of pairs) {
     document.getElementById(modelId)?.addEventListener('change', () => {

--- a/src/renderer/chat.ts
+++ b/src/renderer/chat.ts
@@ -5,7 +5,7 @@ import { preserveTimelineViewport } from './timeline-scroll.js';
 import { communicationTitle, foldAgentCommunication } from './agent-communication.js';
 import { initContextMeter, paintContextMeter } from './context-meter.js';
 import { isAstraModel } from '../shared/chat-models.js';
-import type { InputImage, InputAutomation } from '../shared/input.js';
+import type { InputImage, InputAttachment, InputAutomation } from '../shared/input.js';
 import type { InputEntry } from '../main/session/input.js';
 import type { LocalProject } from '../shared/projects.js';
 import type { TaskProgress } from '../shared/task-progress.js';
@@ -35,6 +35,7 @@ import {
 } from '../shared/session.js';
 import { chronological } from '../shared/chronology.js';
 import {
+  DEFAULT_GOAL_MODEL,
   DEFAULT_GOAL_LOOP_SYSTEM_PROMPT,
   DEFAULT_GOAL_OBJECTIVE_SYSTEM_PROMPT,
   DEFAULT_GOAL_SYSTEM_PROMPT,
@@ -119,7 +120,7 @@ let pendingNewInput: { id: string; generation: number } | null = null;
 let agentPanel: ReturnType<typeof createAgentPanel> | null = null;
 const expandedWorkers = new Set<string>();
 const inputDrafts = new Map<string, string>();
-const imageDrafts = new Map<string, InputImage[]>();
+const imageDrafts = new Map<string, Array<InputImage | InputAttachment>>();
 const startingInputs = new Map<string, InputEntry>();
 const visibleInputIds = new Set<string>();
 // Window-local presentation only: a new incident or changed status is visible again.
@@ -145,13 +146,29 @@ function paintComposerImages(): void {
   const images = imageDrafts.get(key) ?? [];
   const box = $('composerImages'); box.hidden = !images.length; box.replaceChildren();
   images.forEach((image, index) => {
-    const tile = el('div', 'composer-image');
-    const preview = document.createElement('img'); preview.src = image.dataUrl; preview.alt = image.name;
+    const tile = 'dataUrl' in image ? el('div', 'composer-image') : attachmentCard(image);
+    if ('dataUrl' in image) { const preview = document.createElement('img'); preview.src = image.dataUrl; preview.alt = image.name; tile.append(preview); }
     const remove = el('button', 'image-remove', '×'); remove.setAttribute('type', 'button'); remove.setAttribute('aria-label', `Remove ${image.name}`);
     remove.addEventListener('click', () => { imageDrafts.set(key, images.filter((_entry, at) => at !== index)); paintComposerImages(); });
-    tile.append(preview, remove); box.append(tile);
+    tile.append(remove); box.append(tile);
   });
   paintDeliveryControls();
+}
+function attachmentCard(file: InputAttachment): HTMLElement {
+  if (file.preview) { const tile = el('div', 'composer-image'); tile.title = file.name;
+    const image = document.createElement('img'); image.src = file.preview; image.alt = file.name; tile.append(image); return tile; }
+  const tile = el('div', 'attachment-card'); tile.title = file.name;
+  const glyph = el('span', 'attachment-icon');
+  glyph.setAttribute('aria-hidden', 'true');
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24'); svg.setAttribute('width', '24'); svg.setAttribute('height', '24');
+  const lines = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  lines.setAttribute('d', 'M7 3h10a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V6a3 3 0 0 1 3-3Zm1 6h8M8 13h8M8 17h5');
+  lines.setAttribute('fill', 'none'); lines.setAttribute('stroke', 'currentColor'); lines.setAttribute('stroke-width', '1.6'); lines.setAttribute('stroke-linecap', 'round');
+  svg.append(lines); glyph.append(svg);
+  const details = el('div', 'attachment-details');
+  details.append(el('div', 'attachment-name', file.name), el('div', 'attachment-kind', file.mimeType.startsWith('image/') ? 'Image' : 'File'));
+  tile.append(glyph, details); return tile;
 }
 
 let events: SessionEvent[] = [];
@@ -179,6 +196,7 @@ let handoff: Handoff | null = null;
 let handoffFor: string | null = null;
 
 let listTimer: number | undefined;
+let listRefreshDirty = false;
 let toolActivityTimer: number | undefined;
 let sessionsLoadGeneration = 0;
 let detailLoadGeneration = 0;
@@ -892,7 +910,7 @@ async function sendPreparedPlan(): Promise<void> {
   plan.sending = true; paintPreparedPlan();
   try {
     const sent = await sendComposer(undefined, tasks);
-    if (preparedPlan === plan && sent) cancelTaskPlan();
+    if (preparedPlan === plan && sent) { await refreshInputQueue(); if (preparedPlan === plan) cancelTaskPlan(); }
   } finally {
     if (preparedPlan === plan) { plan.sending = false; paintPreparedPlan(); paintDeliveryControls(); }
   }
@@ -1283,6 +1301,7 @@ function eventBody(event: SessionEvent, context?: { id: string; current: () => b
     case 'user_message': {
       const box = el('div', 'said is-user');
       box.append(el('b', '', 'You'));
+      if (event.attachments?.length) { const files = el('div', 'message-attachments'); files.append(...event.attachments.map(attachmentCard)); box.append(files); }
       box.append(textBlock('msg', event.authoredText ?? event.message.text, event.authoredText === undefined && event.message.truncated, event.authoredText?.length ?? event.message.chars));
       if (event.inputDelivery) {
         box.classList.add('has-input-receipt');
@@ -2155,6 +2174,7 @@ export function chatSettingsPatch(current: Config): {
   compaction: Config['compaction'];
   multiAgent: Config['multiAgent'];
   goal: Config['goal'];
+  mcp: Config['mcp'];
 } {
   const number = (id: string, fallback: number, min: number, max: number): number => {
     const raw = Number($<HTMLInputElement>(id).value);
@@ -2191,9 +2211,17 @@ export function chatSettingsPatch(current: Config): {
       loopBackend: $<HTMLSelectElement>('loopBackend').value as Config['goal']['loopBackend'],
       helperModel: $<HTMLSelectElement>('helperModel').value || current.goal.helperModel || 'gpt-5.6-sol',
       helperReasoning: ($<HTMLSelectElement>('helperReasoning').value || current.goal.helperReasoning || 'high') as Config['goal']['helperReasoning'],
-      // The chosen model is held here rather than in an input, because it is picked from a
-      // list and never typed. `current` is the fallback for the first save after a repaint.
-      model: goalModel || current.goal.model,
+      provider: {
+        kind: ($<HTMLSelectElement>('goalProvider').value || current.goal.provider?.kind || 'openrouter') as Config['goal']['provider']['kind'],
+        baseUrl: $<HTMLInputElement>('goalBaseUrl').value
+      },
+      // The api-backend model is picked from the catalogue and never typed, except on a
+      // custom endpoint whose id is typed in its own field instead. `current` is the
+      // fallback for the first save after a repaint.
+      model:
+        $<HTMLSelectElement>('goalProvider').value === 'custom'
+          ? $<HTMLInputElement>('goalCustomModel').value.trim() || current.goal.model
+          : goalModel || current.goal.model,
       reasoning: $<HTMLSelectElement>('goalReasoning').value as Config['goal']['reasoning'],
       // Blank means "restore the safe default", not "send an unconstrained system message".
       prompt: $<HTMLTextAreaElement>('goalPrompt').value.trim() || DEFAULT_GOAL_SYSTEM_PROMPT,
@@ -2202,7 +2230,9 @@ export function chatSettingsPatch(current: Config): {
         DEFAULT_GOAL_OBJECTIVE_SYSTEM_PROMPT,
       loopPrompt:
         $<HTMLTextAreaElement>('goalLoopPrompt').value.trim() || DEFAULT_GOAL_LOOP_SYSTEM_PROMPT
-    }
+    },
+    // Empty is a real choice here, not a value to repair: it means "add nothing of mine".
+    mcp: { instructions: $<HTMLTextAreaElement>('mcpInstructions').value.trim() }
   };
 }
 
@@ -2215,7 +2245,7 @@ export function chatSettingsPatch(current: Config): {
  * loaded most of the time: an `<input>` would have to hold an id nobody typed, and a
  * `<select>` would have to hold several hundred options nobody asked for.
  */
-let goalModel = '';
+let goalModel = DEFAULT_GOAL_MODEL;
 /** The catalogue as far as it has been paged in, and how long it actually is. */
 let goalModels: Array<{ id: string; name: string; created: number; contextLength: number }> = [];
 let goalTotal = 0;
@@ -2329,9 +2359,13 @@ function applyGoal(state: AppState, previous?: Config): void {
   automation.title = config.sessions.record ? 'Continue this chat automatically' : 'Enable session recording to use Goal or Loop';
   paintAutomationSwitch();
   const secureStorageAvailable = state.secureStorage?.available ?? true;
-  goalModel = config.goal.model;
+  // This picker owns the last known OpenRouter selection. A custom deployment uses
+  // its own input and must not replace that selection during an unrelated repaint.
+  // A session opened directly on custom starts with the picker's defined default.
+  if (config.goal.provider?.kind !== 'custom') goalModel = config.goal.model;
   applyChatValue($<HTMLSelectElement>('goalReasoning'), config.goal.reasoning, previous?.goal.reasoning);
   applyChatValue($<HTMLTextAreaElement>('goalPrompt'), config.goal.prompt, previous?.goal.prompt);
+  applyChatValue($<HTMLTextAreaElement>('mcpInstructions'), config.mcp?.instructions ?? '', previous?.mcp?.instructions);
   applyChatValue(
     $<HTMLTextAreaElement>('goalObjectivePrompt'),
     config.goal.objectivePrompt,
@@ -2342,6 +2376,17 @@ function applyGoal(state: AppState, previous?: Config): void {
     config.goal.loopPrompt,
     previous?.goal.loopPrompt
   );
+  // Which endpoint the api backend talks to. The key sentence below only applies to
+  // OpenRouter: a custom endpoint is often keyless, so a missing key never means custom.
+  const customProvider = config.goal.provider?.kind === 'custom';
+  const providerBaseUrl = config.goal.provider?.baseUrl ?? '';
+  applyChatValue($<HTMLSelectElement>('goalProvider'), customProvider ? 'custom' : 'openrouter', previous?.goal.provider?.kind);
+  applyChatValue($<HTMLInputElement>('goalBaseUrl'), providerBaseUrl, previous?.goal.provider?.baseUrl);
+  applyChatValue($<HTMLInputElement>('goalCustomModel'), config.goal.model, previous?.goal.model);
+  $('goalCustomPanel').hidden = !customProvider;
+  $('goalPickerRow').hidden = customProvider;
+  if (customProvider) $('goalModels').hidden = true;
+  $('goalKeyField').hidden = customProvider;
   $('goalModelName').textContent = config.goal.model;
   const goalKey = $<HTMLInputElement>('goalKey');
   goalKey.placeholder = state.hasGoalKey ? '•••••••• stored' : 'sk-or-v1-…';
@@ -2353,6 +2398,16 @@ function applyGoal(state: AppState, previous?: Config): void {
       : 'Stored with secure OS credential storage. It never leaves this app, and the browser is only ever handed the reply.';
   $('goalKeyState').classList.toggle('is-warn', !secureStorageAvailable);
   $<HTMLButtonElement>('goalKeyRemove').disabled = !state.hasGoalKey || !secureStorageAvailable;
+  const goalCustomKey = $<HTMLInputElement>('goalCustomKey');
+  goalCustomKey.placeholder = state.hasCustomProviderKey ? '•••••••• stored' : 'leave empty for a keyless local server';
+  goalCustomKey.disabled = !secureStorageAvailable;
+  $('goalCustomKeyState').textContent = !secureStorageAvailable
+    ? (state.secureStorage?.detail ?? 'Secure credential storage is unavailable.')
+    : state.hasCustomProviderKey
+      ? 'A key is stored with secure OS credential storage. Type a new one to replace it.'
+      : 'Optional. Stored with secure OS credential storage and sent only by the app to your configured API endpoint. The browser receives only the reply.';
+  $('goalCustomKeyState').classList.toggle('is-warn', !secureStorageAvailable);
+  $<HTMLButtonElement>('goalCustomKeyRemove').disabled = !state.hasCustomProviderKey || !secureStorageAvailable;
   if (goalModels.length > 0) paintGoalModels();
 }
 
@@ -2437,6 +2492,27 @@ function wireGoal(save: () => Promise<void>): void {
       toast('OpenRouter key removed');
     }
   });
+  // Same blur-to-save discipline as the OpenRouter key above. Empty submits nothing:
+  // a keyless local endpoint is a supported configuration, not a key being removed.
+  $('goalCustomKey').addEventListener('blur', async () => {
+    const input = $<HTMLInputElement>('goalCustomKey');
+    const submitted = input.value;
+    const key = submitted.trim();
+    if (key === '') return;
+    const next = await run(api.setCustomProviderKey(key));
+    if (next) {
+      if (input.value === submitted) input.value = '';
+      applyGoal(next);
+      toast('Custom provider key stored');
+    }
+  });
+  $('goalCustomKeyRemove').addEventListener('click', async () => {
+    const next = await run(api.setCustomProviderKey(''));
+    if (next) {
+      applyGoal(next);
+      toast('Custom provider key removed');
+    }
+  });
 }
 
 /**
@@ -2459,9 +2535,10 @@ function applyAutoCompactHint(config: Config): void {
  * every other switch that decides what ChatGPT can reach, and saves from there.
  */
 const CHAT_INPUTS = [
+  'chatBrowser',
   'goalIncludeToolCalls',
   'planBackend',
-  'finishTool', 'finishAction', 'finishLeadMinutes', 'workerModel', 'workerReasoning', 'backgroundChats',
+  'finishTool', 'finishAction', 'finishLeadMinutes', 'workerModel', 'workerReasoning', 'backgroundChats', 'browserOnly', 'autoRefreshPlugins',
   'goalBackend',
   'loopBackend',
   'helperModel', 'helperReasoning',
@@ -2471,10 +2548,14 @@ const CHAT_INPUTS = [
   'maWorkers',
   'allowUnattributedCalls',
   'recoverAgentTabs',
+  'goalProvider',
+  'goalBaseUrl',
+  'goalCustomModel',
   'goalReasoning',
   'goalPrompt',
   'goalObjectivePrompt',
-  'goalLoopPrompt'
+  'goalLoopPrompt',
+  'mcpInstructions'
 ];
 
 /** Writes app state into this panel's controls. Called from the renderer's apply(). */
@@ -2558,9 +2639,16 @@ async function refreshAll(): Promise<void> {
 /** Sessions change on every recorded event, so the reload is coalesced. */
 function scheduleReload(): void {
   if (!visible) return;
-  // Continuous streaming must not starve the receipt that selects a new chat.
-  if (listTimer !== undefined) return;
-  listTimer = window.setTimeout(() => { listTimer = undefined; void loadSessions(); }, 400);
+  // One refresh owns the timer until its asynchronous read completes. Starting a
+  // newer read every 400 ms can invalidate every result on a busy/slower store.
+  if (listTimer !== undefined) { listRefreshDirty = true; return; }
+  listTimer = window.setTimeout(() => {
+    listRefreshDirty = false;
+    void loadSessions().finally(() => {
+      listTimer = undefined;
+      if (listRefreshDirty) scheduleReload();
+    });
+  }, 400);
 }
 
 async function refreshInputQueue(): Promise<void> {
@@ -2589,6 +2677,15 @@ async function refreshInputQueue(): Promise<void> {
     ? pendingNewInput?.generation === selectionGeneration && entry.id === pendingNewInput.id
     : (entry.sessionId ?? entry.deliveredSessionId) === selectedId;
   const queuedTasks = all.filter(entry => belongsToSelection(entry) && queuedFollowup(entry) && ['queued', 'tool', 'browser'].includes(entry.state));
+  // The first input already durably owns every later stage. Show that authority
+  // until its native receipt materializes the actual queue, without a blank gap.
+  const staged = [...all, ...[...startingInputs.values()].filter(entry => !all.some(row => row.id === entry.id))]
+    .filter(entry => belongsToSelection(entry) && !entry.stagesApplied && ['queued', 'browser', 'tool'].includes(entry.state));
+  const projectedIds = new Set<string>();
+  for (const entry of staged) for (const [index, text] of (entry.stages ?? []).entries()) {
+    const id = `${entry.id}:stage:${index}`; projectedIds.add(id);
+    queuedTasks.push({ ...entry, id, text, mode: 'finish', state: 'browser', stages: undefined });
+  }
   const queueSession = selectedId;
   const reorder = async (from: string, to: string, after: boolean) => {
     if (!queueSession || selectedId !== queueSession) return;
@@ -2608,6 +2705,7 @@ async function refreshInputQueue(): Promise<void> {
     if (dragging && existing) return existing;
     if (entry.state === 'queued' && existing?.querySelector('textarea') && existing.contains(document.activeElement)) return existing;
     const card = el('div', 'queued-input'); card.dataset.inputId = entry.id;
+    if (projectedIds.has(entry.id)) card.setAttribute('aria-label', 'Plan stage · waiting for the first message to be sent');
     const label = el('span', 'queue-label', entry.text); label.title = `${entry.state === 'queued' ? (entry.mode === 'after-turn' ? 'After the next completed answer' : 'At Session finish or after a completed answer') : 'Awaiting receipt'} · ${entry.text}`;
     card.append(icon('i-clock'), label);
     if (entry.state === 'queued') {
@@ -2683,6 +2781,7 @@ async function refreshInputQueue(): Promise<void> {
     visibleInputIds.add(entry.id);
     if (visibleInputIds.size > 100) visibleInputIds.delete(visibleInputIds.values().next().value!);
     const status = entry.error || (entry.state === 'failed' ? 'Delivery not confirmed' : entry.state === 'decision' ? 'Preparing follow-up' : entry.state === 'browser' ? 'Delivery confirmation pending' : entry.state === 'tool' ? 'Sent to the active turn · awaiting receipt' : entry.dueAt > Date.now() ? `Scheduled ${new Date(entry.dueAt).toLocaleString()}` : 'Queued');
+    if (entry.attachments?.length) { const files = el('div', 'message-attachments'); files.append(...entry.attachments.map(attachmentCard)); row.append(files); }
     row.append(el('div', 'pending-message-text', entry.text));
     if (entry.images?.length) {
       const images = el('div', 'pending-images');
@@ -2707,6 +2806,7 @@ async function refreshInputQueue(): Promise<void> {
         if (input.value.trim() || imageDrafts.get(draftKey())?.length) { toast('Send or clear your current draft before retrying this message.'); return; }
         input.value = entry.text;
         if (entry.images?.length) imageDrafts.set(draftKey(), [...entry.images]);
+        if (entry.attachments?.length) imageDrafts.set(draftKey(), [...(entry.images ?? []), ...entry.attachments]);
         rememberDraft(); paintComposerImages(); paintDeliveryControls(); input.focus();
         dismissInputNotice(entry.id);
       };
@@ -2760,7 +2860,7 @@ async function sendComposer(delivery?: 'finish', plan?: string[]): Promise<boole
   const key = draftKey();
   const projectId = selectedId ? sessions.find(row => row.id === selectedId)?.projectId ?? null : selectedProjectId;
   const images = imageDrafts.get(key) ?? [];
-  const text = plan?.[0] ?? (input.value.trim() || (images.length ? 'Please look at the attached images.' : ''));
+  const text = plan?.[0] ?? (input.value.trim() || (images.length ? 'Please look at the attached files.' : ''));
   if ($<HTMLButtonElement>('chatSend').disabled) return;
   if (!text) {
     const target = selectedId, selection = selectionGeneration;
@@ -2799,14 +2899,15 @@ async function sendComposer(delivery?: 'finish', plan?: string[]): Promise<boole
   const dueAt = Date.now();
   const id = crypto.randomUUID();
   const authoredDraft = input.value;
-  startingInputs.set(id, { id, sessionId, projectId, text, images, mode: mode === 'finish' ? 'finish' : mode === 'auto' ? 'auto' : 'after-turn',
+  const attachmentPayload = { images: images.filter((file): file is InputImage => 'dataUrl' in file), attachments: images.filter((file): file is InputAttachment => 'id' in file) };
+  startingInputs.set(id, { id, sessionId, projectId, text, ...attachmentPayload, stages: plan?.slice(1), mode: mode === 'finish' ? 'finish' : mode === 'auto' ? 'auto' : 'after-turn',
     dueAt, ...modelSettings, state: 'queued', owner: null, createdAt: dueAt, conversationId: null });
   input.value = ''; input.style.height = 'auto'; inputDrafts.delete(key);
   if (sessionId === null) pendingNewInput = { id, generation };
   void refreshInputQueue();
   paintDeliveryControls();
   try {
-    const result = await run(api.sendInput({ id, sessionId, projectId, text, images, stages: plan?.slice(1), objective: mode === 'finish' ? undefined : $<HTMLTextAreaElement>('sessionObjective').value.trim() || undefined, automation: mode === 'finish' ? undefined : $<HTMLSelectElement>('chatAutomation').value as InputAutomation, mode: mode === 'finish' ? 'finish' : mode === 'auto' ? 'auto' : 'after-turn', dueAt, ...modelSettings }));
+    const result = await run(api.sendInput({ id, sessionId, projectId, text, ...attachmentPayload, stages: plan?.slice(1), objective: mode === 'finish' ? undefined : $<HTMLTextAreaElement>('sessionObjective').value.trim() || undefined, automation: mode === 'finish' ? undefined : $<HTMLSelectElement>('chatAutomation').value as InputAutomation, mode: mode === 'finish' ? 'finish' : mode === 'auto' ? 'auto' : 'after-turn', dueAt, ...modelSettings }));
     if (cancelledStarts.has(id)) return;
     if (!result) {
       if (selectedId === sessionId && selectionGeneration === generation && !input.value) input.value = authoredDraft;
@@ -3031,15 +3132,15 @@ export function initChat(next: Deps): void {
       finally { button.disabled = false; if (selectedId === id) void refreshSessionControls(); }
     });
   }
-  const appendImages = (key: string, chosen: InputImage[] | null | undefined): void => {
+  const appendImages = (key: string, chosen: InputAttachment[] | null | undefined): void => {
     if (!chosen?.length) return;
     const combined = [...(imageDrafts.get(key) ?? []), ...chosen];
-    if (combined.length > 4) { toast('Attach up to four images per message'); return; }
+    if (combined.length > 20 || combined.reduce((sum, file) => sum + ('size' in file ? file.size : 0), 0) > 512 * 1024 * 1024) { toast('Attach up to 20 files and 512 MB per message'); return; }
     imageDrafts.set(key, combined); if (draftKey() === key) paintComposerImages();
   };
   $('attachImages').addEventListener('click', async () => {
     const key = draftKey();
-    appendImages(key, await run(api.chooseImages()));
+    appendImages(key, await run(api.chooseFiles()));
   });
   $('generateFinishGoal').addEventListener('click', async () => {
     const button = $<HTMLButtonElement>('generateFinishGoal'), id = selectedId, turnId = controlledTurnId;
@@ -3054,16 +3155,24 @@ export function initChat(next: Deps): void {
     }
   });
   $('composer').addEventListener('dragover', event => {
-    if (!event.dataTransfer?.types.includes('Files')) return;
+    if (!event.dataTransfer?.types.some(type => type === 'Files' || type === 'text/plain')) return;
     event.preventDefault(); event.dataTransfer.dropEffect = 'copy';
   });
   $('composer').addEventListener('drop', async event => {
-    if (!event.dataTransfer?.types.includes('Files')) return;
+    if (!event.dataTransfer?.types.some(type => type === 'Files' || type === 'text/plain')) return;
     event.preventDefault();
     const files = Array.from(event.dataTransfer.files), key = draftKey();
+    if (!files.length) { const text = event.dataTransfer.getData('text/plain'); if (text) { const file = await run(api.attachText(text)); if (file) appendImages(key, [file]); } return; }
+    if (files.length + (imageDrafts.get(key)?.length ?? 0) > 20) { toast('Attach up to 20 files per message'); return; }
+    appendImages(key, await run(api.dropFiles(files)));
+  });
+  $('chatInput').addEventListener('paste', async event => {
+    const files = Array.from(event.clipboardData?.files ?? []).filter(file => file.type.startsWith('image/'));
     if (!files.length) return;
-    if (files.length + (imageDrafts.get(key)?.length ?? 0) > 4) { toast('Attach up to four images per message'); return; }
-    appendImages(key, await run(api.dropImages(files)));
+    event.preventDefault();
+    const key = draftKey();
+    if (files.length + (imageDrafts.get(key)?.length ?? 0) > 20) { toast('Attach up to 20 files per message'); return; }
+    appendImages(key, await run(api.dropFiles(files)));
   });
   api.onWriteSession?.(id => { selectSession(id); $<HTMLTextAreaElement>('chatInput').focus(); });
   $('newChat').addEventListener('click', () => {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -162,7 +162,7 @@
           <section class="usage-section"><h2>Cost estimate per day</h2>
             <details id="usageFormulaDetails"><summary>Edit cost formula</summary>
             <p id="usageFormula" class="muted"></p>
-            <p class="muted">Automatic baselines use Standard short-context cached-input prices, checked 5 September 2026: <a href="https://developers.openai.com/api/docs/models/gpt-5.6-sol" target="_blank" rel="noopener noreferrer">GPT-5.6 Sol</a>, <a href="https://developers.openai.com/api/docs/models/gpt-6-astra" target="_blank" rel="noopener noreferrer">GPT-6 Astra</a>, <a href="https://developers.openai.com/api/docs/models/gpt-5.5" target="_blank" rel="noopener noreferrer">GPT-5.5</a>. These are editable cost comparisons, not actual bills.</p>
+            <p class="muted">Automatic baselines use Standard short-context cached-input prices, checked 7 September 2026: <a href="https://developers.openai.com/api/docs/models/gpt-5.6-sol" target="_blank" rel="noopener noreferrer">GPT-5.6 Sol</a>, <a href="https://developers.openai.com/api/docs/models/gpt-5.6-terra" target="_blank" rel="noopener noreferrer">GPT-5.6 Terra</a>, <a href="https://developers.openai.com/api/docs/models/gpt-5.6-luna" target="_blank" rel="noopener noreferrer">GPT-5.6 Luna</a>, <a href="https://developers.openai.com/api/docs/models/gpt-6-astra" target="_blank" rel="noopener noreferrer">GPT-6 Astra</a>, <a href="https://developers.openai.com/api/docs/models/gpt-5.5" target="_blank" rel="noopener noreferrer">GPT-5.5</a>. These are editable cost comparisons, not actual bills.</p>
             <label class="setting"><span class="setting-text"><b>Context times unique tool calls, divided by</b><em>Changes estimated tokens and costs.</em></span><input id="usageDivisor" aria-label="Usage token divisor" type="number" min="0.01" step="0.01" value="2" /></label>
             <label class="setting"><span class="setting-text"><b>Cached-input cost multiplier</b><em>Applied after each model's cached-input rate.</em></span><input id="usageMultiplier" aria-label="Cached-input cost multiplier" type="number" min="0" step="0.01" value="1.2" /></label>
             <div id="usageRates"></div></details>
@@ -515,6 +515,7 @@
               </div>
 
               <div class="field">
+                <label class="inline" id="startAtLoginRow" hidden><input type="checkbox" id="startAtLogin" /> Start Chat On Steroids when I sign in</label>
                 <label class="inline"><input type="checkbox" id="autoConnect" /> Connect automatically at startup</label>
                 <label class="inline"><input type="checkbox" id="minimizeToTray" /> <span id="minimizeToTrayCopy">Keep running when closed</span></label>
                 <label class="inline" id="privacyScreenshotsSetting"><input type="checkbox" id="privacyScreenshots" /> Privacy screenshots: default to the active window instead of the whole monitor</label>
@@ -588,10 +589,19 @@
                 <h2 class="settings-section-title">Keep the turn open</h2>
                 <div class="pane">
                   <label class="setting"><span class="setting-text"><b>Plan generation</b><em>Create staged tasks. ChatGPT uses the Goal, Loop and Plan model above; API uses the model and reasoning in API provider settings.</em></span><select id="planBackend"><option value="chatgpt">ChatGPT</option><option value="api">API provider</option></select></label>
-                  <label class="setting"><span class="setting-text"><b>Session finish</b><em>Ask Astra to keep the turn open for your next instruction. Tool changes refresh the connector automatically after 20 seconds.</em></span><input id="finishTool" type="checkbox" /></label>
+                  <label class="setting"><span class="setting-text"><b>Session finish</b><em>Ask Astra to keep the turn open for your next instruction. With Automatic plugin refresh enabled, tool changes refresh the connector after 20 seconds.</em></span><input id="finishTool" type="checkbox" /></label>
                   <div class="setting"><span class="setting-text"><b>When ChatGPT is wrapping up</b><em>Automatic follow-ups use your Loop instructions and selected Loop source.</em></span><select id="finishAction"><option value="notify">Notify me · Write or Generate Goal</option><option value="goal">Generate and inject Goal</option></select></div>
                   <div class="setting"><span class="setting-text"><b>Requested notice</b><em>A request to the model, not a guaranteed countdown.</em></span><select id="finishLeadMinutes"><option value="3">3 minutes</option><option value="5">5 minutes</option></select></div>
                   </div>
+                <h2 class="settings-section-title">Connector instructions</h2>
+                <div class="pane">
+                  <div class="field">
+                    <label for="mcpInstructions">Your own instructions</label>
+                    <textarea id="mcpInstructions" rows="6" maxlength="4000" spellcheck="false" placeholder="e.g. Always run the test suite before saying a change works."></textarea>
+                    <p class="hint">Added to the end of what each connector tells ChatGPT about itself, marked as yours. Kept across app updates. Leave empty for none.</p>
+                  </div>
+                  <p class="muted">ChatGPT reads connector instructions once, when it loads the tools, so a change reaches an existing conversation only after the connector is loaded again.</p>
+                </div>
                 <h2 class="settings-section-title">ChatGPT models</h2>
                 <div class="pane">
                   <div class="setting"><span class="setting-text"><b>Available ChatGPT models</b><em id="chatModelStatus">Read model choices from your account.</em></span><button class="btn" id="refreshChatModels" type="button">Refresh</button></div>
@@ -599,9 +609,12 @@
                   <div class="setting"><span class="setting-text"><b>Default sub-agent reasoning</b><em>Selected independently from the model.</em></span><select id="workerReasoning"><option value="" disabled>No observed choices</option></select></div>
                   </div>
                 <h2 class="settings-section-title">Browser & history</h2>
+                <div class="pane"><label class="setting"><span class="setting-text"><b>ChatGPT browser</b><em>Used when the app launches a browser. Install the companion and sign in to ChatGPT in this browser's active profile. Already connected tabs stay in their browser.</em></span><select id="chatBrowser"><option value="chrome">Google Chrome / Chromium</option><option value="edge">Microsoft Edge</option></select></label></div>
                 <div class="pane">
                   <label class="setting"><span class="setting-text"><b>Background chats</b><em>Keep app-created ChatGPT tabs in the background.</em></span><input id="backgroundChats" type="checkbox" /></label>
-                  <p class="muted">Keeps as many app chat tabs as your worker limit. Above that, the longest-idle chats close after one minute without work. Active turns and unsent drafts stay open.</p>
+                  <label class="setting"><span class="setting-text"><b>Automatic plugin refresh</b><em>Let the companion refresh changed connector tools in ChatGPT. Off by default; manual refresh remains available in ChatGPT.</em></span><input id="autoRefreshPlugins" type="checkbox" /></label>
+                  <label class="setting"><span class="setting-text"><b>Browser only</b><em>Do not open tabs for automatic plugin refresh or chat recovery. Explicit new chats, workers and Reload models still work.</em></span><input id="browserOnly" type="checkbox" /></label>
+                  <p class="muted">Idle app-created tabs close after two minutes. Sleeping worker tabs can close earlier when the worker limit is exceeded. Active turns and unsent drafts stay open.</p>
                   <label class="setting"><span class="setting-text"><b>Overwrite ChatGPT tool rows</b><em>Show recorded local activity in the ChatGPT page.</em></span><input id="browserOverwrite" type="checkbox" disabled /></label>
                   <label class="setting"><span class="setting-text"><b>Show durations in ChatGPT</b><em>Uses the same preference as the extension popup.</em></span><input id="browserDurations" type="checkbox" disabled /></label>
                   <div class="setting"><span class="setting-text"><b>Browser preferences</b><em id="browserPreferencesStatus" role="status">Refresh to read the browser's current preferences.</em></span><button id="browserPreferencesRefresh" class="btn" type="button">Refresh browser preferences</button></div>
@@ -625,7 +638,32 @@
                   </div>
                 <h2 class="settings-section-title">API provider</h2>
                 <div class="pane">
-                  <div class="field">
+                  <div class="setting">
+                    <span class="setting-text">
+                      <b>Provider</b>
+                      <em>OpenRouter, or your own OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, a gateway) for the API response source.</em>
+                    </span>
+                    <select id="goalProvider">
+                      <option value="openrouter">OpenRouter</option>
+                      <option value="custom">Custom endpoint</option>
+                    </select>
+                  </div>
+
+                  <div class="field" id="goalCustomPanel" hidden>
+                    <label for="goalBaseUrl">Endpoint base URL</label>
+                    <input id="goalBaseUrl" type="text" spellcheck="false" placeholder="http://localhost:11434/v1" autocomplete="off" />
+                    <p class="hint">https, or http on localhost. <code>/chat/completions</code> and <code>/models</code> are called under it.</p>
+                    <label for="goalCustomModel">Model</label>
+                    <input id="goalCustomModel" type="text" spellcheck="false" placeholder="llama3.1" autocomplete="off" />
+                    <p class="hint">Your endpoint's own model id, typed exactly as it serves it.</p>
+                    <label for="goalCustomKey">Endpoint API key (optional)</label>
+                    <input id="goalCustomKey" type="password" spellcheck="false" placeholder="leave empty for a keyless local server" autocomplete="off" />
+                    <p class="hint" id="goalCustomKeyState"></p>
+                    <div class="step-actions">
+                      <button class="btn" id="goalCustomKeyRemove" type="button">Remove stored key</button>
+                    </div>
+                  </div>
+                  <div class="field" id="goalKeyField">
                     <label for="goalKey">OpenRouter API key</label>
                     <input id="goalKey" type="password" spellcheck="false" placeholder="sk-or-v1-…" autocomplete="off" />
                     <p class="hint" id="goalKeyState"></p>
@@ -636,7 +674,12 @@
                       </button>
                     </div>
                   </div>
-                  <div class="setting">
+                  <!--
+                    The catalogue is several hundred models long and changes weekly, so it is
+                    not fetched until somebody actually asks to change the one in use - and
+                    then twenty at a time, newest release first.
+                  -->
+                  <div class="setting" id="goalPickerRow">
                     <span class="setting-text">
                       <b>Model</b>
                       <em id="goalModelName"></em>
@@ -763,7 +806,7 @@
                 <details class="composer-menu" id="attachmentMenu">
                   <summary aria-label="Add attachments" title="Add attachments"><svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><use href="#i-plus" /></svg></summary>
                   <div class="composer-popover">
-                    <button id="attachImages" type="button"><svg class="ico" viewBox="0 0 24 24"><use href="#i-image" /></svg>Add images</button>
+                    <button id="attachImages" type="button"><svg class="ico" viewBox="0 0 24 24"><use href="#i-image" /></svg>Add photos &amp; files</button>
                     <button id="composerFolder" type="button"><svg class="ico" viewBox="0 0 24 24"><use href="#i-folder" /></svg>Share a folder</button>
                   </div>
                 </details>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -16,7 +16,7 @@ import { initBrowserPreferences } from './browser-preferences.js';
 
 import type { AppApi, SettingsPatch } from '../preload/index.js';
 import { requiresApprovedFilesystemRoot } from '../shared/capabilities.js';
-import type { AppState, Capability, LogEntry, SurfaceStatus } from '../shared/types.js';
+import type { AppState, Capability, ChatBrowser, LogEntry, SurfaceStatus } from '../shared/types.js';
 import {
   browserExtensionRequired,
   isNewer,
@@ -63,8 +63,8 @@ const GROUPS: Group[] = [
     id: 'write',
     title: 'Change files',
     icon: 'i-pencil',
-    blurb: 'Create, edit, move and delete, inside those folders only.',
-    caps: ['create', 'edit', 'move', 'deleteFile']
+    blurb: 'Create, edit, move, delete and save ChatGPT files, inside those folders only.',
+    caps: ['create', 'edit', 'move', 'deleteFile', 'saveArtifact']
   },
   {
     id: 'desktop',
@@ -442,12 +442,16 @@ function save(over: { readOnly?: boolean; theme?: 'light' | 'dark' } = {}): Prom
       binaryPath: $<HTMLInputElement>('binaryPath').value.trim()
     },
     ui: {
+      chatBrowser: $<HTMLSelectElement>('chatBrowser').value as ChatBrowser,
       finishTool: $<HTMLInputElement>('finishTool').checked,
       planBackend: $<HTMLSelectElement>('planBackend').value as 'chatgpt' | 'api',
       finishAction: $<HTMLSelectElement>('finishAction').value as 'notify' | 'goal',
       finishLeadMinutes: Number($<HTMLSelectElement>('finishLeadMinutes').value),
       backgroundChats: $<HTMLInputElement>('backgroundChats').checked,
+      browserOnly: $<HTMLInputElement>('browserOnly').checked,
+      autoRefreshPlugins: $<HTMLInputElement>('autoRefreshPlugins').checked,
       autoConnect: $<HTMLInputElement>('autoConnect').checked,
+      startAtLogin: $<HTMLInputElement>('startAtLogin').checked,
       minimizeToTray: $<HTMLInputElement>('minimizeToTray').checked,
       developerMode: $<HTMLInputElement>('developerMode').checked,
       privacyScreenshots: $<HTMLInputElement>('privacyScreenshots').checked,
@@ -472,6 +476,10 @@ async function saveSnapshot(patch: SettingsPatch, previous: AppState['config']):
   const toolSurfaceChanged =
     previous.sessions.record !== patch.sessions.record ||
     previous.multiAgent.enabled !== patch.multiAgent.enabled ||
+    // The user's own connector instructions are part of what each server advertises about
+    // itself, and ChatGPT reads that once when it loads the tools. Editing them is therefore
+    // the same kind of change as adding a tool: it needs the same reconnect to be seen.
+    (previous.mcp?.instructions ?? '') !== patch.mcp.instructions ||
     (Object.keys(patch.capabilities) as Capability[]).some((cap) => {
       const before = previous.capabilities[cap] && !(previous.readOnly && WRITE_CAPABILITIES.includes(cap));
       const after = patch.capabilities[cap] && !(patch.readOnly && WRITE_CAPABILITIES.includes(cap));
@@ -484,6 +492,7 @@ async function saveSnapshot(patch: SettingsPatch, previous: AppState['config']):
     ui: previous.ui,
     sessions: previous.sessions,
     compaction: previous.compaction,
+    mcp: previous.mcp ?? { instructions: '' },
     multiAgent: previous.multiAgent,
     goal: previous.goal
   };
@@ -922,11 +931,17 @@ function apply(next: AppState): void {
     previousState?.config.tunnel.desktopTunnelId
   );
   applyValue($<HTMLInputElement>('binaryPath'), config.tunnel.binaryPath, previousState?.config.tunnel.binaryPath);
+  applyValue($<HTMLSelectElement>('chatBrowser'), config.ui.chatBrowser ?? 'chrome', previousState?.config.ui.chatBrowser ?? 'chrome');
   $<HTMLSelectElement>('planBackend').value = config.ui.planBackend ?? 'chatgpt';
   applyChecked($<HTMLInputElement>('finishTool'), config.ui.finishTool === true, previousState?.config.ui.finishTool);
   applyValue($<HTMLSelectElement>('finishAction'), config.ui.finishAction ?? 'notify', previousState?.config.ui.finishAction);
   applyValue($<HTMLSelectElement>('finishLeadMinutes'), String(config.ui.finishLeadMinutes ?? 5), String(previousState?.config.ui.finishLeadMinutes ?? 5));
   applyChecked($<HTMLInputElement>('backgroundChats'), config.ui.backgroundChats === true, previousState?.config.ui.backgroundChats);
+  applyChecked($<HTMLInputElement>('browserOnly'), config.ui.browserOnly === true, previousState?.config.ui.browserOnly);
+  applyChecked($<HTMLInputElement>('autoRefreshPlugins'), config.ui.autoRefreshPlugins === true, previousState?.config.ui.autoRefreshPlugins);
+  $('startAtLoginRow').hidden = next.loginStartupAvailable !== true;
+  $<HTMLInputElement>('startAtLogin').disabled = next.loginStartupAvailable !== true;
+  applyChecked($<HTMLInputElement>('startAtLogin'), config.ui.startAtLogin === true, previousState?.config.ui.startAtLogin);
   applyChecked($<HTMLInputElement>('autoConnect'), config.ui.autoConnect, previousState?.config.ui.autoConnect);
   applyChecked($<HTMLInputElement>('developerMode'), config.ui.developerMode === true, previousState?.config.ui.developerMode);
   applyChecked(
@@ -1628,6 +1643,7 @@ $('removeApiKey').addEventListener('click', async () => {
 
 for (const id of [
   'autoConnect',
+  'startAtLogin',
   'minimizeToTray',
   'developerMode',
   'privacyScreenshots',

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2436,7 +2436,13 @@ nav button:hover, nav button.is-sel { background: var(--hover); color: var(--ink
 .usage-table th, .usage-table td { text-align: right; border-bottom: 1px solid var(--line); padding: 12px 4px; }
 .usage-table th:first-child, .usage-table td:first-child { text-align: left; }
 
-.composer-images { display: flex; gap: 10px; margin-bottom: 12px; }
+.composer-images { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px; }
+.attachment-card { position: relative; display: flex; align-items: center; gap: 8px; height: 62px; padding: 10px; max-width: 280px; min-width: 150px; border: 1px solid var(--line); border-radius: 18px; background: var(--page); box-sizing: border-box; text-align: left; }
+.attachment-icon { width: 40px; height: 40px; flex: 0 0 40px; display: grid; place-items: center; font-size: 26px; color: #0285ff; }
+.attachment-details { min-width: 0; font-size: 14px; line-height: 20px; }
+.attachment-name { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.attachment-kind { color: var(--muted); }
+.message-attachments:has(.attachment-card) { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 8px; }
 .composer-image { position: relative; width: 78px; height: 66px; }
 .composer-image img { width: 100%; height: 100%; object-fit: cover; border-radius: 10px; border: 1px solid var(--line); }
 .image-remove { position: absolute; top: -4px; right: -4px; border: 0; width: 20px; height: 20px; border-radius: 50%; background: var(--ink); color: var(--page); cursor: pointer; }
@@ -2646,8 +2652,10 @@ select option { background: var(--card); color: var(--ink); }
 .composer-dock .queued-input.is-editing { flex-wrap: wrap; }
 .composer-dock textarea { width: 100%; min-height: 65px; padding: 8px; font: inherit; resize: vertical; }
 #taskPlanPreview { max-height: 300px; overflow-y: auto; }
+/* Status spans need a real row: inline padding does not contribute to dock height. */
+#taskPlanPreview > .muted { display: block; line-height: 20px; }
 #taskPlanPreview > .muted, #taskPlanPreview > .task-progress-text { margin: 0; padding: 10px 12px; }
-.task-progress-text { max-height: 180px; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; font: inherit; font-size: 13px; color: var(--soft); }
+.task-progress-text { white-space: pre-wrap; overflow-wrap: anywhere; font: inherit; font-size: 13px; color: var(--soft); }
 .plan-stage + .plan-stage { border-top: 1px solid var(--edge); }
 .plan-stage-heading { display: flex; align-items: center; gap: 10px; min-height: 39px; padding: 6px 12px; color: var(--soft); font-size: 13px; }
 .stage-number { flex: 0 0 18px; color: var(--faint); font-size: 11px; text-align: center; font-variant-numeric: tabular-nums; }
@@ -2669,7 +2677,7 @@ select option { background: var(--card); color: var(--ink); }
 #contextMeterButton:hover { background: var(--hover); }
 #contextMeterButton svg { width: 16px; height: 16px; fill: none; stroke: currentColor; stroke-width: 2; transform: rotate(-90deg); }
 .context-track { opacity: .35; }
-#contextMeterInfo { display: none; position: absolute; z-index: 20; bottom: calc(100% + 8px); right: 0; width: max-content; max-width: min(310px, 75vw); white-space: pre-line; padding: 12px 16px; border: 1px solid var(--edge); border-radius: 12px; background: var(--card); color: var(--ink); font-size: 12px; line-height: 1.6; box-shadow: 0 8px 24px #0003; text-align: center; }
+#contextMeterInfo { display: none; position: absolute; z-index: 20; bottom: calc(100% + 8px); left: 50%; transform: translateX(-50%); width: max-content; max-width: min(310px, 75vw); white-space: pre-line; padding: 12px 16px; border: 1px solid var(--edge); border-radius: 12px; background: var(--card); color: var(--ink); font-size: 12px; line-height: 1.6; box-shadow: 0 8px 24px #0003; text-align: center; }
 .context-meter:hover #contextMeterInfo, .context-meter:focus-within #contextMeterInfo, .context-meter.pinned #contextMeterInfo { display: block; }
 .queue-delivery { flex-shrink: 0; font-size: 11px; padding: 3px 7px; }
 .queue-delivery[aria-pressed="true"] { color: var(--text); border-color: var(--soft); }

--- a/src/renderer/usage.ts
+++ b/src/renderer/usage.ts
@@ -1,5 +1,5 @@
 import { $, el, run } from './dom.js';
-import { DEFAULT_USAGE_FORMULA, usageEstimate, type UsageFormula, type UsageOverview } from '../shared/usage.js';
+import { DEFAULT_USAGE_FORMULA, usageEstimate, usageRate, type UsageFormula, type UsageOverview } from '../shared/usage.js';
 let snapshot: UsageOverview | null = null;
 let loadGeneration = 0;
 const FORMULA_KEY = 'usage-formula-v1';
@@ -75,8 +75,8 @@ function paintRates(): void {
   const host = $('usageRates'); host.replaceChildren();
   for (const model of [...new Set(snapshot.models.map(row => row.model))].sort()) {
     const label = el('label', 'setting'); const text = el('span', 'setting-text');
-    text.append(el('b', '', model), el('em', '', Object.hasOwn(DEFAULT_USAGE_FORMULA.rates, model) ? 'USD / 1M cached input · editable official baseline, checked 5 September 2026' : 'USD / 1M cached input · enter a verified comparison rate'));
-    const input = document.createElement('input'); input.type = 'number'; input.min = '0'; input.step = '0.01'; input.placeholder = 'Unknown rate'; input.value = formula.rates[model]?.toString() ?? '';
+    text.append(el('b', '', model), el('em', '', usageRate(model, DEFAULT_USAGE_FORMULA) !== undefined ? 'USD / 1M cached input · editable official baseline, checked 7 September 2026' : 'USD / 1M cached input · enter a verified comparison rate'));
+    const input = document.createElement('input'); input.type = 'number'; input.min = '0'; input.step = '0.01'; input.placeholder = 'Unknown rate'; input.value = usageRate(model, formula)?.toString() ?? '';
     input.setAttribute('aria-label', `${model} cached-input USD per million tokens`);
     input.addEventListener('input', () => {
       if (input.value === '') formula.rates[model] = null;

--- a/src/shared/chat-models.ts
+++ b/src/shared/chat-models.ts
@@ -9,7 +9,7 @@ export type ChatModelOption = { id: string; label: string; efforts: ReasoningEff
 /** Pro silence policy follows the selected provider identity, including the older generation. */
 export function isProModel(model: string | null | undefined, effort?: ReasoningEffort): boolean {
   const normalized = (model ?? '').trim().toLowerCase().replace(/\s+/g, '-');
-  return isAstraModel(model, effort) || /^gpt-?5\.6-pro$/.test(normalized) ||
+  return isAstraModel(model, effort) || /^gpt-?\d+(?:[.-]\d+)?-pro$/.test(normalized) ||
     (/^gpt-?5\.6(?:-sol)?$/.test(normalized) && effort === 'pro');
 }
 /** Keep the selected generation intact; Pro is already a complete model label. */

--- a/src/shared/goal.ts
+++ b/src/shared/goal.ts
@@ -1,5 +1,7 @@
 /** Maximum editable Goal instruction size accepted by config and renderer IPC. */
 export const MAX_GOAL_SYSTEM_PROMPT_CHARS = 20_000;
+/** Default API model, also used when switching back from a custom model namespace. */
+export const DEFAULT_GOAL_MODEL = 'z-ai/glm-5.3';
 
 /**
  * All three Goal models are meta-prompters, not reviewers.

--- a/src/shared/input.ts
+++ b/src/shared/input.ts
@@ -1,3 +1,5 @@
 /** Normalized image bytes only. No local filesystem path crosses into the renderer. */
 export interface InputImage { name: string; dataUrl: string; }
+/** Immutable staged upload. Neither renderer nor browser receives a local path. */
+export interface InputAttachment { id: string; name: string; size: number; mimeType: string; preview?: string; }
 export type InputAutomation = 'off' | 'goal' | 'loop';

--- a/src/shared/session.ts
+++ b/src/shared/session.ts
@@ -258,6 +258,7 @@ export type SessionEvent =
       inputDelivery?: 'offered' | 'confirmed';
       /** Original app-authored text, excluding transport-only control instructions. */
       authoredText?: string;
+      attachments?: import('./input.js').InputAttachment[];
       assets?: AssetRef[];
       /** First sequence assigned to this stable website message; revisions keep this anchor. */
       origin?: number;
@@ -813,14 +814,21 @@ export function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
-/** Token weight of one stored event, using the text we actually kept. */
+/** Recorder clipping changes storage, not the text already sent to the model. */
+function storedTextTokens(value: StoredText): number {
+  const chars = value.truncated && Number.isSafeInteger(value.chars) && value.chars >= 0
+    ? value.chars : value.text.length;
+  return Math.ceil(chars / 4);
+}
+
+/** Token weight of original recorded text; previews, assets and HTML are not extra context. */
 export function eventTokens(event: SessionEvent): number {
   switch (event.kind) {
     case 'user_message':
     case 'assistant_message':
     case 'chat_error':
     case 'note':
-      return estimateTokens(event.message.text);
+      return storedTextTokens(event.message);
     case 'progress':
       // Live progress/reasoning captions are useful audit evidence but are not stable
       // conversation context, and often restate work that later appears in the final
@@ -832,11 +840,11 @@ export function eventTokens(event: SessionEvent): number {
       // result the model actually reads, so it occupies the conversation the same way a
       // tool result does. Leaving it at zero made the meter under-report exactly the runs
       // most likely to need compacting — the multi-agent ones.
-      return estimateTokens(event.message.text);
+      return storedTextTokens(event.message);
     case 'tool_call':
       return (
-        estimateTokens(event.call.args.text) +
-        estimateTokens(event.call.result.text) +
+        storedTextTokens(event.call.args) +
+        storedTextTokens(event.call.result) +
         estimateTokens(event.call.summary.title)
       );
     case 'handoff':

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -31,6 +31,7 @@ export const CAPABILITIES = [
   'move',
   'deleteFile',
   'command',
+  'saveArtifact',
   'screen',
   'control',
   'clipboardRead',
@@ -60,6 +61,7 @@ export const WRITE_CAPABILITIES: readonly Capability[] = [
   'move',
   'deleteFile',
   'command',
+  'saveArtifact',
   'control',
   'clipboardWrite'
 ];
@@ -116,8 +118,15 @@ export interface TunnelSettings {
   binaryPath: string;
 }
 
+export const CHAT_BROWSERS = ['chrome', 'edge'] as const;
+export type ChatBrowser = (typeof CHAT_BROWSERS)[number];
+
 export interface UiPrefs {
+  /** Maintenance may reuse existing tabs but cannot open helpers or missing chats. */
+  browserOnly?: boolean;
   backgroundChats?: boolean;
+  /** Opt-in browser automation for changed connector tool schemas. */
+  autoRefreshPlugins?: boolean;
   /** Actual app-owned tabs to retain; active work and drafts stay protected. Omitted uses workers + 2. */
   tabsToKeepOpen?: number;
   finishTool?: boolean;
@@ -127,8 +136,11 @@ export interface UiPrefs {
   developerMode?: boolean;
   minimizeToTray: boolean;
   autoConnect: boolean;
+  startAtLogin?: boolean;
   /** Default screenshots to the active window instead of the whole primary monitor. */
   privacyScreenshots: boolean;
+  /** Browser for app-originated launches; connected source tabs retain placement ownership. */
+  chatBrowser?: ChatBrowser;
   /** Explicit choice, never inherited from the OS: the window looks how you left it. */
   theme: 'light' | 'dark';
 }
@@ -187,12 +199,13 @@ export type GoalReasoning = (typeof GOAL_REASONING_LEVELS)[number];
  * The goal loop: a second model, standing in for the user, that keeps a chat going.
  *
  * When ChatGPT finishes a turn, the recorded conversation — every user message and every
- * final ChatGPT answer, and nothing else — is sent to an OpenRouter model with an editable
+ * final ChatGPT answer, and nothing else — is sent to the configured provider's model with an editable
  * continuation-gate instruction. A completion claim produces `NO_REPLY`; only a concrete
  * requested item the final answer explicitly leaves unfinished becomes a user message.
  *
- * Off by default, and useless without an OpenRouter API key: the key is the credential the
- * whole feature runs on, so the UI says so rather than failing quietly at the first turn.
+ * Off by default, and useless without a key for the configured provider: the key is the credential the
+ * whole feature runs on, so the UI says so rather than failing quietly at the first turn. A custom
+ * keyless local endpoint is the one exception — there is nothing to store for it.
  */
 /**
  * Which of the two standing modes the switch runs.
@@ -206,6 +219,27 @@ export const GOAL_MODES = ['goal', 'loop'] as const;
 export type GoalMode = (typeof GOAL_MODES)[number];
 
 export type GoalBackend = 'api' | 'chatgpt' | 'templates';
+/**
+ * Where the Goal/Loop second model runs when the backend is `api`.
+ *
+ * `openrouter` is the shipped default: OpenRouter's catalogue, key and routing. `custom`
+ * points at any OpenAI-compatible `/chat/completions` endpoint the user runs themselves
+ * (Ollama, vLLM, LM Studio, a gateway) and is used with that endpoint's own model id.
+ * The other backends (`chatgpt`, `templates`) never read this block.
+ */
+export const GOAL_PROVIDERS = ['openrouter', 'custom'] as const;
+export type GoalProviderKind = (typeof GOAL_PROVIDERS)[number];
+
+export interface GoalProviderSettings {
+  kind: GoalProviderKind;
+  /**
+   * Base URL of a custom provider, e.g. `http://localhost:11434/v1`. Ignored unless
+   * kind is `custom`. Stored verbatim; validated when a draft is started, not when saved,
+   * so a typo fails loudly at use time rather than silently rewriting the user's text.
+   */
+  baseUrl: string;
+}
+
 export interface GoalSettings {
   /** Optional active-turn Goal impulses; zero disables them. */
   impulseMinutes?: number;
@@ -223,7 +257,8 @@ export interface GoalSettings {
    * with the switch off runs as `goal`, because Loop is a thing the user switches on.
    */
   mode: GoalMode;
-  /** An OpenRouter model id, exactly as its `/models` listing spells it. */
+  provider: GoalProviderSettings;
+  /** A model id: an OpenRouter id while the provider is openrouter, the endpoint's own id while custom. */
   model: string;
   reasoning: GoalReasoning;
   /** Editable continuation-gate instruction sent as the OpenRouter system message. */
@@ -267,7 +302,19 @@ export interface MultiAgentSettings {
   recoverAgentTabs: boolean;
 }
 
+/** The user's own additions to what each MCP connector tells the model about itself. */
+export interface McpSettings {
+  /** Appended to the Core and Desktop server instructions, or empty for none. */
+  instructions: string;
+}
+
+export interface ArtifactSettings {
+  /** Per-file byte ceiling enforced before, during and after the download stream. */
+  maxFileBytes: number;
+}
+
 export interface Config {
+  artifacts: ArtifactSettings;
   roots: Root[];
   capabilities: Capabilities;
   readOnly: boolean;
@@ -277,6 +324,7 @@ export interface Config {
   compaction: CompactionSettings;
   multiAgent: MultiAgentSettings;
   goal: GoalSettings;
+  mcp: McpSettings;
 }
 
 export type ConnectionState =
@@ -504,11 +552,15 @@ export interface AppState {
   config: Config;
   status: ConnectionStatus;
   platform: PlatformInfo;
+  /** Only packaged Windows builds may change the login item. */
+  loginStartupAvailable?: boolean;
   secureStorage: SecureStorageInfo;
   /** True when an OpenAI control-plane API key is stored. The key itself never leaves the main process. */
   hasApiKey: boolean;
-  /** True when an OpenRouter key is stored, which is what the goal loop spends. Same rule: the key stays here. */
+  /** True when an OpenRouter key is stored, which is what the goal loop spends on that provider. Same rule: the key stays here. */
   hasGoalKey: boolean;
+  /** True when a custom-provider key is stored. Only meaningful beside a custom endpoint, which may also run keyless. */
+  hasCustomProviderKey: boolean;
   /** Resolved path of the tunnel binary we would run, or null if we cannot find one. */
   resolvedBinary: string | null;
   /** Version of the tunnel-client copy shipped inside the app, for diagnostics. */
@@ -529,6 +581,7 @@ export const DEFAULT_CAPABILITIES: Capabilities = {
   move: false,
   deleteFile: false,
   command: false,
+  saveArtifact: false,
   screen: false,
   control: false,
   clipboardRead: false,
@@ -545,6 +598,7 @@ export const CAPABILITY_LABELS: Record<Capability, string> = {
   move: 'Move / rename',
   deleteFile: 'Delete files',
   command: 'Run commands',
+  saveArtifact: 'Save ChatGPT files',
   screen: 'See the screen',
   control: 'Control mouse and keyboard',
   clipboardRead: 'Read clipboard',
@@ -569,6 +623,7 @@ export const CAPABILITY_DETAILS: Record<Capability, string> = {
   move: 'Move or rename, both ends inside approved folders.',
   deleteFile: 'Permanent — there is no Recycle Bin.',
   command: 'Run anything as you. NOT limited to approved folders.',
+  saveArtifact: 'Save images and files ChatGPT generates into an approved folder.',
   screen: 'Screenshots, open windows, and the controls on them.',
   control: 'Moves the pointer, clicks, types and presses keys, as you.',
   clipboardRead: 'Read the current clipboard text.',
@@ -593,6 +648,7 @@ export const CAPABILITY_TOOLS: Record<Capability, readonly string[]> = {
   move: ['apply_patch'],
   deleteFile: ['apply_patch'],
   command: ['exec_command', 'write_stdin'],
+  saveArtifact: ['download_artifact'],
   screen: ['observe'],
   control: ['computer'],
   clipboardRead: ['computer'],

--- a/src/shared/usage.ts
+++ b/src/shared/usage.ts
@@ -26,13 +26,18 @@ export interface UsageFormula {
   multiplier: number;
   rates: Record<string, number | null>;
 }
-// Standard short-context cached-input comparison rates verified 2026-09-06.
+// Standard short-context cached-input comparison rates verified 2026-09-07.
 // GPT-6 Pro is ChatGPT's Astra label; Astra cached input is $1 per million tokens.
 // Sources are linked next to the editable formula and in usage-model-attribution.md.
 export const DEFAULT_USAGE_FORMULA: UsageFormula = {
   divisor: 2, multiplier: 1.2,
-  rates: { 'gpt-5.6': 0.4, 'gpt-5.6-sol': 0.4, 'gpt-6-astra': 1, 'gpt-6-pro': 1, 'gpt-5.5': 0.5 }
+  rates: { 'gpt-5.6': 0.4, 'gpt-5.6-sol': 0.4, 'gpt-5.6-terra': 0.2, 'gpt-5.6-luna': 0.02, 'gpt-6-astra': 1, 'gpt-6-pro': 1, 'gpt-5.5': 0.5 }
 };
+/** Exact provider picker identity, verified against its GPT-5.6 Sol category; never fuzzy-match unknown IDs. */
+export function usageRate(model: string, formula: UsageFormula): number | null | undefined {
+  if (Object.hasOwn(formula.rates, model)) return formula.rates[model];
+  return model === 'gpt-5-6-thinking' ? formula.rates['gpt-5.6-sol'] : undefined;
+}
 export function usageModelKey(row: Pick<UsageModelTokens, 'model' | 'reasoningEffort' | 'assumed'>): string {
   return JSON.stringify([row.model, row.reasoningEffort, row.assumed]);
 }
@@ -42,7 +47,7 @@ export function usageEstimate(rows: readonly UsageModelTokens[], formula: UsageF
   for (const row of rows) {
     const amount = row.tokens * 2 / formula.divisor;
     tokens += amount;
-    const rate = formula.rates[row.model];
+    const rate = usageRate(row.model, formula);
     if (typeof rate === 'number' && Number.isFinite(rate) && rate >= 0) cost += amount / 1e6 * rate * formula.multiplier;
     else unpricedTokens += amount;
   }

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -2317,6 +2317,22 @@ describe('through the MCP endpoint', () => {
     expect(pendingWorkerSpawns()).toEqual([]);
   });
 
+  it('publishes each accepted MCP spawn to its own run when another prime is active', async () => {
+    const opened = vi.fn();
+    const dispose = onSpawnRequest(opened);
+    try {
+      await asChat('prime-existing', 'spawn', { workers: [{ task: 'existing work' }] });
+      await asChat('prime-new', 'spawn', { workers: [{ task: 'new work' }] });
+      expect(opened).toHaveBeenCalledTimes(2);
+      expect(opened.mock.calls.map(([workers]) => workers)).toEqual([
+        [expect.objectContaining({ id: 'worker-1', runId: currentRunId('prime-existing'), primeConversationId: 'prime-existing', task: 'existing work' })],
+        [expect.objectContaining({ id: 'worker-1', runId: currentRunId('prime-new'), primeConversationId: 'prime-new', task: 'new work' })]
+      ]);
+    } finally {
+      dispose();
+    }
+  });
+
   it('rolls back a spawn whose durable acceptance barrier fails instead of resurrecting it from the debounce', async () => {
     const stateName = 'spawn-atomicity-failure';
     onSwarmPersist(() => writeDurableSoon(stateName, snapshotSwarm()));
@@ -2441,6 +2457,29 @@ describe('through the MCP endpoint', () => {
     const exact = textOfReply(await ordinaryWithRequestId(requestId, 'read', { paths: ['/anything'] }));
     await setEnabled(true);
     expect(exact).toContain('WORKER_RETIRED');
+  });
+
+  it('explains scheduled-run permission with dormant history and never adopts that history', async () => {
+    startSwarm(1);
+    const worker = startWorker('worker-1');
+    finishAgent(worker.caller, 'parked history');
+    expect(releaseQuiescentRun()).toBe(true);
+
+    const blocked = await callTool('read', { paths: ['/anything'] });
+    expect(blocked).toContain('CALLER_IDENTITY_REQUIRED');
+    expect(blocked).toContain('Scheduled or headless runs');
+    expect(blocked).toContain('"Allow unattributed calls"');
+    expect(swarmRunning()).toBe(false);
+
+    await setEnabled(true, 3, true);
+    const allowed = await callTool('read', { paths: ['/anything'] });
+    expect(allowed).not.toContain('CALLER_IDENTITY_REQUIRED');
+    // The ordinary sandbox now decides the call; no approved root was granted by this setting.
+    expect(allowed).toMatch(REFUSED_ON_ROOTS);
+    expect(swarmRunning()).toBe(false);
+
+    await setEnabled(true);
+    expect(await callTool('read', { paths: ['/anything'] })).toContain('CALLER_IDENTITY_REQUIRED');
   });
 
   it('permits an unattributed workspace-dependent call to fail honestly instead of guessing a chat', async () => {

--- a/test/artifact-download.test.ts
+++ b/test/artifact-download.test.ts
@@ -1,0 +1,408 @@
+/**
+ * download_artifact: ChatGPT-provided files land inside approved roots, and only there.
+ *
+ * Three layers, tested bottom-up like the implementation is built:
+ * artifact-fetch (trusted-URL gateway) → artifact-target (exclusive publish) →
+ * downloadArtifactFile (sandbox resolution + orchestration) → MCP surface
+ * (registration, _meta fileParams, TOOL_DISABLED gating).
+ */
+
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  normalizeOpenAIFileReference,
+  openArtifactFile,
+  validateOpenAIFileUrl
+} from '../src/main/mcp/artifact-fetch.js';
+import { downloadArtifactFile } from '../src/main/mcp/artifact-download.js';
+import {
+  ARTIFACT_PARTIAL_PREFIX,
+  openArtifactTarget
+} from '../src/main/mcp/artifact-target.js';
+import { startMcpServer, type McpEndpoint } from '../src/main/mcp/server.js';
+import type { ToolContext } from '../src/main/mcp/tools.js';
+import { resetWorkspaces } from '../src/main/workspace.js';
+import { DEFAULT_CAPABILITIES, type Capabilities, type Root } from '../src/shared/types.js';
+import { makeTempDir, removeTempDir } from './helpers.js';
+
+const FILE_ID = 'file-abc123';
+const GOOD_URL = 'https://files.oaiusercontent.com/file-abc123?se=2030&sig=test';
+
+function fileRef(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return { download_url: GOOD_URL, file_id: FILE_ID, ...over };
+}
+
+/** Minimal fetch stub: route URL → canned Response. */
+function stubFetch(handler: (url: string) => Response): typeof fetch {
+  return (async (input: unknown) => handler(String(input))) as unknown as typeof fetch;
+}
+
+function okResponse(body: string, headers: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'application/octet-stream', ...headers }
+  });
+}
+
+async function streamText(stream: AsyncIterable<unknown>): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const value of stream) {
+    chunks.push(typeof value === 'string' ? Buffer.from(value) : Buffer.from(value as Uint8Array));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+// ------------------------------------------------------------------ fetch gateway
+
+describe('artifact file gateway', () => {
+  it('accepts only the trusted ChatGPT file hosts over https', () => {
+    expect(validateOpenAIFileUrl(GOOD_URL)).toBe(GOOD_URL);
+    for (const bad of [
+      'http://files.oaiusercontent.com/file-abc123',
+      'https://evil.example.com/file-abc123',
+      'https://files.oaiusercontent.com.evil.example.com/x',
+      'https://myaccount.blob.core.windows.net/c/f',
+      'https://oaisdmntprlookalike.blob.core.windows.net/c/f',
+      'https://files.oaiusercontent.com:8080/x',
+      'https://user:pass@files.oaiusercontent.com/x',
+      'https://files.oaiusercontent.com/x#frag',
+      'not-a-url'
+    ]) {
+      expect(() => validateOpenAIFileUrl(bad), bad).toThrow();
+    }
+  });
+
+  it('rejects malformed or smuggled file references', () => {
+    expect(() => normalizeOpenAIFileReference({})).toThrow();
+    expect(() => normalizeOpenAIFileReference(fileRef({ file_id: 42 }))).toThrow();
+    // strictObject behaviour lives in the tool schema; the gateway additionally refuses
+    // unknown keys so a hand-built call cannot widen the reference shape.
+    expect(() => normalizeOpenAIFileReference(fileRef({ authorization: 'Bearer x' }))).toThrow();
+    expect(() => normalizeOpenAIFileReference(fileRef({ file_id: 'x'.repeat(600) }))).toThrow();
+    expect(() => normalizeOpenAIFileReference(fileRef({ file_id: 'bad\x01id' }))).toThrow();
+  });
+
+  it('re-validates every redirect hop and rejects escapes', async () => {
+    const fetch = stubFetch((url) => {
+      if (url === GOOD_URL) return new Response(null, { status: 302, headers: { location: 'https://evil.example.com/f' } });
+      return okResponse('nope');
+    });
+    await expect(openArtifactFile(fileRef(), { fetch })).rejects.toThrow(/outside the trusted file host/);
+  });
+
+  it('follows an allowlisted redirect and checks size agreement', async () => {
+    const target = 'https://files.oaiusercontent.com/redirected-file?sig=y';
+    const fetch = stubFetch((url) => {
+      if (url === GOOD_URL) return new Response(null, { status: 302, headers: { location: target } });
+      return okResponse('hello', { 'content-length': '5' });
+    });
+    const opened = await openArtifactFile(fileRef({ size: 5, file_name: 'hi.txt' }), { fetch });
+    expect(await streamText(opened.stream)).toBe('hello');
+    const mismatch = stubFetch(() => okResponse('hello', { 'content-length': '5' }));
+    await expect(openArtifactFile(fileRef({ size: 6 }), { fetch: mismatch })).rejects.toThrow(/did not match/);
+  });
+
+
+});
+
+// ------------------------------------------------------------------ secure target
+
+describe('artifact secure target', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await makeTempDir('clf-artifact-target-');
+  });
+  afterEach(async () => { await removeTempDir(dir); });
+
+  it('writes an exclusive partial and publishes it atomically', async () => {
+    const target = await openArtifactTarget({ parentReal: dir, rootReal: dir, name: 'a.png', maxFileBytes: 1024 });
+    await target.writeAll(Buffer.from('PNGDATA'), 0);
+    await target.syncAndVerify(7);
+    // Not visible before publish.
+    await expect(fs.stat(path.join(dir, 'a.png'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await target.publish();
+    await target.close();
+    expect(await fs.readFile(path.join(dir, 'a.png'), 'utf8')).toBe('PNGDATA');
+    const leftovers = (await fs.readdir(dir)).filter((f) => f.startsWith(ARTIFACT_PARTIAL_PREFIX));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('requires canonical paths even when a directory has a stable ancestor alias', async () => {
+    const real = path.join(dir, 'real');
+    const alias = path.join(dir, 'alias');
+    await fs.mkdir(path.join(real, 'nested'), { recursive: true });
+    await fs.symlink(real, alias, process.platform === 'win32' ? 'junction' : 'dir');
+    const spelled = path.join(alias, 'nested');
+    // Like macOS /var or a Windows runner junction, the leaf is an ordinary directory.
+    // Its spelling still does not satisfy the target's sandbox-canonical contract.
+    expect((await fs.lstat(spelled)).isSymbolicLink()).toBe(false);
+    await expect(openArtifactTarget({ parentReal: spelled, rootReal: spelled, name: 'result.bin', maxFileBytes: 10 })).rejects.toThrow(/parent changed/);
+    const canonical = await fs.realpath(spelled);
+    const target = await openArtifactTarget({ parentReal: canonical, rootReal: canonical, name: 'result.bin', maxFileBytes: 10 });
+    try {
+      await target.writeAll(Buffer.from('safe'), 0);
+      await target.syncAndVerify(4);
+      await target.publish();
+    } finally { await target.close(); }
+    expect(await fs.readFile(path.join(spelled, 'result.bin'), 'utf8')).toBe('safe');
+  });
+  it('refuses to overwrite and leaves the existing file alone', async () => {
+    await fs.writeFile(path.join(dir, 'taken.txt'), 'original');
+    await expect(
+      openArtifactTarget({ parentReal: dir, rootReal: dir, name: 'taken.txt', maxFileBytes: 1024 })
+    ).rejects.toThrow(/already exists/);
+    expect(await fs.readFile(path.join(dir, 'taken.txt'), 'utf8')).toBe('original');
+  });
+
+  it('rejects symlinked parents and unsafe names', async () => {
+    const real = path.join(dir, 'real');
+    await fs.mkdir(real);
+    const linkPath = path.join(dir, 'linkparent');
+    try {
+      await fs.symlink(real, linkPath, 'dir');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EPERM') return;
+      throw error;
+    }
+    await expect(
+      openArtifactTarget({ parentReal: linkPath, rootReal: dir, name: 'x.bin', maxFileBytes: 1024 })
+    ).rejects.toThrow(/real directory/);
+    for (const bad of ['..', '', 'a/b', 'a\\b']) {
+      await expect(
+        openArtifactTarget({ parentReal: dir, rootReal: dir, name: bad, maxFileBytes: 1024 })
+      ).rejects.toThrow(/invalid/);
+    }
+  });
+
+  it('refuses an equal-sized partial replacement before linking and does not remove that foreign file', async () => {
+    const target = await openArtifactTarget({ parentReal: dir, rootReal: dir, name: 'result.bin', maxFileBytes: 100 });
+    await target.writeAll(Buffer.from('safe'), 0);
+    await target.syncAndVerify(4);
+    const partial = path.join(dir, (await fs.readdir(dir)).find(file => file.startsWith(ARTIFACT_PARTIAL_PREFIX))!);
+    await fs.rename(partial, path.join(dir, 'original.partial'));
+    await fs.writeFile(partial, 'evil');
+    await expect(target.publish()).rejects.toThrow(/changed/);
+    await target.close();
+    await expect(fs.stat(path.join(dir, 'result.bin'))).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(await fs.readFile(partial, 'utf8')).toBe('evil');
+  });
+  it('refuses a changed parent after streaming without creating a destination there', async () => {
+    const folder = path.join(dir, 'folder');
+    await fs.mkdir(folder);
+    const target = await openArtifactTarget({ parentReal: folder, rootReal: dir, name: 'result.bin', maxFileBytes: 100 });
+    await target.writeAll(Buffer.from('safe'), 0);
+    await target.syncAndVerify(4);
+    // Windows rejects renaming a directory with our open partial. Model the changed
+    // canonical observation directly so this publication boundary is tested on every OS.
+    const { rawPromises } = await import('../src/main/rawfs.js');
+    const realpath = vi.spyOn(rawPromises, 'realpath').mockResolvedValueOnce(path.join(dir, 'moved'));
+    try { await expect(target.publish()).rejects.toThrow(/parent changed/); }
+    finally { realpath.mockRestore(); await target.close(); }
+    expect(await fs.readdir(folder)).toEqual([]);
+  });
+});
+
+// ------------------------------------------------------------------ orchestration
+
+describe('downloadArtifactFile', () => {
+  let base: string;
+  let approved: string;
+  let roots: Root[];
+
+  beforeAll(async () => {
+    base = await makeTempDir('clf-artifact-');
+    approved = path.join(base, 'workspace');
+    await fs.mkdir(approved, { recursive: true });
+    roots = [{ name: 'workspace', path: approved }];
+  });
+
+  afterAll(async () => {
+    await removeTempDir(base);
+  });
+
+  beforeEach(() => {
+    resetWorkspaces();
+  });
+
+  function fetchBytes(body: string): typeof fetch {
+    return stubFetch(() => okResponse(body, { 'content-length': String(Buffer.byteLength(body)) }));
+  }
+
+  it('saves into an existing nested folder and reports size+sha256', async () => {
+    await fs.mkdir(path.join(approved, 'reports'));
+    const saved = await downloadArtifactFile(roots, '/workspace/reports/icon.png', fileRef(), {
+      maxFileBytes: 1024 * 1024,
+      fetch: fetchBytes('IMAGEDATA!')
+    });
+    expect(saved.virtual).toBe('/workspace/reports/icon.png');
+    expect(saved.size).toBe(10);
+    expect(saved.sha256).toBe(`sha256:${createHash('sha256').update('IMAGEDATA!').digest('hex')}`);
+    expect(await fs.readFile(path.join(approved, 'reports', 'icon.png'), 'utf8')).toBe('IMAGEDATA!');
+  });
+
+  it('cleans a partial and cancels an oversized response before reading its body', async () => {
+    const cancel = vi.fn();
+    const response = new Response(new ReadableStream({ cancel }), { headers: { 'content-length': '100' } });
+    await expect(downloadArtifactFile(roots, '/workspace/cancel.bin', fileRef(), {
+      maxFileBytes: 4, fetch: stubFetch(() => response)
+    })).rejects.toThrow(/limit/);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(cancel).toHaveBeenCalledOnce();
+    expect((await fs.readdir(approved)).filter(file => file.startsWith(ARTIFACT_PARTIAL_PREFIX))).toEqual([]);
+    await expect(fs.stat(path.join(approved, 'cancel.bin'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('leaves no partial after a fetch failure and never creates missing parents', async () => {
+    await expect(downloadArtifactFile(roots, '/workspace/fetchfail.bin', fileRef(), {
+      maxFileBytes: 4, fetch: (async () => { throw new Error('private network detail'); }) as typeof fetch
+    })).rejects.toThrow('ChatGPT file could not be downloaded.');
+    expect((await fs.readdir(approved)).filter(file => file.startsWith(ARTIFACT_PARTIAL_PREFIX))).toEqual([]);
+    const fetch = vi.fn();
+    await expect(downloadArtifactFile(roots, '/workspace/missing/child.bin', fileRef(), { maxFileBytes: 4, fetch })).rejects.toThrow();
+    expect(fetch).not.toHaveBeenCalled();
+    await expect(fs.stat(path.join(approved, 'missing'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('refuses traversal, folders, existing files and oversized streams', async () => {
+    await expect(
+      downloadArtifactFile(roots, '/workspace/../../evil.bin', fileRef(), {
+        maxFileBytes: 1024,
+        fetch: fetchBytes('x')
+      })
+    ).rejects.toThrow();
+    await expect(
+      downloadArtifactFile(roots, '/workspace/folder/', fileRef(), {
+        maxFileBytes: 1024,
+        fetch: fetchBytes('x')
+      })
+    ).rejects.toThrow(/folder/);
+    await fs.writeFile(path.join(approved, 'kept.bin'), 'keep');
+    await expect(
+      downloadArtifactFile(roots, '/workspace/kept.bin', fileRef(), {
+        maxFileBytes: 1024,
+        fetch: fetchBytes('new')
+      })
+    ).rejects.toThrow(/already exists/);
+    expect(await fs.readFile(path.join(approved, 'kept.bin'), 'utf8')).toBe('keep');
+    await expect(
+      downloadArtifactFile(roots, '/workspace/big.bin', fileRef(), {
+        maxFileBytes: 4,
+        fetch: fetchBytes('way too long')
+      })
+    ).rejects.toThrow(/limit/);
+    await expect(
+      downloadArtifactFile(roots, '/workspace/x.bin', { nope: true }, {
+        maxFileBytes: 1024,
+        fetch: fetchBytes('x')
+      })
+    ).rejects.toThrow(/malformed/);
+  });
+});
+
+// ------------------------------------------------------------------ MCP surface
+
+describe('download_artifact MCP surface', () => {
+  let base: string;
+  let approved: string;
+  let endpoint: McpEndpoint;
+  let ctx: ToolContext;
+  let nextId = 1;
+
+  const withCaps = (overrides: Partial<Capabilities>): Capabilities => ({ ...DEFAULT_CAPABILITIES, ...overrides });
+
+  function rawCall(body: string): Promise<{ status: number; parsed: any }> {
+    const url = new URL(endpoint.urls.core);
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: url.pathname + url.search,
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream',
+            'content-length': Buffer.byteLength(body)
+          }
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (chunk: Buffer) => chunks.push(chunk));
+          res.on('end', () => {
+            const text = Buffer.concat(chunks).toString('utf8').trim();
+            let parsed: any = text;
+            try {
+              parsed = JSON.parse(text);
+            } catch {
+              const last = [...text.matchAll(/^data:\s*(.*)$/gm)].map((m) => m[1]).at(-1);
+              if (last !== undefined) parsed = JSON.parse(last);
+            }
+            resolve({ status: res.statusCode ?? 0, parsed });
+          });
+        }
+      );
+      req.on('error', reject);
+      req.end(body);
+    });
+  }
+
+  const list = async (): Promise<Array<Record<string, any>>> => {
+    const { parsed } = await rawCall(JSON.stringify({ jsonrpc: '2.0', id: nextId++, method: 'tools/list', params: {} }));
+    return (parsed?.result?.tools ?? []) as Array<Record<string, any>>;
+  };
+
+  beforeAll(async () => {
+    base = await makeTempDir('clf-artifact-mcp-');
+    approved = path.join(base, 'workspace');
+    await fs.mkdir(approved, { recursive: true });
+  });
+
+  afterAll(async () => {
+    if (endpoint) await endpoint.stop();
+    await removeTempDir(base);
+  });
+
+  beforeEach(async () => {
+    if (endpoint) await endpoint.stop();
+    resetWorkspaces();
+    ctx = {
+      roots: [{ name: 'workspace', path: approved }],
+      caps: withCaps({}),
+      readOnly: true,
+      sessionTools: false,
+      agentTools: false
+    };
+    endpoint = await startMcpServer(() => ctx);
+  });
+
+  it('is absent without the capability and advertised with fileParams once enabled', async () => {
+    expect((await list()).map((t) => t.name)).not.toContain('download_artifact');
+    ctx.caps = withCaps({ saveArtifact: true });
+    const tools = await list();
+    const tool = tools.find((t) => t.name === 'download_artifact');
+    expect(tool).toBeDefined();
+    // The one field ChatGPT needs to inject the native file value (the spike question).
+    expect(tool?.['_meta']).toMatchObject({ 'openai/fileParams': ['file'] });
+  });
+
+  it('keeps the schema but refuses the call after the permission is switched off', async () => {
+    ctx.caps = withCaps({ saveArtifact: true });
+    expect((await list()).map((t) => t.name)).toContain('download_artifact');
+    ctx.caps = withCaps({});
+    ctx.readOnly = false;
+    const { parsed } = await rawCall(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: nextId++,
+        method: 'tools/call',
+        params: { name: 'download_artifact', arguments: { file: fileRef(), path: '/workspace/x.bin' } }
+      })
+    );
+    expect(parsed?.result?.isError).toBe(true);
+    expect(JSON.stringify(parsed?.result?.content)).toContain('TOOL_DISABLED');
+  });
+});

--- a/test/background-window.test.ts
+++ b/test/background-window.test.ts
@@ -37,10 +37,18 @@ function harness(initial: Tab[], cached?: number) {
         if (!windows.has(id)) throw new Error('Window closed'); return windows.get(id);
       } }
     }
-  }) as { createChatTab(url: string, background: boolean): Promise<Tab>; reconcileBackgroundWindow(policy: object): Promise<boolean> };
+  }) as { createChatTab(url: string, background: boolean, active?: boolean): Promise<Tab>; reconcileBackgroundWindow(policy: object): Promise<boolean> };
   return { ...api, tabs, stored, create, move, get, windowCreate, windowUpdate };
 }
 const policy = { background: true, managedConversations: ['main', 'worker'] };
+
+it('selects a recovery tab inside the owned window without focusing or restoring the window', async () => {
+  const app = harness([{ id: 1, windowId: 9, url: 'https://chatgpt.com/c/main' }], 9);
+  await app.createChatTab('https://chatgpt.com/c/recovered', true, true);
+  expect(app.create).toHaveBeenCalledWith({ url: 'https://chatgpt.com/c/recovered', windowId: 9, active: true });
+  expect(app.windowCreate).not.toHaveBeenCalled();
+  expect(app.windowUpdate).not.toHaveBeenCalled();
+});
 
 it('adopts an existing app main window after cache loss and puts planner and worker tabs beside it', async () => {
   const app = harness([{ id: 1, windowId: 9, url: 'https://chatgpt.com/c/main' }]);

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -17,6 +17,10 @@ import type { ContinuationSnapshot } from '../src/main/session/continuation.js';
 import type { SwarmSnapshot } from '../src/main/agents.js';
 import type { Config } from '../src/shared/types.js';
 
+const recoveryBrowserWake = vi.hoisted(() => vi.fn(async (_url: string, _retry?: boolean, _background?: boolean,
+  _authority?: { current(): boolean; requireProcessAbsence: boolean }) => {}));
+vi.mock('../src/main/browser-startup.js', () => ({ wakeBrowserUrl: recoveryBrowserWake }));
+
 async function recordFinalForTest(conversationId: string, turnId: string): Promise<void> {
   await request('POST', '/events', { body: { conversationId, events: [{ kind: 'assistant_message', time: Date.now(),
     turnId, messageId: `final-${turnId}`, text: 'The requested turn is finished.', state: 'final', final: true }] } });
@@ -41,6 +45,8 @@ const { initSecretsPath, resetSecretsCacheForTests, setSecret } = await import('
 const {
   bridgePort,
   bridgeStatus,
+  compactSession,
+  setSessionObjective,
   unattributedRepairEta,
   cancelResume,
   commandUrl,
@@ -52,7 +58,6 @@ const {
   setBrowserOpener,
   shutdownBridge,
   STALE_SWARM_MS,
-  BROWSER_PLACEMENT_MS,
   CHAT_SILENCE_MS,
   GOAL_QUIET_MS,
   GOAL_SILENCE_LISTEN_MS,
@@ -137,7 +142,7 @@ const {
 } = await import(
   '../src/main/agents.js'
 );
-const { makeTempDir, removeTempDir, SAMPLE_BRIEF } = await import('./helpers.js');
+const { makeTempDir, removeTempDir, SAMPLE_BRIEF, faultGate } = await import('./helpers.js');
 const { resumeBootstrapText } = await import('../src/main/session/handoff.js');
 const { getLog } = await import('../src/main/logger.js');
 
@@ -327,6 +332,7 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
+  recoveryBrowserWake.mockClear();
   vi.mocked(safeStorage.isAsyncEncryptionAvailable).mockResolvedValue(true);
   // A test that writes its own config is not allowed to leak it into the next one.
   await saveConfig(suiteConfig);
@@ -537,22 +543,26 @@ describe('active agent tab discard projection', () => {
       finishAgent({ conversationId: chats[0]! }, 'first sleeping');
       finishAgent({ conversationId: chats[1]! }, 'second sleeping');
       const status = (await request('POST', '/status', { body: { openConversations: chats } })).body;
-      expect(status.idleCloseAfterMs).toBe(60000);
+      expect(status.idleCloseAfterMs).toBe(120000);
       expect(status.tabsToKeepOpen).toBe(3);
+      expect(status.workerConversations).toEqual(expect.arrayContaining(chats));
+      expect(status.sleepingWorkerConversations).toEqual(chats.slice(0, 2));
       expect(status.managedConversations).toEqual(expect.arrayContaining(chats));
       expect(status.closableConversations).toEqual([]);
       expect(status.nonDiscardableConversations).not.toContain(chats[2]); // broker state alone is not live page work
       const now = Date.now();
-      const clock = vi.spyOn(Date, 'now').mockReturnValue(now + 61_000);
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(now + 121_000);
       try {
         noteAgentAlive(chats[0], 'page'); // periodic page presence must not renew idle work
         const quiet = (await request('POST', '/status', { body: { openConversations: chats } })).body;
         expect(quiet.closableConversations).toEqual(expect.arrayContaining(chats.slice(0, 2)));
+        expect(quiet.retiredConversations).toEqual(expect.arrayContaining(chats.slice(0, 2)));
+        expect(quiet.retiredConversations).toContain(chats[2]); // idle deadline also applies without a broker sleep
         setChatBlocked(chats[2]!, true);
         const newlyBlocked = (await request('POST', '/status', { body: { openConversations: chats } })).body;
         expect(newlyBlocked.blockedConversations).toContain(chats[2]);
         expect(newlyBlocked.closableConversations).not.toContain(chats[2]);
-        clock.mockReturnValue(now + 122_000);
+        clock.mockReturnValue(now + 242_000);
         noteAgentAlive(chats[2], 'page');
         const blockedIdle = (await request('POST', '/status', { body: { openConversations: chats } })).body;
         expect(blockedIdle.closableConversations).toContain(chats[2]);
@@ -565,6 +575,53 @@ describe('active agent tab discard projection', () => {
       await saveConfig({ ...getConfig(), ui: { ...getConfig().ui, tabsToKeepOpen: 2 } });
       expect((await request('GET', '/status')).body.closableConversations).toEqual([]);
     } finally { await saveConfig(previous); }
+  });
+  it.each(['opening', 'established', 'missing-source', 'same-source'])('retires only cancelled claimed dedicated helpers, preserving source and personal chats (%s)', async kind => {
+    await pair();
+    const { registerGoalDecisionChat } = await import('../src/main/goal.js');
+    const { resetInputForTests } = await import('../src/main/session/input.js');
+    const main = 'cafe0189-0000-4000-8000-000000000189';
+    const helper = `cafe0190-0000-4000-8000-00000000019${['opening', 'established', 'missing-source', 'same-source'].indexOf(kind)}`;
+    const personal = 'cafe0191-0000-4000-8000-000000000191';
+    const source = await createSession({ conversationId: kind === 'same-source' ? helper : main, title: 'Source' });
+    const sourceId = kind === 'opening' ? undefined : kind === 'missing-source' ? '2026-09-07-missing' : source.id;
+    const eligible = kind === 'opening' || kind === 'established';
+    await registerGoalDecisionChat(helper, sourceId);
+    const row = { id: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee', sessionId: null, purpose: 'decision', state: 'cancelled',
+      text: 'Cancelled helper instruction', mode: 'after-turn', dueAt: Date.now() - 180000, createdAt: Date.now() - 180000,
+      model: null, reasoningEffort: null, owner: '71:helper-document:0', decisionSourceSessionId: sourceId, conversationId: helper };
+    await writeDurableNow('session-input', [row, { ...row, id: 'bbbbbbbb-bbbb-4ccc-8ddd-eeeeeeeeeeee', conversationId: personal }]);
+    resetInputForTests();
+    try {
+      const status = (await request('POST', '/status', { body: { openConversations: [main, helper, personal] } })).body;
+      expect(status.cancelledDecisionClaims.length).toBe(eligible ? 1 : 0);
+      if (eligible) {
+        expect(status.managedConversations).toContain(helper);
+        expect(status.closableConversations).toContain(helper);
+      }
+      expect(status.closableConversations).not.toContain(main);
+      expect(status.managedConversations).not.toContain(personal);
+      expect(status.cancelledDecisionClaims).toEqual(eligible ? [{ id: row.id, owner: row.owner, conversationId: helper }] : []);
+    } finally { await writeDurableNow('session-input', []); resetInputForTests(); }
+  });
+
+  it('projects only the owning prime worker status without task or conversation details', async () => {
+    await pair();
+    const primeConversation = '11223344-1111-4222-8333-444444444444';
+    const workerConversation = 'aabbccdd-1111-4222-8333-444444444444';
+    await createSession({ conversationId: primeConversation, title: 'Prime' });
+    await createSession({ conversationId: workerConversation, title: 'Worker' });
+    await recordFinalForTest(primeConversation, 'prime-progress');
+    await recordFinalForTest(workerConversation, 'worker-progress');
+    spawn({ workers: [{ task: 'PRIVATE_TASK_MUST_NOT_CROSS', label: 'Repository audit' }], caller: { conversationId: primeConversation } });
+    expect(bindConversation('worker-1', workerConversation)).toBe(true);
+    const prime = (await request('GET', `/activity?conversationId=${primeConversation}`)).body.progress;
+    expect(prime.workers).toMatchObject({ total: 1, active: 1, finished: 0, failed: 0, names: ['Repository audit'] });
+    expect(JSON.stringify(prime)).not.toContain('PRIVATE_TASK');
+    expect(JSON.stringify(prime)).not.toContain(workerConversation);
+    expect((await request('GET', `/activity?conversationId=${workerConversation}`)).body.progress.workers).toBeNull();
+    finishAgent({ conversationId: workerConversation }, 'done');
+    expect((await request('GET', `/activity?conversationId=${primeConversation}`)).body.progress.workers).toMatchObject({ active: 0, finished: 1 });
   });
   it('does not mistake a broker active label for a running provider turn', async () => {
     await pair();
@@ -993,6 +1050,18 @@ describe('activity feed', () => {
     expect((await request('GET', `/activity?conversationId=${own}`)).body.bootstrap).toBeNull();
   });
 
+  it('reports the committed current resume independently of the original desktop origin', async () => {
+    await pair();
+    const { rebindSession } = await import('../src/main/session/store.js');
+    const from = '77777777-3333-2222-1111-000000000071';
+    const to = '77777777-3333-2222-1111-000000000072';
+    const session = await createSession({ conversationId: from, origin: { kind: 'desktop', fromSessionId: null, agentId: null, task: '' } });
+    expect((await request('GET', `/activity?conversationId=${from}`)).body.bootstrap).toBe('desktop');
+    expect(await rebindSession(session.id, from, to, '2026-09-07-testproof')).toBe(true);
+    expect((await request('GET', `/activity?conversationId=${to}`)).body.bootstrap).toBe('resume');
+    expect((await request('GET', `/activity?conversationId=${from}`)).body.bootstrap).not.toBe('resume');
+  });
+
   it('returns nothing for a conversation it has never seen', async () => {
     await pair();
     const reply = await request('GET', '/activity?conversationId=deadbeef-0000-0000-0000-000000000000');
@@ -1177,6 +1246,50 @@ describe('activity feed', () => {
  */
 describe('automatic compaction', () => {
   const settled = () => new Promise((resolve) => setTimeout(resolve, 25));
+
+  it('hands an explicit desktop compaction to startup and fences a cancelled ticket', async () => {
+    await pair();
+    const conversationId = 'a1a1a1a1-0000-4000-8000-00000000ac98';
+    const session = await createSession({ conversationId });
+    await compactSession(session.id);
+    expect(recoveryBrowserWake).toHaveBeenCalledTimes(1);
+    const [url, , , authority] = recoveryBrowserWake.mock.calls[0]!;
+    expect(url).toBe(`https://chatgpt.com/c/${conversationId}`);
+    expect(authority?.current()).toBe(true);
+    abortContinuation(continuationForSession(session.id)!.token, 'user_cancelled');
+    expect(authority?.current()).toBe(false);
+  });
+
+  it('recovers a manual compaction with Auto Off and revokes cold startup on cancel', async () => {
+    vi.useFakeTimers();
+    try {
+      await pair();
+      const conversationId = 'a1a1a1a1-0000-4000-8000-00000000ac99';
+      await request('POST', '/events', { body: { conversationId, events: [
+        { kind: 'user_message', time: Date.now(), text: 'manual handoff', messageId: 'manual-pickup' }
+      ] } });
+      await request('POST', '/settings', { body: { conversationId, autoCompact: false } });
+      const filed = await request('POST', '/compact', { body: { conversationId, ticket: true } });
+      expect(filed.status).toBe(202);
+      const ticket = continuationForSession(filed.body.sessionId)!;
+      expect(ticket.automatic).toBe(false);
+      await request('POST', '/settings', { body: { conversationId, autoCompact: false } });
+      expect(continuationForSession(ticket.sessionId)?.token).toBe(ticket.token);
+      await vi.advanceTimersByTimeAsync(2 * 60_000);
+      await sweepStaleSwarm(Date.now());
+      expect(recoveryBrowserWake).toHaveBeenCalledTimes(1);
+      const [url, , , authority] = recoveryBrowserWake.mock.calls[0]!;
+      expect(url).toBe(`https://chatgpt.com/c/${conversationId}`);
+      expect(authority?.current()).toBe(true);
+      await sweepStaleSwarm(Date.now());
+      expect(recoveryBrowserWake).toHaveBeenCalledTimes(1);
+      abortContinuation(ticket.token, 'user_cancelled');
+      expect(authority?.current()).toBe(false);
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      await sweepStaleSwarm(Date.now());
+      expect(recoveryBrowserWake).toHaveBeenCalledTimes(1);
+    } finally { vi.useRealTimers(); }
+  });
 
   const over = (): unknown[] => [
     { kind: 'user_message', time: Date.now(), text: 'x'.repeat(44_000), messageId: 'over-the-line' }
@@ -2591,6 +2704,49 @@ describe('delivering a bootstrap', () => {
     expect(stale.body.error).toBe('no_such_command');
   });
 
+  it('captures the sending Project without an earlier activity poll', async () => {
+    await pair();
+    const id = 'abababab-1111-4222-8333-444444444444';
+    const session = await createSession({ title: 'Project source', conversationId: id });
+    const opened = await openContinuationNow(session.id, id);
+    const project = 'g-p-11111111222233334444555555555555';
+    const result = await request('POST', '/compact', { body: { conversationId: id, token: opened.token, sourceAttempt: true, project } });
+    expect(result.status).toBe(200);
+    expect(continuationByToken(opened.token)?.project).toBe(project);
+  });
+
+  it('validates deferred revival ids read-only before browser restart recovery opens a tab', async () => {
+    await pair();
+    spawn({ workers: [{ task: 'sleep and wake for recovery validation' }], caller: { conversationId: PRIME_CHAT } });
+    const bootstrap = await redeem();
+    const conversationId = 'abababab-1111-4222-8333-444444444444';
+    await request('POST', '/commands/ack', {
+      body: { id: bootstrap.id, status: 'sent', conversationId, agent: 'worker-1' }
+    });
+    finishAgent({ conversationId }, 'sleep now');
+    wake([{ to: 'worker-1', text: 'wake once after restart' }]);
+    const { id } = await waitForRevival();
+
+    const checked = await request('POST', '/commands/revivals/pending', {
+      body: {
+        entries: [
+          { id, conversationId },
+          { id: 'dead-command-id', conversationId },
+          { id, conversationId: '99999999-1111-4222-8333-444444444444' }
+        ]
+      }
+    });
+    expect(checked.status).toBe(200);
+    expect(checked.body).toEqual({ pending: [id] });
+
+    // Validation must not consume or lease the command. The actual page can still redeem the
+    // exact same wake afterwards, which preserves the existing one-page arbitration boundary.
+    const claimed = await request('POST', '/commands/redeem', {
+      body: { id, client: 'validated-restart-tab', conversationId }
+    });
+    expect(claimed.status).toBe(200);
+  });
+
   it('keeps a redeemed revival browser-owned until its exact sent acknowledgement', async () => {
     await pair();
     spawn({ workers: [{ task: 'write the audit' }], caller: { conversationId: PRIME_CHAT } });
@@ -3398,19 +3554,11 @@ describe('delivering a bootstrap', () => {
       body: { id: command.id, status: 'sent', conversationId, agent: 'worker-1' }
     });
 
-    let entered!: () => void;
-    const immediateEntered = new Promise<void>((resolve) => {
-      entered = resolve;
-    });
-    let release!: () => void;
-    const held = new Promise<void>((resolve) => {
-      release = resolve;
-    });
+    const gate = faultGate();
     let projected: ReturnType<typeof snapshotSwarm> = null;
     onSwarmPersistNow(async (snapshot) => {
       projected = snapshot;
-      entered();
-      await held;
+      await gate.hold();
       await writeDurableNow('swarm', snapshot);
     });
 
@@ -3433,12 +3581,12 @@ describe('delivering a bootstrap', () => {
           ]
         }
       });
-      await immediateEntered;
+      await gate.entered;
 
       // The immediate writer must see the exact proposed terminal generation, otherwise a
       // success response could still crash back to an active worker after restart.
       // The assignment occurs inside the persistence callback. TypeScript's synchronous control
-      // flow cannot infer from `immediateEntered` that the callback has run, so name the runtime
+      // flow cannot infer from `gate.entered` that the callback has run, so name the runtime
       // proof explicitly instead of letting it narrow the outer variable to its initial null.
       const projectedAfterEntry = projected as SwarmSnapshot | null;
       expect(projectedAfterEntry?.agents.find((agent) => agent.info.id === 'worker-1')?.info.state).toBe('sleeping');
@@ -3453,7 +3601,7 @@ describe('delivering a bootstrap', () => {
       expect(snapshotSwarm()?.agents.find((agent) => agent.info.id === 'worker-1')?.info.state).toBe('active');
       expect(snapshotSwarm()?.agents.find((agent) => agent.info.id === PRIME_ID)?.queue).toEqual([]);
 
-      release();
+      gate.release();
       const recorded = await recording;
       expect(recorded.status).toBe(200);
       expect(swarmState().running).toBe(false);
@@ -3461,7 +3609,7 @@ describe('delivering a bootstrap', () => {
       expect(ownerState.agents.find((agent) => agent.id === 'worker-1')?.state).toBe('sleeping');
       expect(ownerState.agents.find((agent) => agent.id === PRIME_ID)?.pending).toBe(1);
     } finally {
-      release();
+      gate.release();
       onSwarmPersistNow((snapshot) => writeDurableNow('swarm', snapshot));
     }
   });
@@ -3812,23 +3960,12 @@ describe('delivering a bootstrap', () => {
     expect(workerCommand).toBeTruthy();
     await flushDurable();
 
-    let entered!: () => void;
-    const immediateEntered = new Promise<void>((resolve) => {
-      entered = resolve;
-    });
-    let release!: () => void;
-    const held = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    let persisted!: () => void;
-    const brokerPersisted = new Promise<void>(resolve => { persisted = resolve; });
+    const gate = faultGate();
     let brokerProjection: ReturnType<typeof snapshotSwarm> = null;
     onSwarmPersistNow(async (snapshot) => {
       brokerProjection = snapshot;
-      entered();
-      await held;
+      await gate.hold();
       await writeDurableNow('swarm', snapshot);
-      persisted();
     });
 
     try {
@@ -3836,7 +3973,7 @@ describe('delivering a bootstrap', () => {
       // but disk must retain that old transport until the failed worker/dormant owner snapshot
       // held above has crossed its independent durability boundary.
       for (let n = 0; n < 20; n++) queueResume(`crash-order-session-${n}`, `crash-order-token-${n}`);
-      await immediateEntered;
+      await gate.entered;
       expect(pendingCommands().some((entry) => entry.id === workerCommand.id)).toBe(false);
       expect(swarmState().running).toBe(false);
       expect(swarmStateForCaller({ conversationId: PRIME_CHAT }).agents.find((entry) => entry.id === 'worker-1')).toMatchObject({
@@ -3852,21 +3989,20 @@ describe('delivering a bootstrap', () => {
         )?.info.state
       ).toBe('failed');
 
-      release();
-      // Two microtasks do not complete an actual fs write on a loaded host. Wait for
-      // the broker durability boundary, then drain the bridge write it releases.
-      await brokerPersisted;
-      await vi.waitFor(async () => {
-        await flushDurable();
-        const after = await readDurable<any>('bridge-commands');
-        expect(after?.commands?.some((entry: any) => entry?.id === workerCommand.id)).toBe(false);
-      });
+      // Join the same critical flight as drop() before releasing it. Its earlier
+      // continuation queues bridge retirement before this observer drains disk.
+      const brokerPersisted = persistCriticalSwarmNow();
+      gate.release();
+      expect(await brokerPersisted).toBe(true);
+      await flushDurable();
+      const after = await readDurable<any>('bridge-commands');
+      expect(after?.commands?.some((entry: any) => entry?.id === workerCommand.id)).toBe(false);
       const durableBroker = await readDurable<any>('swarm');
       expect(durableBroker?.dormantRuns?.[0]?.agents.find((entry: any) => entry?.info?.id === 'worker-1')?.info?.state).toBe(
         'failed'
       );
     } finally {
-      release();
+      gate.release();
       onSwarmPersistNow((snapshot) => writeDurableNow('swarm', snapshot));
     }
   });
@@ -3938,7 +4074,7 @@ ${SAMPLE_BRIEF}` }
     const stored = await captureFrom(HOME);
 
     expect(stored.body.stored).toBe(true);
-    expect(stored.body.placement).toEqual({ id: stored.body.commandId, model: null, reasoningEffort: null });
+    expect(stored.body.placement).toMatchObject({ id: stored.body.commandId, model: null, reasoningEffort: null, active: true });
     // The whole point: this app did not ask the operating system where its own chat should go.
     expect(opened).toEqual([]);
     expect(pendingCommands()).toEqual([
@@ -3973,7 +4109,7 @@ ${SAMPLE_BRIEF}` }
     expect(opened).toEqual([commandUrl(command.id)]);
   });
 
-  it('falls back to the OS when the browser it was handed to never opens the tab', async () => {
+  it('never issues a second open while the handed-out browser tab is still hydrating', async () => {
     vi.useFakeTimers();
     try {
       await pair();
@@ -3981,11 +4117,11 @@ ${SAMPLE_BRIEF}` }
       expect(stored.body.placement).not.toBeNull();
       expect(opened).toEqual([]);
 
-      // The page took the offer and died before it could create the tab — a window closing, an
-      // extension too old to understand the field. Nothing redeems, so the command is opened
-      // the old way well inside its own ninety-second deadline rather than expiring unopened.
-      await vi.advanceTimersByTimeAsync(BROWSER_PLACEMENT_MS + 1);
-      expect(opened).toEqual([commandUrl(stored.body.commandId as string)]);
+      // No receipt yet is ambiguous: a slow provider page can already own a real tab.
+      await vi.advanceTimersByTimeAsync(20_001);
+      expect(opened).toEqual([]);
+      expect((await request('GET', `/activity?conversationId=${HOME}`)).body.placement).toBeNull();
+      expect((await redeem(stored.body.commandId)).type).toBe('resume');
     } finally {
       vi.useRealTimers();
     }
@@ -4192,8 +4328,8 @@ describe('targeted open', () => {
       expect(pendingCommands().map((entry) => entry.what)).toEqual([`resume:${sessionId}`]);
       expect(continuationByToken(token)?.state).toBe('claimed');
 
-      // No new lifetime is invented: the existing 10m continuation TTL remains the outer bound.
-      await vi.advanceTimersByTimeAsync(7 * 60_000);
+      // The claim is progress, then ten minutes without further progress ends its waiting lease.
+      await vi.advanceTimersByTimeAsync(8 * 60_000 + 1);
       expect(pendingCommands()).toEqual([]);
       expect(continuationByToken(token)?.state).toBe('aborted');
       expect((await getSession(sessionId))?.conversationId).toBe(sourceConversation);
@@ -4206,25 +4342,34 @@ describe('targeted open', () => {
 // ------------------------------------------------------- worker bootstrap failure
 
 describe('a worker chat that never opens', () => {
-  it('hands a background worker to companion status once without raising the OS browser', async () => {
+  it.each([true, false])('places two workers once through the companion with background window=%s', async (backgroundChats) => {
     await pair();
     const config = getConfig();
-    await saveConfig({ ...config, ui: { ...config.ui, backgroundChats: true } });
+    await saveConfig({ ...config, ui: { ...config.ui, backgroundChats } });
     await request('GET', '/status');
     const socket = new WebSocket(base.replace('http:', 'ws:') + '/wake', { origin: EXTENSION_ORIGIN });
     await once(socket, 'open');
     const authenticated = once(socket, 'message'); socket.send(token!); await authenticated;
     try {
-    spawn({ workers: [{ task: 'background placement probe' }], caller: { conversationId: PRIME_CHAT } });
+    spawn({ workers: [{ task: 'first placement probe' }, { task: 'second placement probe' }], caller: { conversationId: PRIME_CHAT } });
     let placement: any;
     await vi.waitFor(async () => {
       const result = await request('GET', '/status');
       placement ||= result.body.placement;
-      expect(placement?.background).toBe(true);
+      expect(placement?.id).toBeTruthy();
+      expect(placement.active).toBe(false);
+      expect(placement.background === true).toBe(backgroundChats);
     });
     expect(opened).toEqual([]);
     expect((await request('GET', '/status')).body.placement).toBeNull();
     expect((await redeem(placement.id)).agent).toBe('worker-1');
+    await request('POST', '/commands/ack', { body: { id: placement.id, status: 'sent', agent: 'worker-1', conversationId: 'abababab-1111-4222-8333-444444444444' } });
+    let second: any;
+    await vi.waitFor(async () => { second ||= (await request('GET', '/status')).body.placement; expect(second?.id).toBeTruthy(); });
+    expect(second.id).not.toBe(placement.id);
+    expect(second.active).toBe(false);
+    expect((await redeem(second.id)).agent).toBe('worker-2');
+    expect((await request('GET', '/status')).body.placement).toBeNull();
     expect(opened).toEqual([]);
     } finally { const closed = once(socket, 'close'); socket.close(); await closed; }
   });
@@ -4346,59 +4491,23 @@ describe('a worker chat that never opens', () => {
     }
   });
 
-  /**
-   * A chat that opened and never picked up its marker is opened once more, then failed.
-   *
-   * worker-4 on 2026-09-02: the tab loaded as an empty New chat, the bridge held its lease for
-   * the full ninety seconds, and the two workers queued behind it opened only after it was
-   * failed. The re-open is the same command — single-owner, so a late redeem from the first tab
-   * is refused and nothing is typed twice — and it is spent once.
-   */
-  it('opens a worker chat once more when the first page never redeems, and fails it after the second silence', async () => {
+  it('fails an unredeemed opening without duplicating it and advances to the next worker', async () => {
     vi.useFakeTimers();
     try {
       await pair();
-      spawn({ workers: [{ task: 'opens first' }, { task: 'waits behind it' }], caller: { conversationId: PRIME_CHAT } });
+      spawn({ workers: [{ task: 'first' }, { task: 'second' }], caller: { conversationId: PRIME_CHAT } });
       await vi.waitFor(() => expect(opened).toHaveLength(1));
       const first = new URL(opened[0]!).searchParams.get('clf')!;
-
       await vi.advanceTimersByTimeAsync(WORKER_REDEEM_MS + 1_000);
       await vi.waitFor(() => expect(opened).toHaveLength(2));
-      // The same command, not a second one: whichever page redeems first owns it.
-      expect(new URL(opened[1]!).searchParams.get('clf')).toBe(first);
-      expect(pendingWorkerSpawns().map((worker) => worker.id)).toEqual(['worker-1', 'worker-2']);
-
-      const second = await redeem(first, 'tab-2');
-      expect(second.agent).toBe('worker-1');
-      const late = await request('POST', '/commands/redeem', { body: { id: first, client: 'tab-1' } });
-      expect(late.status).toBe(409);
-      // Owned now: the page's typing budget applies, and the redeem window no longer does.
+      const second = new URL(opened[1]!).searchParams.get('clf')!;
+      expect(second).not.toBe(first);
+      expect(swarmState().agents.find(agent => agent.id === 'worker-1')?.state).toBe('failed');
+      expect((await request('POST', '/commands/redeem', { body: { id: first, client: 'late-page' } })).status).toBe(404);
+      expect((await redeem(second)).agent).toBe('worker-2');
       await vi.advanceTimersByTimeAsync(WORKER_REDEEM_MS + 1_000);
       expect(opened).toHaveLength(2);
-      expect(pendingWorkerSpawns().map((worker) => worker.id)).toEqual(['worker-1', 'worker-2']);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('fails a worker whose reopened chat never redeems either, and moves the line on', async () => {
-    vi.useFakeTimers();
-    try {
-      await pair();
-      spawn({ workers: [{ task: 'opens first' }, { task: 'waits behind it' }], caller: { conversationId: PRIME_CHAT } });
-      await vi.waitFor(() => expect(opened).toHaveLength(1));
-      await vi.advanceTimersByTimeAsync(WORKER_REDEEM_MS + 1_000);
-      await vi.waitFor(() => expect(opened).toHaveLength(2));
-      await vi.advanceTimersByTimeAsync(WORKER_REDEEM_MS + 1_000);
-      // worker-1 is failed, and worker-2's chat opens in the same beat rather than after ninety seconds.
-      await vi.waitFor(() => expect(opened).toHaveLength(3));
-      expect(pendingWorkerSpawns().map((worker) => worker.id)).toEqual(['worker-2']);
-      expect(swarmState().agents.find((agent) => agent.id === 'worker-1')?.state).toBe('failed');
-      const next = await redeem(new URL(opened[2]!).searchParams.get('clf')!);
-      expect(next.agent).toBe('worker-2');
-    } finally {
-      vi.useRealTimers();
-    }
+    } finally { vi.useRealTimers(); }
   });
 
   /**
@@ -4418,34 +4527,18 @@ describe('a worker chat that never opens', () => {
         caller: { conversationId: PRIME_CHAT }
       });
       expect(pendingWorkerSpawns().map((worker) => worker.id)).toEqual(['worker-1', 'worker-2', 'worker-3']);
-      // Nothing ever redeems. Each worker's chat opens, is opened once more, and fails: worker-1
-      // by forty seconds, worker-2 by eighty, and worker-3's re-open lands at about a hundred.
-      // Counting worker-3's clock from *there* would keep the slot invited past two minutes; the
-      // limit is measured from the invitation instead.
+      // Each failed opening releases its slot without opening the same command again.
       let elapsed = 0;
       const advance = async (ms: number): Promise<void> => {
         await vi.advanceTimersByTimeAsync(ms);
         elapsed += ms;
       };
-      // Each re-open re-leases through a real durable write, which lands after the fake clock has
-      // moved on, so the deadline it arms may need one more tick to fire.
-      const openedSoon = async (count: number): Promise<void> => {
-        try {
-          await vi.waitFor(() => expect(opened).toHaveLength(count), { timeout: 300 });
-        } catch {
-          await advance(1_000);
-          await vi.waitFor(() => expect(opened).toHaveLength(count));
-        }
-      };
-      for (let count = 1; count <= 5; count += 1) {
-        await openedSoon(count);
-        // The browser keeps polling, so no re-open is mistaken for a cold browser launch.
+      for (let count = 1; count <= 3; count++) {
+        await vi.waitFor(() => expect(opened).toHaveLength(count));
         await request('GET', '/status');
         await advance(WORKER_REDEEM_MS + 1_000);
       }
-      await openedSoon(6);
-      expect(elapsed).toBeLessThan(WORKER_BOOTSTRAP_LIMIT_MS - 5_000);
-      expect(pendingWorkerSpawns().map((worker) => worker.id)).toEqual(['worker-3']);
+      expect(new Set(opened.map(url => new URL(url).searchParams.get('clf'))).size).toBe(3);
 
       await advance(WORKER_BOOTSTRAP_LIMIT_MS + 1_000 - elapsed);
       // No zombie slot left behind: nothing is still owed a tab, and nothing is still invited.
@@ -6041,7 +6134,7 @@ describe('unattributed activity recovery', () => {
     }
   });
 
-  for (const model of ['GPT-6 Pro', 'GPT-5.6 Pro']) it(`keeps ${model} silent until ten minutes without inventing a Goal final`, async () => {
+  for (const model of ['GPT-6 Pro', 'GPT-5.6 Pro', 'gpt-5-6-pro', 'gpt-5-5-pro']) it(`keeps ${model} silent until ten minutes without inventing a Goal final`, async () => {
     const previous = getConfig();
     await saveConfig({ ...previous, goal: { ...previous.goal, enabled: true, mode: 'loop' } });
     await setSecret('openRouterApiKey', 'sk-or-pro');
@@ -6107,13 +6200,13 @@ describe('unattributed activity recovery', () => {
       expect(await maintenance()).toMatchObject({ reason: 'silence' });
     } finally { vi.useRealTimers(); }
   });
-  it('extends Pro activity from fresh observed tool starts and exact calls, not replayed tool rows', async () => {
-    const timingChat = 'a1111111-1111-4111-8111-111111111111';
+  it.each(['gpt-6-pro', 'gpt-5-6-pro'])('extends %s activity from fresh observed tool starts and exact calls, not replayed tool rows', async model => {
+    const timingChat = model === 'gpt-6-pro' ? 'a1111111-1111-4111-8111-111111111111' : 'a5555555-1111-4111-8111-111111111111';
     vi.useFakeTimers();
     try {
       await pair();
       const began = Date.now();
-      await events(timingChat, [{ kind: 'model_selection', model: 'gpt-6', reasoningEffort: 'pro', time: began }, openTurn('pro-tools')]);
+      await events(timingChat, [{ kind: 'model_selection', model, reasoningEffort: 'pro', time: began }, openTurn('pro-tools')]);
       const sessionId = (await request('GET', `/activity?conversationId=${timingChat}`)).body.sessionId;
       const { sessionActivityExpiresAt } = await import('../src/main/bridge.js');
       await vi.advanceTimersByTimeAsync(60_000);
@@ -6882,6 +6975,27 @@ describe('unattributed activity recovery', () => {
     }
   });
 
+  it.each(['gpt-5-6-pro', 'gpt-6-pro'])('updates %s worker tokens and proven model from a call without another page event', async model => {
+    await pair();
+    spawn({ workers: [{ task: 'measure exact recorded context' }], caller: { conversationId: PRIME } });
+    const bootstrap = await redeem();
+    const workerChat = model === 'gpt-5-6-pro' ? 'b1111111-1111-4111-8111-111111111111' : 'b2222222-1111-4111-8111-111111111111';
+    await request('POST', '/commands/ack', { body: { id: bootstrap.id, status: 'sent', conversationId: workerChat, agent: 'worker-1' } });
+    const began = Date.now();
+    await events(workerChat, [{ kind: 'model_selection', model, reasoningEffort: 'pro', time: began }, { kind: 'turn_start', time: began, turnId: 'meter-' + model }]);
+    const sessionId = (await request('GET', `/activity?conversationId=${workerChat}`)).body.sessionId;
+    const before = swarmState().agents.find(agent => agent.conversationId === workerChat)!.contextTokens;
+    const call = await recordToolCall({ tool: 'read', args: { path: '/project/file' }, content: [{ type: 'text', text: 'recorded work '.repeat(100) }], outcome: 'ok', durationMs: 1, startedAt: began + 1, conversationId: workerChat, sessionId });
+    expect(call).toMatchObject({ model, reasoningEffort: 'pro' });
+    const summary = await getSession(sessionId);
+    expect(summary!.contextTokens).toBeGreaterThan(before);
+    expect(swarmState().agents.find(agent => agent.conversationId === workerChat)!.contextTokens).toBe(summary!.contextTokens);
+    // A changed picker now describes the next selection, not the still-running model.
+    await events(workerChat, [{ kind: 'model_selection', model: 'gpt-5-6-thinking', reasoningEffort: 'high', time: began + 2 }]);
+    const afterSwitch = await recordToolCall({ tool: 'read', args: {}, content: [{ type: 'text', text: 'more work' }], outcome: 'ok', durationMs: 1, startedAt: began + 3, conversationId: workerChat, sessionId });
+    expect(afterSwitch?.model).toBeUndefined();
+  });
+
   it('reloads a silent joined turn once, then sleeps the Worker only if it stays dead', async () => {
     vi.useFakeTimers();
     try {
@@ -7127,6 +7241,22 @@ describe('the goal loop over the bridge', () => {
     });
     await setSecret('openRouterApiKey', 'sk-or-bridge');
     resetGoalStateForTests();
+  });
+
+  it('advertises the configured Loop helper rather than the inactive API model', async () => {
+    await pair();
+    const config = defaultConfig();
+    const conversation = 'cafe0081-0000-4000-8000-000000000081';
+    await saveConfig({ ...config, goal: { ...config.goal, enabled: true, mode: 'loop', backend: 'api',
+      loopBackend: 'chatgpt', helperModel: 'gpt-5.6-sol', model: 'z-ai/glm-5.3-flash' } });
+    expect((await request('GET', `/activity?conversationId=${conversation}`)).body.goal)
+      .toMatchObject({ backend: 'chatgpt', model: 'gpt-5.6-sol', mode: 'loop' });
+    expect((await request('GET', '/settings')).body.goal)
+      .toMatchObject({ backend: 'chatgpt', model: 'gpt-5.6-sol' });
+    await saveConfig({ ...config, goal: { ...config.goal, enabled: true, mode: 'loop', loopBackend: 'api',
+      model: 'local-model', provider: { kind: 'custom', baseUrl: 'http://localhost:11434/v1' } } });
+    expect((await request('GET', `/activity?conversationId=${conversation}`)).body.goal)
+      .toMatchObject({ backend: 'api', provider: 'custom', model: 'local-model' });
   });
 
   it('retires a handoff source from Goal and Loop, including the app watchdog', async () => {
@@ -7971,6 +8101,41 @@ describe('the goal loop over the bridge', () => {
     });
   });
 
+  it.each(['browser', 'native'])('re-arms the newest completed reply when %s edits its Loop objective during compaction', async surface => {
+    await pair();
+    const chat = 'cafe0188-0000-4000-8000-000000000188';
+    const first = await request('POST', '/events', { body: { conversationId: chat, events: [
+      { kind: 'user_message', time: Date.now(), text: 'finish the first file', messageId: 'objective-user' },
+      { kind: 'assistant_message', time: Date.now(), messageId: 'objective-old-final', turnId: 'objective-old-turn',
+        text: 'First pass complete.', state: 'final', final: true, goalEligible: true, activeNow: true }
+    ] } });
+    const sessionId = first.body.sessionId as string;
+    const continuation = await openContinuationNow(sessionId, chat);
+    await request('POST', '/events', { body: { conversationId: chat, events: [
+      { kind: 'assistant_message', time: Date.now(), messageId: 'objective-new-final', turnId: 'objective-new-turn',
+        text: 'Second pass complete.', state: 'final', final: true, goalEligible: true, activeNow: true }
+    ] } });
+    // The previous decision is spent; a deliberate edit must re-arm the newest stable
+    // answer, even while the compaction operation delays browser pickup.
+    await setGoalReplyActiveNow(chat, false);
+    expect(goalPendingReplyFor(chat)).toBeNull();
+    let acceptedAt = 0;
+    for (const objective of ['Complete all three files.', 'Complete all four files.']) {
+      if (surface === 'browser') {
+        expect((await request('POST', '/goal/objective', { body: { conversationId: chat, text: objective, mode: 'loop' } })).status).toBe(200);
+      } else await setSessionObjective(sessionId, objective, 'loop');
+      const pending = goalPendingReplyFor(chat);
+      expect(pending).toMatchObject({ replyId: 'objective-new-final', turnId: 'objective-new-turn' });
+      expect(pending!.acceptedAt).toBeGreaterThan(acceptedAt);
+      acceptedAt = pending!.acceptedAt;
+      expect(goalObjectiveFor(chat)).toBe(objective);
+      expect(continuationForSession(sessionId)?.token).toBe(continuation.token);
+      expect(await readDurable<{ replies: unknown[] }>(GOAL_REPLIES_STATE)).toMatchObject({
+        replies: expect.arrayContaining([expect.objectContaining({ conversationId: chat, replyId: 'objective-new-final', state: 'pending' })])
+      });
+    }
+  });
+
   it('makes Goal Off a durable ticket cancel and On a fresh pickup of the same final', async () => {
     await pair();
     const chat = 'cafe0076-0000-4000-8000-000000000076';
@@ -8023,6 +8188,41 @@ describe('the goal loop over the bridge', () => {
    * app typing into somebody's browser about an answer already on screen, and a page that has
    * not come back inside half an hour is not coming back.
    */
+  it('hands one queued Goal recovery to the shared browser startup owner and revokes it on Off', async () => {
+    vi.useFakeTimers();
+    try {
+      await pair();
+      const chat = 'cafe0173-0000-4000-8000-000000000173';
+      await request('POST', '/events', { body: { conversationId: chat, events: [
+        { kind: 'user_message', time: Date.now(), text: 'keep going', messageId: 'm-cold-goal' },
+        { kind: 'assistant_message', time: Date.now(), messageId: 'a-cold-goal', text: 'First part done.',
+          state: 'final', final: true, goalEligible: true, activeNow: true }
+      ] } });
+      expect(goalPendingReplyFor(chat)).not.toBeNull();
+      expect(recoveryBrowserWake).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(2 * 60_000);
+      await sweepStaleSwarm(Date.now());
+      expect(recoveryBrowserWake).toHaveBeenCalledTimes(1);
+      const [url, retry, , authority] = recoveryBrowserWake.mock.calls[0]!;
+      expect(url).toBe(`https://chatgpt.com/c/${chat}`);
+      expect(retry).toBe(true);
+      expect(authority?.requireProcessAbsence).toBe(true);
+      expect(authority?.current()).toBe(true);
+      const config = getConfig();
+      await saveConfig({ ...config, ui: { ...config.ui, browserOnly: true } });
+      expect(authority?.current()).toBe(false);
+      await saveConfig(config);
+      expect(authority?.current()).toBe(true);
+      await sweepStaleSwarm(Date.now());
+      expect(recoveryBrowserWake).toHaveBeenCalledTimes(1);
+      await request('POST', '/settings', { body: { conversationId: chat, goal: false } });
+      expect(authority?.current()).toBe(false);
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      await sweepStaleSwarm(Date.now());
+      expect(recoveryBrowserWake).toHaveBeenCalledTimes(1);
+    } finally { vi.useRealTimers(); }
+  });
+
   it('reloads a chat whose finished reply nothing ever came to collect, then stops', async () => {
     vi.useFakeTimers();
     try {
@@ -8336,6 +8536,7 @@ describe('the goal loop over the bridge', () => {
     expect(reply.status).toBe(200);
     expect(reply.body.goal).toEqual({
       backend: 'api',
+      provider: 'openrouter',
       enabled: true,
       // The app-wide setting belongs to no chat, so it is nobody's own answer: this is what a
       // chat that has never moved its own switch inherits.

--- a/test/browser-selection.test.ts
+++ b/test/browser-selection.test.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { afterAll, beforeAll, expect, it, vi } from 'vitest';
+import { defaultConfig, initConfigPath, loadConfig, saveConfig } from '../src/main/config.js';
+import { openInPreferredBrowser, preferredBrowserCandidates } from '../src/main/browser.js';
+import { makeTempDir, removeTempDir } from './helpers.js';
+
+let dir: string;
+beforeAll(async () => { dir = await makeTempDir('clf-browser-choice-'); initConfigPath(dir); });
+afterAll(async () => { await removeTempDir(dir); });
+
+it('uses the persisted Edge choice for cold minimized discovery without an option override', async () => {
+  const config = defaultConfig();
+  await saveConfig({ ...config, ui: { ...config.ui, chatBrowser: 'edge' } });
+  expect((await loadConfig()).ui.chatBrowser).toBe('edge');
+  const edge = 'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe';
+  const powershell = vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0, timedOut: false, truncated: false, durationMs: 1 }));
+  const launch = vi.fn();
+  const opened = await openInPreferredBrowser('https://chatgpt.com/?cos-model-catalog=owned', {
+    platform: 'win32', env: { 'ProgramFiles(x86)': 'C:\\Program Files (x86)' },
+    backgroundStartup: true, usable: () => true, powershell, launch
+  });
+  expect(opened).toBe(edge);
+  expect(powershell).toHaveBeenCalledWith(expect.stringContaining(`-FilePath '${edge}'`), path.win32.dirname(edge), 10_000);
+  expect(powershell).toHaveBeenCalledWith(expect.stringContaining('-WindowStyle Minimized'), expect.any(String), 10_000);
+  expect(launch).not.toHaveBeenCalled();
+});
+
+it('migrates a config without a browser choice to Chrome without losing its other settings', async () => {
+  const old = defaultConfig();
+  delete old.ui.chatBrowser;
+  old.ui.autoConnect = true;
+  await fs.writeFile(path.join(dir, 'config.json'), JSON.stringify(old));
+  expect((await loadConfig()).ui).toMatchObject({ chatBrowser: 'chrome', autoConnect: true });
+});
+
+it('finds Edge installations on each platform without mixing in Chrome', () => {
+  expect(preferredBrowserCandidates('win32', { LOCALAPPDATA: 'C:\\Local', ProgramFiles: 'C:\\Apps', 'ProgramFiles(x86)': 'C:\\Apps86' }, undefined, 'edge'))
+    .toEqual(['C:\\Local\\Microsoft\\Edge\\Application\\msedge.exe', 'C:\\Apps\\Microsoft\\Edge\\Application\\msedge.exe', 'C:\\Apps86\\Microsoft\\Edge\\Application\\msedge.exe']);
+  const mac = preferredBrowserCandidates('darwin', {}, '/Users/example', 'edge');
+  expect(mac).toContain('/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge');
+  expect(mac).toContain('/Users/example/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge');
+  expect(mac.every(candidate => candidate.includes('Microsoft Edge'))).toBe(true);
+  const linux = preferredBrowserCandidates('linux', { PATH: '/custom/bin:/usr/bin' }, '/home/example', 'edge');
+  expect(linux).toContain('/custom/bin/microsoft-edge');
+  expect(linux).toContain('/usr/bin/microsoft-edge-stable');
+  expect(linux.every(candidate => !/chrome|chromium/.test(candidate))).toBe(true);
+});

--- a/test/browser-startup.test.ts
+++ b/test/browser-startup.test.ts
@@ -1,11 +1,71 @@
 import { beforeEach, expect, it, vi } from 'vitest';
 const browser = vi.hoisted(() => ({ connected: false, present: false, lastSeenAt: null as number | null }));
+const config = vi.hoisted(() => ({ ui: { chatBrowser: 'chrome' } }));
+vi.mock('../src/main/config.js', () => ({ getConfig: () => config }));
 const open = vi.hoisted(() => vi.fn(async (_url: string): Promise<string | null> => 'chrome'));
+const running = vi.hoisted(() => vi.fn(async (): Promise<boolean | null> => null));
 vi.mock('../src/main/bridge.js', () => ({ bridgeStatus: async () => ({ ...browser }), browserWakeConnected: () => browser.connected, startBridge: async () => true }));
-vi.mock('../src/main/browser.js', () => ({ openInPreferredBrowser: open }));
+vi.mock('../src/main/browser.js', () => ({ openInPreferredBrowser: open, isPreferredBrowserRunning: running }));
 vi.mock('../src/main/connection.js', () => ({ connect: vi.fn(), getStatus: vi.fn(), onStatusChange: vi.fn() }));
-import { resetInputStartupForTests, wakeBrowserUrl } from '../src/main/session/start-input.js';
-beforeEach(() => { resetInputStartupForTests(); browser.connected = false; browser.present = false; browser.lastSeenAt = null; open.mockReset().mockResolvedValue('chrome'); });
+import { resetBrowserStartupForTests, wakeBrowserUrl } from '../src/main/browser-startup.js';
+beforeEach(() => { resetBrowserStartupForTests(); config.ui.chatBrowser = 'chrome'; browser.connected = false; browser.present = false; browser.lastSeenAt = null; open.mockReset().mockResolvedValue('chrome'); running.mockReset().mockResolvedValue(null); });
+
+it('starts the newly selected family without reusing the old attempt or overriding a connected companion', async () => {
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=old');
+  config.ui.chatBrowser = 'edge';
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=new');
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=repeat');
+  expect(open).toHaveBeenCalledTimes(2);
+  browser.connected = true;
+  config.ui.chatBrowser = 'chrome';
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=connected');
+  expect(open).toHaveBeenCalledTimes(2);
+});
+
+it('discards absence evidence when the selected browser changes during its probe', async () => {
+  browser.present = true;
+  running.mockImplementationOnce(async () => { config.ui.chatBrowser = 'edge'; return false; });
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=old', true);
+  expect(open).not.toHaveBeenCalled();
+  running.mockResolvedValue(false);
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=new', true);
+  expect(open).toHaveBeenCalledTimes(1);
+});
+
+it('admits a new explicit refresh after the previous browser process exited', async () => {
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=old', true);
+  running.mockResolvedValue(false);
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=new', true);
+  expect(open).toHaveBeenCalledTimes(2);
+});
+it('uses confirmed process absence to supersede stale HTTP presence, never socket suspension alone', async () => {
+  browser.present = true; browser.lastSeenAt = Date.now();
+  running.mockResolvedValue(true);
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=one', true);
+  expect(open).not.toHaveBeenCalled();
+  running.mockResolvedValue(false);
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=one', true);
+  expect(open).toHaveBeenCalledTimes(1);
+});
+it('shares concurrent absence probes and never opens after the wake socket reconnects during a probe', async () => {
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=old', true);
+  let release!: (value: boolean) => void;
+  const probe = new Promise<boolean>(resolve => { release = resolve; });
+  running.mockReturnValue(probe);
+  const first = wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=new', true);
+  const second = wakeBrowserUrl('https://chatgpt.com/?cos-input=other', true);
+  await Promise.resolve(); release(false);
+  await Promise.all([first, second]);
+  expect(open).toHaveBeenCalledTimes(2);
+  running.mockImplementation(async () => { browser.connected = true; return false; });
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=third', true);
+  expect(open).toHaveBeenCalledTimes(2);
+});
+it('also opens for a first authored send when Chrome exited inside the HTTP presence window', async () => {
+  browser.present = true; browser.lastSeenAt = Date.now(); running.mockResolvedValue(false);
+  await wakeBrowserUrl('https://chatgpt.com/?cos-input=first');
+  expect(open).toHaveBeenCalledTimes(1);
+});
 
 it('shares one successful absence episode across input and discovery retries', async () => {
   await Promise.all([wakeBrowserUrl('https://chatgpt.com/?cos-input=one'), wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=two', true)]);
@@ -18,7 +78,7 @@ it('shares one successful absence episode across input and discovery retries', a
   expect(open).toHaveBeenCalledTimes(2);
 });
 it('retries a rejected launch only after explicit retry and keeps successful retry shared', async () => {
-  open.mockResolvedValueOnce(null);
+  open.mockRejectedValueOnce(new Error('Microsoft Edge was not found'));
   await expect(wakeBrowserUrl('https://chatgpt.com/')).rejects.toThrow(/not found/);
   await expect(wakeBrowserUrl('https://chatgpt.com/')).rejects.toThrow(/not found/);
   expect(open).toHaveBeenCalledTimes(1);
@@ -26,16 +86,46 @@ it('retries a rejected launch only after explicit retry and keeps successful ret
   await wakeBrowserUrl('https://chatgpt.com/', true);
   expect(open).toHaveBeenCalledTimes(2);
 });
-it('opens immediately after the wake channel closes even while recent HTTP presence remains true', async () => {
+it('waits for real absence after the wake channel closes with recent HTTP presence', async () => {
   browser.present = true; browser.lastSeenAt = Date.now(); browser.connected = true;
   await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=discovery');
   expect(open).not.toHaveBeenCalled();
-  browser.connected = false; // last model helper/Chrome window closed; no new HTTP sighting
+  browser.connected = false; // MV3 suspension or reconnect is not proof of browser absence
   await Promise.all([wakeBrowserUrl('https://chatgpt.com/?cos-input=first'), wakeBrowserUrl('https://chatgpt.com/?cos-input=second')]);
+  expect(open).not.toHaveBeenCalled();
+  browser.present = false;
+  await wakeBrowserUrl('https://chatgpt.com/?cos-input=first');
   expect(open).toHaveBeenCalledTimes(1);
   expect(open).toHaveBeenCalledWith('https://chatgpt.com/?cos-input=first');
 });
 it('starts model discovery without asking the OS to open its URL in a foreground window', async () => {
   await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=one', true, true);
   expect(open).toHaveBeenCalledWith('https://chatgpt.com/?cos-model-catalog=one', { backgroundStartup: true });
+});
+
+it('opens an authorized recovery only after proving process absence, including stale HTTP absence', async () => {
+  const authority = { current: () => true, requireProcessAbsence: true };
+  await wakeBrowserUrl('https://chatgpt.com/c/recovery', true, true, authority);
+  expect(open).not.toHaveBeenCalled(); // Unknown process state is not absence.
+  running.mockResolvedValue(true);
+  await wakeBrowserUrl('https://chatgpt.com/c/recovery', true, true, authority);
+  expect(open).not.toHaveBeenCalled(); // No socket/HTTP observation is not a closed browser.
+  running.mockResolvedValue(false);
+  await Promise.all([
+    wakeBrowserUrl('https://chatgpt.com/c/recovery', true, true, authority),
+    wakeBrowserUrl('https://chatgpt.com/?cos-input=concurrent')
+  ]);
+  expect(open).toHaveBeenCalledTimes(1);
+});
+
+it('cannot open a recovery revoked while its process probe is pending', async () => {
+  let current = true;
+  let release!: (value: boolean) => void;
+  running.mockReturnValue(new Promise(resolve => { release = resolve; }));
+  const work = wakeBrowserUrl('https://chatgpt.com/c/recovery', true, true,
+    { current: () => current, requireProcessAbsence: true });
+  await Promise.resolve();
+  current = false; release(false);
+  await work;
+  expect(open).not.toHaveBeenCalled();
 });

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,10 +1,65 @@
 import path from 'node:path';
 import os from 'node:os';
 import { describe, expect, it, vi } from 'vitest';
-import { findPreferredBrowser, openInPreferredBrowser, preferredBrowserCandidates } from '../src/main/browser.js';
+import { findPreferredBrowser, isPreferredBrowserRunning, openInPreferredBrowser, preferredBrowserCandidates } from '../src/main/browser.js';
 import { runPowerShell } from '../src/main/exec.js';
 
 describe('browser-backed ChatGPT commands', () => {
+  it('launches selected Edge when Chrome is also installed', async () => {
+    const edge = 'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe';
+    const chrome = 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe';
+    const launch = vi.fn(async () => ({ pid: 123 }));
+    const url = 'https://chatgpt.com/?cos-model-catalog=selected';
+    const opened = await openInPreferredBrowser(url, {
+      browser: 'edge', platform: 'win32',
+      env: { ProgramFiles: 'C:\\Program Files', 'ProgramFiles(x86)': 'C:\\Program Files (x86)' },
+      usable: candidate => candidate === edge || candidate === chrome, launch
+    });
+    expect(opened).toBe(edge);
+    expect(launch).toHaveBeenCalledExactlyOnceWith(edge,
+      ['--disable-renderer-backgrounding', '--disable-background-timer-throttling', url], path.win32.dirname(edge));
+  });
+
+  it('does not open Chrome when selected Edge is absent', async () => {
+    const launch = vi.fn(async () => ({ pid: 123 }));
+    await expect(openInPreferredBrowser('https://chatgpt.com/', {
+      browser: 'edge', platform: 'win32', env: { ProgramFiles: 'C:\\Program Files' },
+      usable: candidate => candidate.endsWith('chrome.exe'), launch
+    })).rejects.toThrow(/Microsoft Edge.*not found/);
+    expect(launch).not.toHaveBeenCalled();
+  });
+
+  it('reports selected Edge launch failure without switching browser families', async () => {
+    const launch = vi.fn(async () => { throw new Error('cannot start'); });
+    await expect(openInPreferredBrowser('https://chatgpt.com/', {
+      browser: 'edge', platform: 'win32', env: { ProgramFiles: 'C:\\Program Files' },
+      usable: () => true, launch
+    })).rejects.toThrow(/Microsoft Edge.*cannot start/);
+    expect(launch.mock.calls).toHaveLength(1);
+  });
+
+  it('probes the selected browser process rather than inferring it from another installed browser', async () => {
+    const probe = vi.fn(async (_script: string) => ({ stdout: 'running', stderr: '', exitCode: 0, timedOut: false, truncated: false, durationMs: 1 }));
+    expect(await isPreferredBrowserRunning('win32', probe, 'edge')).toBe(true);
+    expect(probe.mock.calls[0]?.[0]).toContain("ProcessName -eq 'msedge'");
+    expect(probe.mock.calls[0]?.[0]).not.toContain("ProcessName -eq 'chrome'");
+  });
+  it('grants process absence only from a successful bounded Windows probe', async () => {
+    const result = { stdout: 'absent\r\n', stderr: '', exitCode: 0, timedOut: false, truncated: false, durationMs: 1 };
+    const probe = vi.fn(async () => result);
+    expect(await isPreferredBrowserRunning('win32', probe)).toBe(false);
+    result.stdout = 'running\r\n';
+    expect(await isPreferredBrowserRunning('win32', probe)).toBe(true);
+    result.stdout = '';
+    expect(await isPreferredBrowserRunning('win32', probe)).toBeNull();
+    result.stdout = 'absent'; result.timedOut = true;
+    expect(await isPreferredBrowserRunning('win32', probe)).toBeNull();
+    result.timedOut = false; result.exitCode = 1;
+    expect(await isPreferredBrowserRunning('win32', probe)).toBeNull();
+    probe.mockClear();
+    expect(await isPreferredBrowserRunning('darwin', probe)).toBeNull();
+    expect(probe).not.toHaveBeenCalled();
+  });
   it('cold background startup gives Chrome one owned tab in a minimized startup window', async () => {
     const calls: string[] = [];
     const launch = vi.fn();
@@ -19,7 +74,7 @@ describe('browser-backed ChatGPT commands', () => {
         return { stdout: '', stderr: '', exitCode: 0, timedOut: false, truncated: false, durationMs: 1 };
       }
     });
-    expect(calls).toEqual([`$ErrorActionPreference='Stop'; Start-Process -FilePath '${browser}' -ArgumentList '"--disable-renderer-backgrounding" "--disable-background-timer-throttling" "--start-maximized" "https://chatgpt.com/?cos-model-catalog=owned"' -WorkingDirectory '${path.win32.dirname(browser)}' -WindowStyle Minimized`]);
+    expect(calls).toEqual([`$ErrorActionPreference='Stop'; Start-Process -FilePath '${browser}' -ArgumentList '"--disable-renderer-backgrounding" "--disable-background-timer-throttling" "--window-size=1100,800" "https://chatgpt.com/?cos-model-catalog=owned"' -WorkingDirectory '${path.win32.dirname(browser)}' -WindowStyle Minimized`]);
     expect(launch).not.toHaveBeenCalled();
   });
   it.runIf(process.platform === 'win32')('keeps executable, cwd and quoted URL literal through PowerShell without launching a browser', async () => {
@@ -43,7 +98,7 @@ describe('browser-backed ChatGPT commands', () => {
     expect(captured.file).toBe(browser);
     expect(captured.cwd).toBe(path.win32.dirname(browser));
     expect(captured.style).toBe('Minimized');
-    expect(captured.args).toBe(String.raw`"--disable-renderer-backgrounding" "--disable-background-timer-throttling" "--start-maximized" "https://chatgpt.com/?q=space \"quoted\"&literal=$(` + '`whoami`' + String.raw`)&path=C:\dir with space\\"`);
+    expect(captured.args).toBe(String.raw`"--disable-renderer-backgrounding" "--disable-background-timer-throttling" "--window-size=1100,800" "https://chatgpt.com/?q=space \"quoted\"&literal=$(` + '`whoami`' + String.raw`)&path=C:\dir with space\\"`);
   });
 
   it.each([{ exitCode: 1, timedOut: false }, { exitCode: null, timedOut: true }])('reports minimized startup failure without direct foreground fallback: %j', async failure => {

--- a/test/chat-models.test.ts
+++ b/test/chat-models.test.ts
@@ -5,6 +5,53 @@ const models = [{ id: 'gpt-example', label: 'GPT Example', efforts: ['none', 'me
 beforeEach(() => { resetChatModelsForTests(); vi.useFakeTimers(); });
 afterEach(() => vi.useRealTimers());
 describe('ephemeral observed ChatGPT model catalog', () => {
+  it('explains a missing native picker without claiming sign-in failure or inventing models', () => {
+    requestChatModels();
+    observeChatModels({ nonce: pendingChatModelRequest()!.nonce, models: null, error: 'picker_unavailable' });
+    expect(getChatModels()).toMatchObject({ state: 'unavailable', models: [], error: expect.stringContaining('native model picker') });
+  });
+  it('rechecks browser startup when an unfinished discovery is explicitly opened again', async () => {
+    const wake = vi.fn(async () => {}); configureChatModelDiscovery({ wake, changed: () => {} });
+    await startChatModelDiscovery();
+    const pending = pendingChatModelRequest()!;
+    // The browser may have exited since the completed OS handoff. The shared
+    // browser startup owner, not the catalog nonce, decides whether it is absent.
+    await startChatModelDiscovery();
+    expect(pendingChatModelRequest()).toEqual(pending);
+    expect(wake.mock.calls).toEqual([[pending.nonce, true], [pending.nonce, true]]);
+  });
+  it('promotes a pending passive observation once when the user explicitly refreshes', async () => {
+    const wake = vi.fn(async () => {}); configureChatModelDiscovery({ wake, changed: () => {} });
+    await startChatModelDiscovery(false);
+    const passive = pendingChatModelRequest()!;
+    await Promise.all([startChatModelDiscovery(), startChatModelDiscovery()]);
+    expect(pendingChatModelRequest()).toEqual({ ...passive, allowOpen: true });
+    expect(wake.mock.calls).toEqual([[passive.nonce, false], [passive.nonce, true]]);
+  });
+  it('serializes explicit promotion behind an in-flight passive wake without duplicate opening', async () => {
+    let release!: () => void;
+    const wake = vi.fn((_nonce: string, _allowOpen: boolean) => new Promise<void>(resolve => { release = resolve; }));
+    configureChatModelDiscovery({ wake, changed: () => {} });
+    const passive = startChatModelDiscovery(false);
+    const nonce = pendingChatModelRequest()!.nonce;
+    const first = startChatModelDiscovery(), second = startChatModelDiscovery();
+    expect(wake).toHaveBeenCalledTimes(1);
+    release(); await passive;
+    expect(wake.mock.calls).toEqual([[nonce, false], [nonce, true]]);
+    release(); await Promise.all([first, second]);
+    expect(pendingChatModelRequest()).toMatchObject({ nonce, allowOpen: true });
+  });
+  it('observes existing tabs once on window show without opening Chrome or invalidating ready models', async () => {
+    const wake = vi.fn(async () => {}); configureChatModelDiscovery({ wake, changed: () => {} });
+    await startChatModelDiscovery(false);
+    const request = pendingChatModelRequest()!;
+    expect(request.allowOpen).toBe(false);
+    expect(wake).toHaveBeenCalledWith(request.nonce, false);
+    observeChatModels({ nonce: request.nonce, models });
+    await startChatModelDiscovery(false); await startChatModelDiscovery(false);
+    expect(wake).toHaveBeenCalledTimes(1);
+    expect(getChatModels()).toMatchObject({ state: 'ready', models });
+  });
   it('shares explicit browser startup and publishes a bounded expiry without polling', async () => {
     let release!: () => void;
     const wake = vi.fn(() => new Promise<void>(resolve => { release = resolve; }));

--- a/test/chatgpt-dom-input.test.ts
+++ b/test/chatgpt-dom-input.test.ts
@@ -4,6 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const source = readFileSync(new URL('../extension/chatgpt-dom.js', import.meta.url), 'utf8');
 interface DomApi {
+  composerActions(): { host: HTMLElement; before: HTMLElement | null } | null;
+  generating(): boolean;
+  sendButton(): HTMLButtonElement | null;
+  temporaryChatReady(): boolean;
   errors(): Array<{ text: string; recoverable: boolean; blocking?: boolean }>;
   captureComposerDraft(text: string, current?: () => boolean): { clear(): Promise<boolean>; dispose(): void; attachments(nodes: Element[]): void };
   visibleModelSelection(): { model: string; reasoningEffort?: string } | null;
@@ -12,7 +16,7 @@ interface DomApi {
   inspectModelSettings(current?: () => boolean, failure?: (reason: string) => void): Promise<Array<{id: string; label: string; efforts: string[]}> | null>;
   send(options?: { acceptanceTimeoutMs?: number; stillCurrent?: () => boolean }): Promise<boolean>;
   selectModelSettings(model: string | null, effort: string | null, current?: () => boolean): Promise<boolean>;
-  uploadImages(images: Array<{ name: string; dataUrl: string }>, current?: () => boolean, draft?: ReturnType<DomApi['captureComposerDraft']>): Promise<boolean>;
+  uploadImages(images: Array<{ name: string; dataUrl: string }>, current?: () => boolean, draft?: ReturnType<DomApi['captureComposerDraft']>, files?: File[]): Promise<boolean>;
 }
 let dom: JSDOM;
 let document: Document;
@@ -43,6 +47,16 @@ function user(text: string) {
 }
 
 describe('one native Send and bounded acceptance observation', () => {
+  it.each([false, true])('retires only the unchanged accepted composer text (new draft: %s)', async edited => {
+    document.execCommand = command => { if (command === 'delete') box.replaceChildren(); return true; };
+    button.addEventListener('click', () => {
+      dom.reconfigure({ url: 'https://chatgpt.com/c/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' });
+      user('Exact app prompt');
+      if (edited) box.textContent = 'My next unsent draft';
+    });
+    expect(await api.send()).toBe(true);
+    expect(box.textContent).toBe(edited ? 'My next unsent draft' : '');
+  });
   it('recognizes the live Stop answering composer-submit control without treating Start Voice as Stop', () => {
     button.dataset.testid = 'composer-submit-button'; button.setAttribute('aria-label', 'Stop answering');
     const clicked = vi.fn(); button.addEventListener('click', clicked);
@@ -163,130 +177,6 @@ describe('one native Send and bounded acceptance observation', () => {
   });
 });
 
-function picker() {
-  const trigger = document.querySelector<HTMLButtonElement>('button[aria-haspopup]')!;
-  const container = document.createElement('div');
-  container.setAttribute('data-testid', 'composer-intelligence-picker-content');
-  container.innerHTML = '<button type="button" role="menuitem" aria-label="Select model">Select model</button><button type="button" role="menuitemradio" aria-checked="false">GPT Example</button><button type="button" role="menuitem" aria-label="Power" aria-describedby="power-description">Power</button><span id="power-description">Medium, 2 of 5</span>';
-  // Native Radix model radio rows activate on Enter; jsdom has no keyboard default action.
-  container.addEventListener('keydown', event => {
-    const target = event.target as HTMLElement;
-    if (event.key === 'Enter' && target.getAttribute('role') === 'menuitemradio') target.click();
-  });
-  trigger.addEventListener('keydown', event => { if (event.key === 'Enter') document.body.append(container); });
-  return { container, radio: container.querySelector('[role="menuitemradio"]')!, power: container.querySelector('[aria-label="Power"]')!, description: container.querySelector('span')! };
-}
-describe('actual visible model and reasoning selection', () => {
-  it('recognizes only the visible provider access-limit dialog as a blocking nontransport error', () => {
-    const notice = document.createElement('div');
-    notice.innerHTML = '<h2>Too many requests</h2><p>We have temporarily limited access to conversations to protect your data. Please wait a few minutes.</p>';
-    document.body.append(notice);
-    expect(api.errors()).toEqual([]);
-    notice.setAttribute('role', 'dialog');
-    expect(api.errors()).toEqual([expect.objectContaining({ blocking: true, recoverable: false, text: expect.stringContaining('Too many requests') })]);
-    notice.querySelector('p')!.setAttribute('role', 'alert');
-    expect(api.errors()).toHaveLength(1);
-    notice.setAttribute('aria-hidden', 'true'); expect(api.errors()).toEqual([]);
-    notice.querySelector('p')!.removeAttribute('role');
-    notice.removeAttribute('aria-hidden'); notice.querySelector('p')!.textContent = 'An article about rate limits';
-    expect(api.errors()).toEqual([]);
-  });
-  it('observes only a visible checked model without opening or changing the picker', () => {
-    const controls = picker();
-    controls.radio.textContent = 'GPT-6 Pro'; controls.radio.setAttribute('aria-checked', 'true');
-    expect(api.visibleModelSelection()).toBeNull();
-    document.body.append(controls.container);
-    expect(api.visibleModelSelection()).toMatchObject({ model: 'GPT-6 Pro' });
-    controls.radio.setAttribute('aria-checked', 'false');
-    expect(api.visibleModelSelection()).toBeNull();
-    controls.radio.setAttribute('aria-checked', 'true'); controls.container.setAttribute('aria-hidden', 'true');
-    expect(api.visibleModelSelection()).toBeNull();
-  });
-  it('finds the model outside a nested voice wrapper with description children', async () => {
-    const controls = picker();
-    button.remove();
-    const trailing = document.querySelector('[data-testid="composer-trailing-actions"]')!;
-    trailing.removeAttribute('data-testid');
-    trailing.className = 'flex items-center gap-1 [grid-area:trailing]';
-    const wrapper = document.createElement('div');
-    wrapper.innerHTML = '<div><button type="button" aria-label="Start Voice">Voice</button><span>Voice description</span></div>';
-    trailing.append(wrapper);
-    controls.radio.setAttribute('aria-checked', 'true');
-    expect(await api.selectModelSettings('gpt-example', 'medium')).toBe(true);
-    expect(document.querySelector('[data-testid="composer-intelligence-picker-content"]')).not.toBeNull();
-  });
-
-  it('expands collapsed model rows even when they retain layout rectangles', async () => {
-    const controls = picker();
-    const toggle = controls.container.querySelector('[aria-label="Select model"]')!;
-    toggle.setAttribute('aria-expanded', 'false');
-    const expanded = vi.fn(() => toggle.setAttribute('aria-expanded', 'true'));
-    toggle.addEventListener('click', expanded);
-    controls.radio.addEventListener('click', () => {
-      if (toggle.getAttribute('aria-expanded') !== 'true') return;
-      controls.radio.setAttribute('aria-checked', 'true');
-      toggle.setAttribute('aria-expanded', 'false');
-    });
-    expect(await api.selectModelSettings('gpt-example', null)).toBe(true);
-    expect(expanded).toHaveBeenCalledTimes(2);
-    expect(controls.radio.getAttribute('aria-checked')).toBe('true');
-  });
-
-  it('requires checked model evidence and moves effort independently without selecting Pro', async () => {
-    const controls = picker();
-    const selected = vi.fn(() => controls.radio.setAttribute('aria-checked', 'true'));
-    controls.radio.addEventListener('click', selected);
-    const keys: string[] = [];
-    controls.power.addEventListener('keydown', event => {
-      keys.push((event as KeyboardEvent).key);
-      const position = Number(controls.description.textContent!.match(/(\d) of/)![1]) + ((event as KeyboardEvent).key === 'ArrowRight' ? 1 : -1);
-      controls.description.textContent = `${['Instant', 'Medium', 'High', 'Extra High', 'Pro'][position - 1]}, ${position} of 5`;
-    });
-    expect(await api.selectModelSettings('gpt-example', 'high')).toBe(true);
-    expect(selected).toHaveBeenCalledTimes(2);
-    expect(keys).toEqual(['ArrowLeft', 'ArrowRight', 'ArrowRight']);
-  });
-
-  it.each([false, true])('keeps already-selected High and refuses it when unavailable (%s)', async (unavailable) => {
-    const controls = picker();
-    controls.radio.setAttribute('aria-checked', 'true');
-    controls.description.textContent = `High, 3 of 5.${unavailable ? ' Upgrade required.' : ''}`;
-    const changedPower = vi.fn(); controls.power.addEventListener('keydown', changedPower);
-    expect(await api.selectModelSettings('gpt-example', 'high')).toBe(!unavailable);
-    expect(changedPower).not.toHaveBeenCalled();
-  });
-
-  it('targets the nested Power slider rather than the surrounding menu item', async () => {
-    const controls = picker();
-    const slider = document.createElement('span');
-    slider.setAttribute('role', 'slider'); slider.tabIndex = 0;
-    controls.power.append(slider);
-    let position = 2;
-    slider.addEventListener('keydown', event => {
-      event.stopPropagation();
-      position += (event as KeyboardEvent).key === 'ArrowRight' ? 1 : -1;
-      controls.description.textContent = `${['Instant', 'Medium', 'High', 'Extra High', 'Pro'][position - 1]}, ${position} of 5`;
-    });
-    expect(await api.selectModelSettings(null, 'high')).toBe(true);
-    expect(position).toBe(3);
-  });
-
-  it('fails when a model click never becomes checked and refuses unsupported effort', async () => {
-    picker();
-    const result = api.selectModelSettings('gpt-example', null);
-    await vi.advanceTimersByTimeAsync(3000);
-    expect(await result).toBe(false);
-    expect(await api.selectModelSettings(null, 'ultra')).toBe(false);
-  });
-
-  it('does not click a picker after target ownership is lost', async () => {
-    const controls = picker();
-    const clicked = vi.fn(); controls.radio.addEventListener('click', clicked);
-    expect(await api.selectModelSettings('gpt-example', 'high', () => false)).toBe(false);
-    expect(clicked).not.toHaveBeenCalled();
-  });
-});
-
 function upload() {
   const input = document.createElement('input');
   input.id = 'upload-photos'; input.type = 'file'; input.accept = 'image/*';
@@ -300,6 +190,23 @@ function upload() {
   return input;
 }
 describe('native image readiness', () => {
+  it('uploads original Markdown bytes and recognizes localized native file actions without duplicate tiles', async () => {
+    const input = upload(); input.id = 'upload-files'; input.accept = '';
+    const draft = api.captureComposerDraft('Exact app prompt');
+    document.execCommand = command => { if (command === 'delete') box.replaceChildren(); return true; };
+    input.addEventListener('change', () => {
+      const tile = document.createElement('div'); tile.setAttribute('role', 'group'); tile.setAttribute('aria-label', 'Notes.md');
+      tile.innerHTML = '<div data-default-action="true"><button aria-label="Notes.md"></button></div><button aria-label="删除文件 1: Notes.md"></button>';
+      tile.lastElementChild!.addEventListener('click', () => tile.remove());
+      document.querySelector('form')!.append(tile);
+    });
+    const file = new dom.window.File(['# exact markdown'], 'Notes.md', { type: 'text/markdown' });
+    expect(await api.uploadImages([], () => true, draft, [file])).toBe(true);
+    expect(input.files?.[0]).toBe(file);
+    expect(api.hasComposerAttachments()).toBe(true);
+    expect(await draft.clear()).toBe(true);
+    expect(api.hasComposerAttachments()).toBe(false); draft.dispose();
+  });
   it('withdraws only the exact prepared app text and ready attachment nodes before Send', async () => {
     const input = upload();
     document.execCommand = command => { if (command === 'delete') box.replaceChildren(); return true; };
@@ -387,181 +294,105 @@ describe('native image readiness', () => {
   });
 });
 
-function catalogPicker(labels: string[], hiddenModels = false) {
-  const controls = picker();
-  let position = 2;
-  const radios = [controls.radio];
-  controls.radio.setAttribute('aria-checked', 'true');
-  const other = controls.radio.cloneNode(true) as HTMLElement;
-  other.textContent = 'Sol Example'; other.setAttribute('aria-checked', 'false');
-  controls.radio.after(other); radios.push(other);
-  const render = () => { controls.description.textContent = `${labels[position - 1]}, ${position} of ${labels.length}`; };
-  render();
-  for (const radio of radios) radio.addEventListener('click', () => {
-    for (const entry of radios) entry.setAttribute('aria-checked', String(entry === radio));
-    position = 1; render();
+
+describe('provider limit notice', () => {
+  it('recognizes only the visible provider access-limit dialog as a blocking nontransport error', () => {
+    const notice = document.createElement('div');
+    notice.innerHTML = '<h2>Too many requests</h2><p>We have temporarily limited access to conversations to protect your data. Please wait a few minutes.</p>';
+    document.body.append(notice);
+    expect(api.errors()).toEqual([]);
+    notice.setAttribute('role', 'dialog');
+    expect(api.errors()).toEqual([expect.objectContaining({ blocking: true, recoverable: false, text: expect.stringContaining('Too many requests') })]);
+    notice.querySelector('p')!.setAttribute('role', 'alert');
+    expect(api.errors()).toHaveLength(1);
+    notice.setAttribute('aria-hidden', 'true'); expect(api.errors()).toEqual([]);
+    notice.querySelector('p')!.removeAttribute('role');
+    notice.removeAttribute('aria-hidden'); notice.querySelector('p')!.textContent = 'An article about rate limits';
+    expect(api.errors()).toEqual([]);
   });
-  const keys: string[] = [];
-  controls.power.addEventListener('keydown', event => {
-    const key = (event as KeyboardEvent).key; keys.push(key);
-    position += key === 'ArrowRight' ? 1 : -1; render();
-  });
-  if (hiddenModels) {
-    for (const radio of radios) (radio as HTMLElement).hidden = true;
-    controls.container.querySelector('[aria-label="Select model"]')!.addEventListener('click', () => {
-      for (const radio of radios) (radio as HTMLElement).hidden = false;
-    });
+});
+
+describe('rendered temporary-chat state independent of language', () => {
+  function toggle(label: string, checked: boolean) {
+    const control = document.createElement('button');
+    control.setAttribute('aria-label', label);
+    control.innerHTML = `<svg style="opacity:${checked ? 0 : 1}"><use href="/cdn/assets/sprites-shell-anyhash.svg#chat-temp"></use></svg><svg aria-hidden="true" style="opacity:${checked ? 1 : 0}"><use href="/cdn/assets/sprites-shell-anyhash.svg#chat-temp-checked"></use></svg>`;
+    document.body.append(control);
+    return control;
   }
-  return { ...controls, keys, radios };
-}
-describe('read-only picker catalog', () => {
-  function latestPicker(generation = '6') {
-    const controls = catalogPicker(['Instant', 'Medium', 'High', 'Extra High', 'Pro']);
-    controls.radios[0]!.textContent = 'Latest';
-    controls.radios[1]!.textContent = 'GPT-5.6 Sol';
-    const badge = controls.container.querySelector('[aria-label="Select model"]')!;
-    const renderBadge = () => {
-      const latest = controls.radios[0]!.getAttribute('aria-checked') === 'true';
-      badge.textContent = controls.description.textContent?.startsWith('Pro,') ? `${latest ? generation : '5.6'}Pro` : 'High';
-    };
-    for (const radio of controls.radios) radio.addEventListener('click', renderBadge);
-    controls.power.addEventListener('keydown', renderBadge);
-    renderBadge();
-    return controls;
-  }
-  it('resolves Latest Pro from its native generation badge and keeps explicit 5.6 Pro separate', async () => {
-    const controls = latestPicker();
-    expect(await api.inspectModelSettings()).toEqual([
-      { id: 'gpt-6-pro', label: 'GPT-6 Pro', efforts: ['pro'] },
-      { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', efforts: ['none', 'medium', 'high', 'xhigh', 'pro'] }
-    ]);
-    expect(controls.radios[0]!.getAttribute('aria-checked')).toBe('true');
-    expect(controls.description.textContent).toBe('Medium, 2 of 5');
-    expect(await api.selectModelSettings('gpt-6-pro', 'pro')).toBe(true);
-    expect(api.visibleModelSelection()).toEqual({ model: 'GPT-6 Pro', reasoningEffort: 'pro' });
-    expect(await api.selectModelSettings('gpt-5.6-sol', 'pro')).toBe(true);
-    expect(controls.radios[1]!.getAttribute('aria-checked')).toBe('true');
-    expect(controls.container.querySelector('[aria-label="Select model"]')!.textContent).toBe('5.6Pro');
+  it.each(['Temporären Chat ausschalten', '一時チャットをオフにする', 'Turn off temporary chat', ''])('reads the checked glyph with arbitrary label %s', label => {
+    toggle(label, true);
+    expect(api.temporaryChatReady()).toBe(true);
   });
-  it('refuses a stale Latest Pro identity if the native badge now names another generation', async () => {
-    latestPicker('5.6');
-    expect(await api.selectModelSettings('gpt-6-pro', 'pro')).toBe(false);
+  it('does not mistake a hidden checked glyph, English wording or URL intent for active mode', () => {
+    dom.reconfigure({ url: 'https://chatgpt.com/?temporary-chat=true' });
+    toggle('Turn off temporary chat', false);
+    expect(api.temporaryChatReady()).toBe(false);
   });
-  it('does not invent Latest identity from an effort-only badge', async () => {
-    latestPicker('');
-    const models = await api.inspectModelSettings();
-    expect(models?.map(model => model.id)).toEqual(['gpt-5.6-sol']);
+  it('rejects a hidden toolbar or a glyph quoted in assistant content', () => {
+    const control = toggle('arbitrary', true);
+    control.hidden = true;
+    expect(api.temporaryChatReady()).toBe(false);
+    control.hidden = false;
+    const authored = document.createElement('div'); authored.setAttribute('data-message-author-role', 'assistant');
+    document.body.append(authored); authored.append(control);
+    expect(api.temporaryChatReady()).toBe(false);
   });
-  it('opens the native menu with Enter rather than relying on a click-only fixture', async () => {
-    const controls = catalogPicker(['Instant', 'Medium', 'High']);
-    controls.container.remove();
-    const trigger = document.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]')!;
-    const click = vi.fn(); trigger.addEventListener('click', click);
-    trigger.addEventListener('keydown', event => { if (event.key === 'Enter') document.body.append(controls.container); });
-    const result = api.inspectModelSettings();
-    await vi.advanceTimersByTimeAsync(0);
-    expect(await result).toHaveLength(2);
-    expect(click).not.toHaveBeenCalled();
+});
+
+
+describe('locale-independent provider composer evidence', () => {
+  it.each([['ja', '送信', '回答を停止'], ['ar', 'إرسال', 'إيقاف الإجابة']])('uses provider Send and Stop identities in %s', (language, sendLabel, stopLabel) => {
+    document.documentElement.lang = language;
+    document.documentElement.dir = language === 'ar' ? 'rtl' : 'ltr';
+    button.setAttribute('aria-label', sendLabel);
+    button.textContent = sendLabel;
+    expect(api.sendButton()).toBe(button);
+    expect(api.generating()).toBe(false);
+    button.dataset.testid = 'stop-button';
+    button.id = 'composer-submit-button';
+    button.setAttribute('aria-label', stopLabel);
+    expect(api.sendButton()).toBeNull();
+    expect(api.generating()).toBe(true);
+    expect(api.stopGeneration(() => true)).toBe(true);
   });
-  it('reports unsupported model labels instead of silently returning an empty catalog', async () => {
-    const controls = catalogPicker(['Instant', 'Medium', 'High']);
-    for (const radio of controls.radios) radio.textContent = 'Unknown / model';
-    const failure = vi.fn();
-    expect(await api.inspectModelSettings(() => true, failure)).toBeNull();
-    expect(failure).toHaveBeenCalledWith('model_unconfirmed');
+
+  it.each([['ja', '音声入力'], ['ar', 'إملاء']])('anchors to the provider microphone glyph in %s', (language, label) => {
+    document.documentElement.lang = language;
+    document.documentElement.dir = language === 'ar' ? 'rtl' : 'ltr';
+    button.removeAttribute('data-testid'); button.setAttribute('aria-label', label);
+    button.id = 'composer-submit-button';
+    button.innerHTML = '<svg><use href="#microphone-regular-24"></use></svg>';
+    const trailing = button.parentElement!;
+    // The observed grid area survives even when no test id names its action row.
+    trailing.removeAttribute('data-testid'); trailing.className = '[grid-area:trailing]';
+    expect(api.composerActions()).toEqual({ host: trailing, before: button });
+    expect(api.sendButton()).toBeNull();
+    expect(api.generating()).toBe(false);
+    expect(api.stopGeneration(() => true)).toBe(false);
   });
-  it('waits for a helper composer and its Power row to hydrate in the same document', async () => {
-    const controls = catalogPicker(['Instant', 'Medium', 'High', 'Extra High']);
-    const form = document.querySelector('form')!;
-    form.remove(); controls.power.remove();
-    const result = api.inspectModelSettings();
-    let settled = false; void result.then(() => { settled = true; });
-    await vi.advanceTimersByTimeAsync(1000);
-    expect(settled).toBe(false);
-    document.body.prepend(form);
-    await vi.advanceTimersByTimeAsync(500);
-    expect(settled).toBe(false);
-    controls.container.append(controls.power);
-    await vi.advanceTimersByTimeAsync(0);
-    expect(await result).toHaveLength(2);
+
+  it('does not anchor to a microphone glyph in prose or an unrelated composer control', () => {
+    button.parentElement!.removeAttribute('data-testid');
+    button.removeAttribute('data-testid'); button.removeAttribute('aria-label');
+    button.innerHTML = '<svg><use href="#microphone-regular-24"></use></svg>';
+    const quote = document.createElement('section'); quote.setAttribute('data-testid', 'conversation-turn-1');
+    quote.innerHTML = '<button><svg><use href="#microphone-regular-24"></use></svg></button>';
+    document.body.prepend(quote);
+    expect(api.composerActions()).toBeNull();
+    expect(api.sendButton()).toBeNull();
+    expect(api.generating()).toBe(false);
   });
-  it('reads a menu that replaces Power and Select model with radio choices', async () => {
-    const controls = catalogPicker(['Instant', 'Medium', 'High', 'Extra High'], true);
-    const toggle = controls.container.querySelector('[aria-label="Select model"]')!;
-    const expand = () => {
-      controls.power.remove(); toggle.remove();
-      for (const radio of controls.radios) radio.removeAttribute('hidden');
-    };
-    toggle.addEventListener('click', expand);
-    for (const radio of controls.radios) radio.addEventListener('click', () => {
-      for (const sibling of controls.radios) sibling.setAttribute('hidden', '');
-      controls.container.append(toggle, controls.power);
-    });
-    const result = await api.inspectModelSettings();
-    expect(result).toHaveLength(2);
-    expect(controls.description.textContent).toBe('Medium, 2 of 4');
-    expect(controls.power.isConnected).toBe(true);
-    expect(controls.radio.getAttribute('aria-checked')).toBe('true');
-  });
-  it('omits upgrade-only effort slots and refuses selecting them', async () => {
-    const controls = catalogPicker(['Instant', 'Medium', 'High', 'Pro']);
-    const markUpgrade = () => {
-      if (controls.description.textContent?.startsWith('Pro,')) controls.description.textContent += ' Upgrade required.';
-    };
-    controls.power.addEventListener('keydown', markUpgrade);
-    const result = await api.inspectModelSettings();
-    expect(result?.map(model => model.efforts)).toEqual([['none', 'medium', 'high'], ['none', 'medium', 'high']]);
-    expect(await api.selectModelSettings('gpt-example', 'pro')).toBe(false);
-  });
-  it('captures the original effort before the model submenu unmounts Power', async () => {
-    const controls = catalogPicker(['Instant', 'Medium', 'High', 'Extra High'], true);
-    const toggle = controls.container.querySelector('[aria-label="Select model"]')!;
-    toggle.setAttribute('aria-expanded', 'false');
-    toggle.addEventListener('click', () => {
-      toggle.setAttribute('aria-expanded', 'true');
-      controls.power.remove();
-    });
-    for (const radio of controls.radios) radio.addEventListener('click', () => {
-      toggle.setAttribute('aria-expanded', 'false');
-      controls.container.append(controls.power);
-    });
-    const result = await api.inspectModelSettings();
-    expect(result).toHaveLength(2);
-    expect(controls.radio.getAttribute('aria-checked')).toBe('true');
-    expect(controls.description.textContent).toBe('Medium, 2 of 4');
-  });
-  it.each([
-    ['Instant', 'Medium', 'High', 'Extra High'],
-    ['Instant', 'Medium', 'High', 'Extra High', 'Pro']
-  ])('reads actual %j slots and restores model and effort', async (...labels) => {
-    const controls = catalogPicker(labels, true);
-    const result = await api.inspectModelSettings();
-    expect(result).toEqual([
-      { id: 'gpt-example', label: 'GPT Example', efforts: ['none', 'medium', 'high', 'xhigh', ...(labels.includes('Pro') ? ['pro'] : [])] },
-      { id: 'sol-example', label: 'Sol Example', efforts: ['none', 'medium', 'high', 'xhigh', ...(labels.includes('Pro') ? ['pro'] : [])] }
-    ]);
-    expect(controls.radio.getAttribute('aria-checked')).toBe('true');
-    expect(controls.description.textContent).toBe(`Medium, 2 of ${labels.length}`);
-    expect(box.textContent).toBe('Exact app prompt');
-  });
-  it('returns unknown when restoring the original model is no longer possible', async () => {
-    const controls = catalogPicker(['Instant', 'Medium', 'High', 'Extra High']);
-    controls.radios[1]!.addEventListener('click', () => controls.radio.setAttribute('aria-disabled', 'true'));
-    expect(await api.inspectModelSettings()).toBeNull();
-  });
-  it('stops immediately after ownership changes and does not restore in another document', async () => {
-    const controls = catalogPicker(['Instant', 'Medium', 'High', 'Extra High']);
-    let owned = true;
-    controls.power.addEventListener('keydown', () => { owned = false; });
-    expect(await api.inspectModelSettings(() => owned)).toBeNull();
-    expect(controls.keys).toHaveLength(1);
-  });
-  it('reports unknown if native power has no exact ordinal proof', async () => {
-    const controls = catalogPicker(['Instant', 'Medium', 'High', 'Extra High']);
-    controls.description.textContent = 'Thinking';
-    const result = api.inspectModelSettings();
-    await vi.advanceTimersByTimeAsync(3000);
-    expect(await result).toBeNull();
-    expect(controls.keys).toEqual([]);
+
+  it.each(['画像.webp', 'صورة.webp'])('recognizes the provider attachment group independently of translated removal labels (%s)', name => {
+    const group = document.createElement('div'); group.setAttribute('role', 'group'); group.setAttribute('aria-label', name);
+    group.innerHTML = '<div data-default-action="true"><button type="button">開く</button></div><button aria-label="削除" type="button">×</button>';
+    document.querySelector('form')!.append(group);
+    expect(api.hasComposerAttachments()).toBe(true);
+    group.querySelector('[data-default-action]')!.removeAttribute('data-default-action');
+    expect(api.hasComposerAttachments()).toBe(false);
+    group.firstElementChild!.setAttribute('data-default-action', 'true');
+    group.append(group.lastElementChild!.cloneNode(true));
+    expect(api.hasComposerAttachments()).toBe(false);
   });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -25,6 +25,24 @@ afterAll(async () => {
 });
 
 describe('settings migration', () => {
+  it('defaults login startup off for fresh and legacy settings independently of auto-connect', async () => {
+    expect(defaultConfig().ui.startAtLogin).toBe(false);
+    const legacy = defaultConfig();
+    delete legacy.ui.startAtLogin;
+    legacy.ui.autoConnect = true;
+    await fs.writeFile(path.join(dir, 'config.json'), JSON.stringify(legacy), 'utf8');
+    expect((await loadConfig()).ui).toMatchObject({ startAtLogin: false, autoConnect: true });
+    await saveConfig({ ...defaultConfig(), ui: { ...defaultConfig().ui, startAtLogin: true, autoConnect: false } });
+    expect((await loadConfig()).ui).toMatchObject({ startAtLogin: true, autoConnect: false });
+  });
+  it('defaults automatic plugin refresh off for fresh and legacy settings while preserving explicit opt-in', async () => {
+    expect(defaultConfig().ui.autoRefreshPlugins).toBe(false);
+    const legacy = defaultConfig(); delete legacy.ui.autoRefreshPlugins;
+    await saveConfig(legacy);
+    expect((await loadConfig()).ui.autoRefreshPlugins).toBe(false);
+    await saveConfig({ ...defaultConfig(), ui: { ...defaultConfig().ui, autoRefreshPlugins: true } });
+    expect((await loadConfig()).ui.autoRefreshPlugins).toBe(true);
+  });
   it('defaults Goal and Loop to ChatGPT while preserving explicit backend choices', async () => {
     expect(defaultConfig().goal).toMatchObject({ backend: 'chatgpt', loopBackend: 'chatgpt' });
     for (const backend of ['api', 'templates', 'chatgpt'] as const) {
@@ -84,6 +102,11 @@ describe('settings migration', () => {
     expect(loaded.capabilities.create).toBe(true);
     expect(loaded.capabilities.clipboardRead).toBe(false);
     expect(loaded.capabilities.clipboardWrite).toBe(false);
+    expect(loaded.capabilities.saveArtifact).toBe(false);
+    expect(loaded.artifacts.maxFileBytes).toBe(defaultConfig().artifacts.maxFileBytes);
+    // A config written before custom providers existed keeps OpenRouter with no URL:
+    // an upgrade never moves a running Goal loop onto an endpoint nobody chose.
+    expect(loaded.goal.provider).toEqual({ kind: 'openrouter', baseUrl: '' });
     expect(loaded.ui.autoConnect).toBe(true);
     expect(loaded.ui.privacyScreenshots).toBe(false);
     // The one tunnel id a pre-split config had is Core's, because Core is the connector
@@ -474,6 +497,7 @@ describe('the goal loop settings', () => {
       helperReasoning: 'high',
       enabled: true,
       mode: 'loop',
+      provider: { kind: 'openrouter', baseUrl: '' },
       model: 'openai/gpt-5.2-mini:nitro',
       reasoning: 'high',
       prompt,
@@ -620,6 +644,7 @@ describe('the goal loop settings', () => {
       helperReasoning: 'high',
       enabled: false,
       mode: 'goal',
+      provider: { kind: 'openrouter', baseUrl: '' },
       model: DEFAULT_GOAL_MODEL,
       reasoning: 'default',
       prompt: defaultConfig().goal.prompt,

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -200,7 +200,8 @@ async function harness(
   url = 'https://chatgpt.com/c/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
   replies: Record<string, (message: Record<string, any>) => unknown> = {},
   before: (document: Document, dom: JSDOM) => void = () => undefined,
-  confirmedNonPro = false
+  confirmedNonPro = false,
+  holdSendDeadline = false
 ): Promise<Harness> {
   const dom = new JSDOM(PAGE, { url, runScripts: 'outside-only', pretendToBeVisual: true });
   const window = dom.window as unknown as Window & typeof globalThis & Record<string, any>;
@@ -285,6 +286,7 @@ async function harness(
   // was asked for makes a give-up path arrive after the right number of attempts, instantly.
   let clock = 1_700_000_000_000;
   window.setTimeout = ((fn: () => void, ms?: number) => {
+    if (holdSendDeadline && ms === 30000) return 0;
     clock += Number(ms) || 0;
     void Promise.resolve().then(fn);
     return 0;
@@ -445,12 +447,65 @@ describe('desktop input delivery and helper ownership', () => {
   const chatB = 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff';
   const text = 'Inspect the exact requested task';
   const claimed = (extra: Record<string, unknown> = {}) => ({ id: inputId, owner: 'input-owner', text, model: null, reasoningEffort: null, purpose: 'user', images: [], ...extra });
+  it.each(['untouched', 'delayed-raw', 'edited', 'same-text-edit', 'same-text-early', 'replaced-editor', 'native-delete-refused', 'cancelled', 'foreign-route'])('retires a late acknowledged desktop draft only while owned (%s)', async (change) => {
+    const text = change === 'delayed-raw' ? 'Inspect `src/main/bridge.ts` exactly.' : 'Inspect the exact requested task';
+    live = await harness(`https://chatgpt.com/c/${chatA}`, {
+      desktop_input: message => ({ ok: true, data: message.ack ? { ok: change !== 'cancelled' } : message.authorize ? { ok: true } : { input: claimed({ purpose: 'decision', text }) } })
+    });
+    const host = live.document.querySelector('form')!;
+    const add = host.addEventListener.bind(host);
+    let trustedInput!: EventListener;
+    host.addEventListener = ((type: string, listener: EventListener, options: any) => {
+      if (type === 'input' && options === true) trustedInput = listener;
+      add(type, listener, options);
+    }) as typeof host.addEventListener;
+    const exec = live.document.execCommand;
+    live.document.execCommand = (command, showUI, value) => {
+      if (command === 'delete' && change === 'native-delete-refused') return false;
+      if (command === 'delete') { live!.document.querySelector('#prompt-textarea')!.replaceChildren(); return true; }
+      return exec(command, showUI, value);
+    };
+    const instantTimer = live.window.setTimeout;
+    live.window.setTimeout = ((fn: () => void, ms?: number) => ms === 15000 ? 0 : instantTimer(fn, ms)) as typeof live.window.setTimeout;
+    let clicked!: () => void;
+    const click = new Promise<void>(resolve => { clicked = resolve; });
+    live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+      if (change === 'same-text-early') {
+        trustedInput({ isTrusted: true } as Event);
+        userTurn(live!.document, 'late-owned-user', text, { sent: false });
+      } else startGenerating(live!.document, { send: false }); // Accepted before the user row exists.
+      clicked();
+    });
+    const delivery = live.runtimeMessage({ type: 'clf-desktop-input', id: inputId, conversationId: chatA });
+    await click; await settle();
+    if (change !== 'same-text-early') expect(live.sent.filter(message => message.ack)).toEqual([]);
+    const composer = live.document.querySelector('#prompt-textarea')!;
+    if (change === 'edited') composer.textContent = 'My independent draft';
+    if (change === 'same-text-edit') {
+      // Exercise the existing trusted-event owner without pretending script events are trusted.
+      expect(trustedInput).toBeTypeOf('function');
+      trustedInput({ isTrusted: true } as Event);
+    }
+    if (change === 'foreign-route') live.dom.reconfigure({ url: `https://chatgpt.com/c/${chatB}` });
+    if (change === 'replaced-editor') composer.replaceWith(composer.cloneNode(true));
+    if (change !== 'same-text-early') userTurn(live.document, 'late-owned-user', change === 'delayed-raw' ? text.replaceAll('`', '') : text, { sent: false });
+    if (change === 'delayed-raw') {
+      await settle();
+      expect(live.sent.filter(message => message.ack)).toEqual([]);
+      const section = live.document.querySelector('[data-turn-id="late-owned-user"]') as HTMLElement;
+      await bindFiberTurns([{ section, turn: { turnId: 'late-owned-user', conversationId: chatA, messages: [{ role: 'user', stable: true,
+        messageId: 'm-late-owned-user', rawMessageId: 'm-late-owned-user', rawText: text }] } }]);
+    }
+    expect(await delivery).toEqual({ ok: change !== 'cancelled' && change !== 'foreign-route' });
+    expect(live.document.querySelector('#prompt-textarea')!.textContent).toBe(change === 'untouched' || change === 'delayed-raw' ? '' : change === 'edited' ? 'My independent draft' : text);
+  });
+
   it('retains the temporary decision when composer acceptance precedes the mounted user receipt', async () => {
     const canonical = '{"action":"continue","reply":"late mounted plan"}';
     live = await harness(`https://chatgpt.com/?temporary-chat=true&cos-input=${inputId}`, {
       desktop_input: message => ({ ok: true, data: message.authorize || message.ack || message.response ? { ok: true } : { input: claimed({ purpose: 'decision', lifetime: 'temporary-planner' }) } })
     });
-    const toggle = live.document.createElement('button'); toggle.setAttribute('aria-label', 'Turn off temporary chat'); live.document.body.append(toggle);
+    const toggle = live.document.createElement('button'); toggle.setAttribute('aria-label', '一時チャット'); toggle.innerHTML = '<svg><use href="/sprite.svg#chat-temp-checked"></use></svg>'; Object.defineProperty(toggle, 'getClientRects', { value: () => [{}] }); live.document.body.append(toggle);
     const instantTimer = live.window.setTimeout;
     live.window.setTimeout = ((fn: () => void, ms?: number) => ms === 15000 ? 0 : instantTimer(fn, ms)) as typeof live.window.setTimeout;
     let clicked!: () => void;
@@ -478,7 +533,7 @@ describe('desktop input delivery and helper ownership', () => {
     live = await harness(`https://chatgpt.com/?temporary-chat=true&cos-input=${inputId}`, {
       desktop_input: message => ({ ok: true, data: message.authorize || message.ack || message.response ? { ok: true } : { input: claimed({ purpose: 'decision', lifetime: 'temporary-planner' }) } })
     });
-    const toggle = live.document.createElement('button'); toggle.setAttribute('aria-label', 'Turn off temporary chat'); live.document.body.append(toggle);
+    const toggle = live.document.createElement('button'); toggle.setAttribute('aria-label', '一時チャット'); toggle.innerHTML = '<svg><use href="/sprite.svg#chat-temp-checked"></use></svg>'; Object.defineProperty(toggle, 'getClientRects', { value: () => [{}] }); live.document.body.append(toggle);
     live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
       userTurn(live!.document, 'temp-user', text);
       live!.document.querySelector('#prompt-textarea')!.textContent = '';
@@ -697,6 +752,227 @@ describe('desktop input delivery and helper ownership', () => {
     expect(live.sent.some(message => message.type === 'desktop_input' && message.ack)).toBe(false);
   });
 
+  it.each(['worker', 'resume', 'revive', 'trusted-edit', 'new-user', 'foreign-route', 'rejected-ack'])('retires only an owned late bootstrap draft (%s)', async kind => {
+    const commandId = 'cmd-late-bootstrap';
+    const prompt = '[[CLF-RESUME:0123456789abcdef0123456789abcdef]]\nContinue exact task.';
+    let trustedInput!: EventListener;
+    let releaseAck!: (value: unknown) => void;
+    const ackReply = new Promise(resolve => { releaseAck = resolve; });
+    const revival = kind === 'revive';
+    live = await harness(revival ? `https://chatgpt.com/c/${chatA}?clf=${commandId}` : `https://chatgpt.com/?clf=${commandId}`, {
+      redeem: () => ({ ok: true, command: { id: commandId, type: kind === 'resume' ? 'resume' : 'worker', text: prompt,
+        agent: 'worker-1', ...(revival ? { conversationId: chatA } : {}) } }),
+      ack: () => revival ? ackReply : ({ ok: kind !== 'rejected-ack' })
+    }, (document, dom) => {
+      const host = document.querySelector('form')!;
+      const add = host.addEventListener.bind(host);
+      host.addEventListener = ((type: string, listener: EventListener, options: any) => {
+        if (type === 'input' && options === true) trustedInput = listener;
+        add(type, listener, options);
+      }) as typeof host.addEventListener;
+      document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+        dom.reconfigure({ url: `https://chatgpt.com/c/${chatA}` });
+        startGenerating(document, { send: false });
+      });
+    }, false, true);
+    const exec = live.document.execCommand;
+    live.document.execCommand = (command, ui, value) => {
+      if (command === 'delete') { live!.document.querySelector('#prompt-textarea')!.replaceChildren(); return true; }
+      return exec(command, ui, value);
+    };
+    await settle();
+    expect(composerText(live.document)).toContain('Continue exact task.');
+    if (kind === 'trusted-edit') trustedInput({ isTrusted: true } as Event);
+    if (kind === 'foreign-route') live.dom.reconfigure({ url: `https://chatgpt.com/c/${chatB}` });
+    userTurn(live.document, 'late-bootstrap-user', prompt, { sent: false });
+    if (kind === 'new-user') userTurn(live.document, 'later-independent-user', 'My separate message', { sent: false });
+    releaseAck({ ok: true });
+    live.hook.observe();
+    await new Promise(resolve => globalThis.setTimeout(resolve, 550));
+    await settle();
+    expect(composerText(live.document)).toBe(['worker', 'resume', 'revive'].includes(kind) ? '' : prompt.replaceAll('\n', ''));
+  });
+
+  it('acknowledges a fresh resume after its route precedes exact MAIN-world user text', async () => {
+    const commandId = 'cmd-delayed-raw-resume';
+    const prompt = '[[CLF-RESUME:0123456789abcdef0123456789abcdef]]\nContinue `src/main/bridge.ts`.';
+    let user!: HTMLElement;
+    let clicks = 0;
+    live = await harness(`https://chatgpt.com/?clf=${commandId}`, {
+      redeem: () => ({ ok: true, command: { id: commandId, type: 'resume', text: prompt, agent: null } }),
+      ack: () => ({ ok: true })
+    }, (document, dom) => {
+      document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+        clicks++;
+        dom.reconfigure({ url: `https://chatgpt.com/c/${chatA}` });
+        user = userTurn(document, 'delayed-resume-user', prompt.replaceAll('`', ''), { sent: false });
+        document.querySelector('#prompt-textarea')!.textContent = '';
+      });
+    }, false, true);
+    await settle();
+    expect(clicks).toBe(1);
+    expect(live.sent.filter(message => message.type === 'ack' && message.status === 'sent')).toEqual([]);
+    live.hook.observe();
+    await settle();
+    await bindFiberTurns([{ section: user, turn: { turnId: 'delayed-resume-user', conversationId: chatA,
+      messages: [{ role: 'user', stable: true, messageId: 'm-delayed-resume-user', rawMessageId: 'm-delayed-resume-user', rawText: prompt }] } }]);
+    await new Promise(resolve => globalThis.setTimeout(resolve, 550));
+    await settle();
+    expect(live.sent.filter(message => message.type === 'ack' && message.status === 'sent')).toEqual([
+      expect.objectContaining({ id: commandId, conversationId: chatA })
+    ]);
+    expect(clicks).toBe(1);
+  });
+
+  it.each([false, true])('acknowledges a helper Markdown prompt with delayed provider evidence (fresh: %s)', async (fresh) => {
+    const prompt = ('Inspect `src/main/bridge.ts` and report the exact next step.\n').repeat(1800);
+    const rendered = prompt.replaceAll('`', '');
+    const canonical = JSON.stringify({ action: 'continue', reply: 'Read the third file.' });
+    live = await harness(fresh ? `https://chatgpt.com/?cos-input=${inputId}` : `https://chatgpt.com/c/${chatA}`, {
+      desktop_input: message => ({ ok: true, data: message.authorize || message.ack || message.response || message.partial
+        ? { ok: true } : { input: claimed({ purpose: 'decision', text: prompt }) } })
+    }, undefined, false, true);
+    if (!fresh) userTurn(live.document, 'previous-helper-user', 'Earlier objective');
+    let user!: HTMLElement;
+    let clicked!: () => void;
+    const click = new Promise<void>(resolve => { clicked = resolve; });
+    live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+      if (fresh) live!.dom.reconfigure({ url: `https://chatgpt.com/c/${chatA}` });
+      user = userTurn(live!.document, 'long-helper-user', rendered, { sent: false });
+      live!.document.querySelector('#prompt-textarea')!.textContent = '';
+      clicked();
+    });
+    const delivery = live.runtimeMessage({ type: 'clf-desktop-input', id: inputId, conversationId: fresh ? null : chatA });
+    await click;
+    expect(live.sent.filter(message => message.ack)).toEqual([]);
+    const userProof = { turnId: 'long-helper-user', conversationId: chatA, messages: [{ role: 'user', stable: true,
+      messageId: 'm-long-helper-user', rawMessageId: 'm-long-helper-user', rawText: prompt }] };
+    if (fresh) live.hook.observe();
+    await bindFiberTurns([{ section: user, turn: userProof }]);
+    expect(await delivery).toEqual({ ok: true });
+    expect(live.sent.filter(message => message.ack)).toEqual([expect.objectContaining({ messageId: 'm-long-helper-user' })]);
+    const section = assistantTurn(live.document, 'long-helper-final', []);
+    prose(live.document, section, 'long-helper-answer', canonical);
+    const turn = (live.window as any).CLF_DOM.turns().find((item: any) => item.id === 'long-helper-final');
+    live.hook.noteGoalTurn(turn, 'completed', 'long-helper-final');
+    await bindFiberTurns([{ section: user, turn: userProof }, { section, turn: { turnId: 'long-helper-final', conversationId: chatA,
+      endMessageId: 'long-helper-answer', messages: [{ role: 'assistant', messageId: 'long-helper-answer', rawMessageId: 'long-helper-answer', rawText: canonical }] } }]);
+    expect(live.sent.filter(message => message.response)).toEqual([expect.objectContaining({ response: canonical })]);
+  });
+
+  it.each([false, true])('revokes a pending fresh helper on a second route (return to first: %s)', async (returnToFirst) => {
+    const prompt = 'Inspect `src/main/bridge.ts`';
+    live = await harness(`https://chatgpt.com/?cos-input=${inputId}`, {
+      desktop_input: message => ({ ok: true, data: message.authorize || message.ack ? { ok: true } : { input: claimed({ purpose: 'decision', text: prompt }) } })
+    }, undefined, false, true);
+    let clicks = 0;
+    let clicked!: () => void;
+    const click = new Promise<void>(resolve => { clicked = resolve; });
+    live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+      clicks++;
+      live!.dom.reconfigure({ url: `https://chatgpt.com/c/${chatA}` });
+      userTurn(live!.document, 'revoked-fresh-user', prompt.replaceAll('`', ''), { sent: false });
+      live!.document.querySelector('#prompt-textarea')!.textContent = '';
+      clicked();
+    });
+    const delivery = live.runtimeMessage({ type: 'clf-desktop-input', id: inputId, conversationId: null });
+    await click;
+    live.hook.observe(); await settle();
+    live.dom.reconfigure({ url: `https://chatgpt.com/c/${chatB}` });
+    live.hook.observe(); await settle();
+    if (returnToFirst) { live.dom.reconfigure({ url: `https://chatgpt.com/c/${chatA}` }); live.hook.observe(); }
+    live.document.querySelector('[data-message-author-role="user"]')!.textContent = prompt;
+    expect(await delivery).toEqual({ ok: false });
+    expect(live.sent.filter(message => message.ack || message.response)).toEqual([]);
+    expect(clicks).toBe(1);
+  });
+
+  it('refuses matching rendered text when the current exact provider user object contradicts it', async () => {
+    live = await harness(`https://chatgpt.com/c/${chatA}`, {
+      desktop_input: message => ({ ok: true, data: message.authorize || message.ack ? { ok: true } : { input: claimed({ purpose: 'decision' }) } })
+    });
+    let user!: HTMLElement;
+    let clicked!: () => void;
+    const click = new Promise<void>(resolve => { clicked = resolve; });
+    // Mount the real mismatching bubble first; only decoration later pretends to match.
+    live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+      user = userTurn(live!.document, 'conflicting-helper-user', 'Different provider input', { sent: false });
+      live!.document.querySelector('#prompt-textarea')!.textContent = '';
+      clicked();
+    });
+    const delivery = live.runtimeMessage({ type: 'clf-desktop-input', id: inputId, conversationId: chatA });
+    await click;
+    await bindFiberTurns([{ section: user, turn: { turnId: 'conflicting-helper-user', conversationId: chatA, messages: [{ role: 'user', stable: true,
+      messageId: 'm-conflicting-helper-user', rawMessageId: 'm-conflicting-helper-user', rawText: 'Different provider input' }] } }]);
+    user.querySelector('.whitespace-pre-wrap')!.textContent = text;
+    await settle();
+    expect(live.sent.filter(message => message.ack || message.response)).toEqual([]);
+    live.dom.reconfigure({ url: `https://chatgpt.com/c/${chatB}` });
+    live.hook.observe();
+    expect(await delivery).toEqual({ ok: false });
+  });
+
+  it.each(['same-page-id', 'changed-page-id'])('delivers the exact acknowledged helper answer from its current %s terminal', async (variant) => {
+    const canonical = '{"action":"continue","reply":"Continue the accepted task."}';
+    live = await harness(`https://chatgpt.com/c/${chatA}`, {
+      desktop_input: message => ({ ok: true, data: message.authorize || message.ack || message.response || message.partial
+        ? { ok: true } : { input: claimed({ purpose: 'decision' }) } })
+    });
+    const old = assistantTurn(live.document, 'historical-helper-final', []);
+    prose(live.document, old, 'historical-helper-answer', canonical);
+    live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+      userTurn(live!.document, 'accepted-terminal-user', text, { sent: false });
+      live!.document.querySelector('#prompt-textarea')!.textContent = '';
+    });
+    expect(await live.runtimeMessage({ type: 'clf-desktop-input', id: inputId, conversationId: chatA })).toEqual({ ok: true });
+    await bindFiberTurns([{ section: old, turn: { turnId: 'historical-helper-final', conversationId: chatA,
+      endMessageId: 'historical-helper-answer', messages: [{ role: 'assistant', messageId: 'historical-helper-answer', rawMessageId: 'historical-helper-answer', rawText: canonical }] } }]);
+    expect(live.sent.filter(message => message.response)).toEqual([]);
+    let section = assistantTurn(live.document, 'initial-helper-render', []);
+    prose(live.document, section, 'current-helper-answer', '{"');
+    startGenerating(live.document, { send: false });
+    live.hook.observe(); await settle();
+    // The model's terminal edge arrives before its raw body, ending local lifecycle once.
+    await bindFiberTurns([{ section, turn: { turnId: 'provider-current-turn', conversationId: chatA,
+      endMessageId: 'current-helper-answer', messages: [] } }]);
+    stopGenerating(live.document); live.hook.observe(); await settle();
+    expect(emitted(live.sent, 'turn_end').some(entry => entry.event.outcome === 'completed')).toBe(true);
+    expect(live.sent.filter(message => message.response)).toEqual([]);
+    section.remove();
+    section = assistantTurn(live.document, variant === 'same-page-id' ? 'initial-helper-render' : 'different-mounted-render-id', []);
+    prose(live.document, section, 'current-helper-answer', canonical);
+    const proof = { turnId: 'provider-current-turn', conversationId: chatA, endMessageId: 'current-helper-answer',
+      messages: [{ role: 'assistant', messageId: 'current-helper-answer', rawMessageId: 'current-helper-answer', rawText: canonical }] };
+    await bindFiberTurns([{ section, turn: { ...proof, calls: [{ tool: 'read', messageId: 'unfinished-helper-call', answered: false }] } }]);
+    expect(live.sent.filter(message => message.response)).toEqual([]);
+    await bindFiberTurns([{ section, turn: proof }]);
+    expect(live.sent.filter(message => message.response)).toEqual([expect.objectContaining({ id: inputId, response: canonical })]);
+  });
+
+  it.each(['newer-user', 'newer-assistant', 'foreign-conversation', 'stale-scan'])('refuses a helper terminal with %s ownership', async (conflict) => {
+    const canonical = '{"action":"continue","reply":"Never deliver a stale answer."}';
+    live = await harness(`https://chatgpt.com/c/${chatA}`, {
+      desktop_input: message => ({ ok: true, data: message.authorize || message.ack || message.response
+        ? { ok: true } : { input: claimed({ purpose: 'decision' }) } })
+    });
+    live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+      userTurn(live!.document, 'fenced-terminal-user', text, { sent: false });
+      live!.document.querySelector('#prompt-textarea')!.textContent = '';
+    });
+    expect(await live.runtimeMessage({ type: 'clf-desktop-input', id: inputId, conversationId: chatA })).toEqual({ ok: true });
+    const section = assistantTurn(live.document, 'fenced-helper-render', []);
+    prose(live.document, section, 'fenced-helper-answer', canonical);
+    const proof = { turnId: 'fenced-provider-turn', conversationId: conflict === 'foreign-conversation' ? chatB : chatA,
+      endMessageId: 'fenced-helper-answer', messages: [{ role: 'assistant', messageId: 'fenced-helper-answer', rawMessageId: 'fenced-helper-answer', rawText: canonical }] };
+    if (conflict === 'newer-user') userTurn(live.document, 'unrelated-new-user', 'A different request', { sent: false });
+    if (conflict === 'newer-assistant') prose(live.document, assistantTurn(live.document, 'newer-retry', []), 'newer-retry-message', 'Still working');
+    if (conflict === 'stale-scan') {
+      await bindFiberTurns([{ section, turn: { ...proof, endMessageId: null } }]);
+      await replyFiber([], [{ ...proof, index: 0 }], null, false);
+    } else await bindFiberTurns([{ section, turn: proof }]);
+    expect(live.sent.filter(message => message.response)).toEqual([]);
+  });
+
   it('delivers exact canonical helper JSON while completed native markdown is still truncated', async () => {
     const canonical = JSON.stringify({ action: 'continue', reply: JSON.stringify({ stages: ['Write a three-line poem', 'Verify exactly three lines'] }) });
     live = await harness(`https://chatgpt.com/?cos-input=${inputId}`, {
@@ -733,6 +1009,36 @@ describe('desktop input delivery and helper ownership', () => {
       expect.objectContaining({ id: inputId, owner: 'input-owner', response: canonical })
     ]);
   });
+  it('revokes only the cancelled helper claim while retaining fresh generation and draft close guards', async () => {
+    live = await harness(`https://chatgpt.com/?cos-input=${inputId}`, {
+      desktop_input: message => ({ ok: true, data: message.response ? { ok: false } :
+        message.authorize || message.ack ? { ok: true } : { input: claimed({ purpose: 'decision' }) } })
+    });
+    live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+      live!.dom.reconfigure({ url: `https://chatgpt.com/c/${chatA}` });
+      userTurn(live!.document, 'cancel-helper-user', text);
+      live!.document.querySelector('#prompt-textarea')!.textContent = '';
+    });
+    expect(await live.runtimeMessage({ type: 'clf-desktop-input', id: inputId, conversationId: null })).toEqual({ ok: true });
+    const section = assistantTurn(live.document, 'cancel-helper-final', []);
+    prose(live.document, section, 'cancel-helper-message', '{"action":"stop"}');
+    await bindFiberTurns([{ section, turn: { turnId: 'cancel-helper-final', endMessageId: 'cancel-helper-message',
+      messages: [{ role: 'assistant', messageId: 'cancel-helper-message', rawMessageId: 'cancel-helper-message', rawText: '{"action":"stop"}' }] } }]);
+    await settleTurn(live); await live.hook.flush(); await settle();
+    const check = (owner: string, id = inputId) => live!.runtimeMessage({ type: 'clf-tab-close-check', conversationId: chatA,
+      cancelledDecisions: [{ id: 'older-cancelled-input', owner }, { id, owner }] });
+    expect(await check('wrong-owner')).toMatchObject({ safe: false });
+    expect(await check('input-owner', 'bbbbbbbb-bbbb-4ccc-8ddd-eeeeeeeeeeee')).toMatchObject({ safe: false });
+    const composer = live.document.querySelector('#prompt-textarea')!;
+    composer.textContent = 'User draft stays';
+    expect(await check('input-owner')).toMatchObject({ safe: false });
+    expect(composer.textContent).toBe('User draft stays');
+    composer.textContent = '';
+    // The cancellation retires only response capability; a later normal close check
+    // can use the existing safe-idle rule after the user has cleared their draft.
+    expect(await live.runtimeMessage({ type: 'clf-tab-close-check', conversationId: chatA })).toMatchObject({ safe: true });
+  });
+
   it('publishes observed helper partials without acknowledging an unfinished answer', async () => {
     live = await harness(`https://chatgpt.com/?cos-input=${inputId}`, {
       desktop_input: message => ({ ok: true, data: message.authorize ? { ok: true } : message.ack || message.partial ? { ok: true } : { input: claimed({ purpose: 'decision' }) } })
@@ -927,7 +1233,11 @@ function toolBlock(document: Document, label: string): HTMLElement {
   block.className = 'pointer-events-none contents';
   const button = document.createElement('button');
   button.type = 'button';
-  if (connector) button.setAttribute('aria-label', 'Open tool call list');
+  if (connector) {
+    button.setAttribute('aria-label', 'Open tool call list');
+    // This harness fakes MAIN-world observation; the real helper proves the row.
+    button.setAttribute('data-clf-fiber', 'fixture:0');
+  }
   const span = document.createElement('span');
   span.className = 'text-start';
   span.textContent = connector ? label.slice(0, -1) : label;
@@ -5254,6 +5564,8 @@ describe('a stop button that goes missing while the turn is still running', () =
     null,
     { model: 'GPT-6 Pro' },
     { model: 'GPT-5.6 Pro' },
+    { model: 'gpt-5-6-pro' },
+    { model: 'gpt-5-5-pro' },
     { model: 'GPT-6', reasoningEffort: 'pro' },
     { model: 'GPT-5.6 Sol', reasoningEffort: 'pro' }
   ])('requires actual final evidence without Fiber for Pro or unknown selection %j', async (selection) => {
@@ -7584,7 +7896,7 @@ describe('evidence from the page context', () => {
     const token = 'JXIuSUNfIFE5hNDG40d9Fw';
     const requestId = 'ad15030a-dcba-41e9-b5e7-7c251eb6dc38';
     const prompt = `[[CLF-RESUME:${token}]]\n\nContinue the previous ChatGPT session.`;
-    live.reply.set('compact', () => ({ ok: true, data: {} }));
+    live.reply.set('compact', () => ({ ok: true, data: { committed: true, conversationId } }));
     live.reply.set('correlate', () => ({
       ok: true,
       data: { conversationId, sessionId: '2026-09-01-7b3c26c2', confirmed: [requestId], complete: true }
@@ -8094,6 +8406,7 @@ describe('evidence from the page context', () => {
   it('says nothing about a row the helper did not stamp', async () => {
     live = await harness();
     const section = assistantTurn(live.document, 'turn-1', ['Called tool!']);
+    section.querySelector('[data-clf-fiber]')!.removeAttribute('data-clf-fiber');
     await reply([GOOD]);
     expect(live.hook.fiberFor(section.querySelector('[aria-label="Open tool call list"]')!)).toBeNull();
   });
@@ -9739,6 +10052,49 @@ describe('the Compact & resume control', () => {
  * its actual output through the composer — the one part of the page that belongs to the
  * user. The work now happens in a second field behind the input, and the input stays empty.
  */
+describe('truthful quiet operation status', () => {
+  it('explains one/multiple workers and failures without claiming the parent depends on them', async () => {
+    live = await harness();
+    const view = (workers: unknown) => live!.hook.stageView({ now: 10000, changedAt: 0, progress: { workers } });
+    expect(view({ active: 1, finished: 2, failed: 0, names: ['Repository audit'] })).toMatchObject({ stage: 'Worker still running: Repository audit', detail: '2 finished · 1 running' });
+    expect(view({ active: 2, finished: 1, failed: 1 })).toMatchObject({ stage: '2 workers still running', detail: '1 finished · 2 running · 1 failed' });
+    expect(view({ active: 0, finished: 2, failed: 1 })).toMatchObject({ stage: 'A worker needs attention' });
+    expect(view({ active: 0, finished: 3, failed: 0 })).toBeNull(); // no invented consolidation
+  });
+  it('waits through short pauses and clears the status when real output resumes', async () => {
+    live = await harness();
+    const progress = { tools: { count: 1, since: 5000 } };
+    expect(live.hook.stageView({ now: 6000, changedAt: 0, progress })).toBeNull();
+    expect(live.hook.stageView({ now: 10000, changedAt: 0, progress })).toMatchObject({ stage: 'Waiting for a local tool to finish' });
+    expect(live.hook.stageView({ now: 10000, changedAt: 9999, progress })).toBeNull();
+    expect(live.hook.stageView({ now: 10000, changedAt: 0, progress: { tools: null } })).toBeNull();
+  });
+  it('updates one ephemeral panel and removes it when the activity feed becomes unavailable', async () => {
+    live = await harness();
+    const clock = vi.spyOn(live.window.Date, 'now').mockReturnValue(Date.now() + 10000);
+    try {
+    let count = 1;
+    live.reply.set('activity', () => ({ ok: true, data: { entries: [], job: null, progress: { tools: { count, since: Date.now() - 10000 } } } }));
+    await live.hook.pullActivity();
+    expect(live.document.querySelectorAll('.clf-stage')).toHaveLength(1);
+    const panel = live.document.querySelector('.clf-stage');
+    count = 2;
+    await live.hook.pullActivity();
+    expect(live.document.querySelectorAll('.clf-stage')).toHaveLength(1);
+    expect(live.document.querySelector('.clf-stage')).toBe(panel);
+    expect(panel!.textContent).toContain('2 local tools');
+    live.reply.set('activity', () => ({ ok: false }));
+    await live.hook.pullActivity();
+    expect(live.document.querySelector('.clf-stage')).toBeNull();
+    } finally { clock.mockRestore(); }
+  });
+  it('does not guess a GitHub or API dependency from an otherwise unexplained pending generation', async () => {
+    live = await harness();
+    expect(live.hook.stageView({ now: 10000, changedAt: 0, generating: true })).toMatchObject({ stage: 'Still waiting for the current operation to complete' });
+    expect(live.hook.stageView({ now: 10000, changedAt: 0, generating: false })).toBeNull();
+  });
+});
+
 describe('the field above the composer', () => {
   const view = (over: Record<string, unknown>) => live!.hook.stageView({ job: null, ...over });
 
@@ -11500,6 +11856,37 @@ app-owned prompt`, { sent: false });
     expect(emitted(live.sent, 'user_message').map((entry) => entry.event.text)).toContain('the question asked after reopening');
   });
 
+  it('journals a reloaded committed destination even when history already contains duplicate resume markers', async () => {
+    live = await harness(`https://chatgpt.com/c/${CHAT}`, {
+      activity: () => ({ ok: true, data: { entries: [], stream: [], nextSince: 0, pendingTools: 0,
+        sessionId: 'known-resumed-session', bootstrap: 'resume', job: null } }),
+      compact: () => ({ ok: false, status: 0, error: 'must not need another commit' })
+    });
+    userTurn(live.document, 'original-bootstrap', `${destinationMarker}\noriginal handoff`);
+    userTurn(live.document, 'duplicated-bootstrap', `${destinationMarker}\nold duplicate handoff`);
+    live.hook.observe(); await settle();
+    userTurn(live.document, 'new-question-reloaded', 'New question in the app-proven resumed session');
+    live.hook.observe(); await settle(); await live.hook.flush();
+    expect(emitted(live.sent, 'user_message').map(({ event }) => event.text))
+      .toContain('New question in the app-proven resumed session');
+  });
+
+  it('does not reopen a settled journal gate when later text quotes the same resume marker', async () => {
+    live = await harness(`https://chatgpt.com/c/${CHAT}`, {
+      activity: activityReply,
+      compact: () => ({ ok: true, data: { committed: true, conversationId: CHAT } })
+    });
+    const section = userTurn(live.document, 'turn-destination', `${destinationMarker}\napp-owned prompt`, { sent: false });
+    live.hook.observe(); await settle();
+    await bindFiberTurns([{ section, turn: markedTurn('destination') }]);
+    userTurn(live.document, 'turn-quoted-marker', `${destinationMarker}\nquoted in a later message`);
+    live.hook.observe(); await settle();
+    userTurn(live.document, 'turn-after-quote', 'New question after the committed handoff');
+    live.hook.observe(); await settle(); await live.hook.flush();
+    expect(emitted(live.sent, 'user_message').map(({ event }) => event.text))
+      .toContain('New question after the committed handoff');
+  });
+
   it('keeps holding the journal while the app is merely unreachable', async () => {
     live = await harness(`https://chatgpt.com/c/${CHAT}`, {
       activity: activityReply,
@@ -11518,6 +11905,29 @@ app-owned prompt`, { sent: false });
     await live.hook.flush();
 
     expect(emitted(live.sent, 'user_message')).toHaveLength(0);
+  });
+
+  it.each([
+    { ok: false, error: 'stale_document' },
+    { ok: true, data: {} }
+  ])('holds the destination journal until an authoritative commit after %j', async (initialReply) => {
+    let reply: any = initialReply;
+    live = await harness(`https://chatgpt.com/c/${CHAT}`, {
+      activity: activityReply,
+      compact: () => reply
+    });
+    const section = userTurn(live.document, 'turn-destination', `${destinationMarker}\napp-owned prompt`, { sent: false });
+    live.hook.observe(); await settle();
+    await bindFiberTurns([{ section, turn: markedTurn('destination') }]);
+    userTurn(live.document, 'turn-next', 'queued behind the pending continuation');
+    live.hook.observe(); await settle(); await live.hook.flush();
+    expect(emitted(live.sent, 'user_message')).toHaveLength(0);
+
+    reply = { ok: true, data: { committed: true, conversationId: CHAT } };
+    await bindFiberTurns([{ section, turn: markedTurn('destination') }]);
+    await live.hook.flush();
+    expect(emitted(live.sent, 'user_message').map(({ event }) => event.text))
+      .toContain('queued behind the pending continuation');
   });
 
   it('does not carry a held journal gate into the next chat the tab moves to', async () => {
@@ -13154,6 +13564,23 @@ describe('the goal loop', () => {
     });
     // Idle says nothing at all rather than an empty panel.
     expect(view({ phase: '', error: '', model: MODEL, draft: null })).toBeNull();
+    // A custom endpoint is named as one: the OpenRouter default above must not leak into a
+    // run that never touched OpenRouter.
+    expect(view({ phase: 'requesting', error: '', model: 'llama3.1', provider: 'custom', draft: null })).toMatchObject({
+      stage: 'Sending the answer to custom endpoint',
+      detail: 'llama3.1'
+    });
+    expect(
+      view({ phase: 'drafting', error: '', model: 'llama3.1', provider: 'custom', draft: { stage: 'failed' } })
+    ).toMatchObject({ detail: 'custom endpoint did not answer' });
+    expect(view({ phase: 'requesting', model: 'gpt-5.6-sol', backend: 'chatgpt', provider: 'openrouter', draft: null }))
+      .toMatchObject({ stage: 'Sending the answer to ChatGPT helper', detail: 'gpt-5.6-sol' });
+    expect(view({ phase: 'drafting', model: MODEL, backend: 'api', provider: 'custom',
+      draft: { stage: 'sending', backend: 'chatgpt', model: 'gpt-5.6-sol' } }))
+      .toMatchObject({ stage: 'Sending the answer to ChatGPT helper', detail: 'gpt-5.6-sol' });
+    expect(view({ phase: 'drafting', model: MODEL, backend: 'api',
+      draft: { stage: 'answering', backend: 'chatgpt', model: 'gpt-5.6-sol', text: 'Next task' } }))
+      .toMatchObject({ stage: 'gpt-5.6-sol is answering', body: 'Next task' });
     // A running job owns the panel: a compaction is the bigger event, and the loop refuses to
     // act during one anyway.
     expect(hook.stageView({ job: { stage: 'opening', busy: true }, goal: { phase: 'settling', model: MODEL, draft: null } })).toMatchObject({
@@ -13249,6 +13676,24 @@ describe('the goal loop', () => {
     // Nothing has been typed yet, so "Preparing" is the truth and stays.
     expect(pending({ state: 'not-attempted', messageId: null })).toMatchObject({ at: 0 });
     expect(pending(null)).toMatchObject({ at: 0 });
+  });
+
+  it.each([
+    { backend: 'chatgpt', provider: 'openrouter', model: 'gpt-5.6-sol', destination: 'ChatGPT helper' },
+    { backend: 'api', provider: 'custom', model: 'local-model', destination: 'custom endpoint' }
+  ])('keeps the actual $backend driver in the mounted progress panel', async driver => {
+    const activity = () => {
+      const reply: any = feed({ token: 'progress-token', conversationId: CHAT, turnId: 'progress-turn',
+        stage: 'sending', model: driver.model, text: '', reply: '', error: null })();
+      Object.assign(reply.data.goal, driver);
+      return reply;
+    };
+    live = await harness(`https://chatgpt.com/c/${CHAT}`, { ...goalReplies(), activity });
+    await live.hook.pullActivity();
+    live.hook.injectStage();
+    const panel = live.document.querySelector('.clf-stage')!;
+    expect(panel.querySelector('.clf-stage-title')!.textContent).toBe(`Sending the answer to ${driver.destination}`);
+    expect(panel.querySelector('.clf-stage-detail')!.textContent).toBe(driver.model);
   });
 
   it('draws the bar above the composer, lit up to the stage it is on', async () => {
@@ -13672,6 +14117,57 @@ describe('the goal loop', () => {
     expect(composerText(live.document)).toBe('');
   });
 
+  it.each([
+    { matches: true, fromExisting: false }, { matches: false, fromExisting: false },
+    { matches: true, fromExisting: true }, { matches: false, fromExisting: true },
+    { matches: true, fromExisting: true, navigate: true }
+  ])('binds an opening Goal only to its delayed exact user receipt (%j)', async ({ matches, fromExisting, navigate }) => {
+    const opening = 'Inspect `src/main/bridge.ts` and report the result.';
+    live = await harness(fromExisting ? 'https://chatgpt.com/c/bbbbbbbb-cccc-dddd-eeee-ffffffffffff' : 'https://chatgpt.com/', {
+      settings_get: () => ({ ok: true, data: {
+        context: { auto: false, threshold: 400_000, warn: 400_000, limit: 533_000 },
+        goal: { enabled: false, hasKey: true, model: MODEL, objective: '', blocked: '' }
+      } }),
+      goal_open: () => ({ ok: true, data: { reply: opening, model: MODEL } })
+    }, undefined, false, true);
+    if (fromExisting) {
+      live.window.history.replaceState({}, '', '/');
+      live.hook.observe(); await settle();
+    }
+    await live.hook.pullActivity();
+    let user!: HTMLElement;
+    let clicks = 0;
+    live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+      clicks++;
+      live!.window.history.replaceState({}, '', `/c/${CHAT}`);
+      user = userTurn(live!.document, 'opening-goal-receipt', opening.replaceAll('`', ''), { sent: false });
+      live!.document.querySelector('#prompt-textarea')!.textContent = '';
+      live!.hook.observe(); // The route is already visible before its MAIN-world proof.
+    });
+    live.hook.injectControl(); live.hook.toggleMenu();
+    (live.document.querySelector('.clf-menu-goal-link') as HTMLButtonElement).click();
+    const box = live.document.querySelector('[data-clf-goal-input]') as HTMLTextAreaElement;
+    box.value = 'Review the bridge'; box.dispatchEvent(new live.window.Event('input', { bubbles: true }));
+    (live.document.querySelector('.clf-menu-goal-save') as HTMLButtonElement).click();
+    await settle(100);
+    expect(clicks).toBe(1);
+    expect(live.sent.filter(message => message.type === 'goal_objective')).toEqual([]);
+    if (navigate) {
+      live.window.history.replaceState({}, '', '/c/cccccccc-dddd-eeee-ffff-111111111111');
+      live.hook.observe(); await settle();
+      live.window.history.replaceState({}, '', `/c/${CHAT}`);
+      live.hook.observe(); await settle();
+    }
+    await bindFiberTurns([{ section: user, turn: { turnId: 'opening-goal-receipt', conversationId: CHAT,
+      messages: [{ role: 'user', stable: true, messageId: 'm-opening-goal-receipt', rawMessageId: 'm-opening-goal-receipt',
+        rawText: matches ? opening : 'An unrelated question in another chat' }] } }]);
+    await settle(100); live.hook.observe(); await settle();
+    expect(live.sent.filter(message => message.type === 'goal_objective')).toEqual(matches && !navigate ? [
+      expect.objectContaining({ conversationId: CHAT, text: 'Review the bridge', mode: 'goal' })
+    ] : []);
+    expect(clicks).toBe(1);
+  });
+
   it('opens a New Chat on a goal, and writes its first message', async () => {
     live = await harness('https://chatgpt.com/', {
       settings_get: () => ({
@@ -13694,7 +14190,7 @@ describe('the goal loop', () => {
     // mounted so this test can still assert what was typed, but model ChatGPT starting generation
     // by swapping in its Stop control when the send button is clicked.
     live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
-      startGenerating(live!.document);
+      startGenerating(live!.document, { send: false });
     });
     live.hook.injectControl();
     live.hook.toggleMenu();
@@ -13717,6 +14213,7 @@ describe('the goal loop', () => {
 
     // And the goal is bound to the chat the moment ChatGPT names it, so the ordinary loop
     // picks it up from the next turn onwards.
+    userTurn(live.document, 'accepted-goal-opening', 'rewrite the parser in rust', { sent: false });
     live.window.history.replaceState({}, '', `/c/${CHAT}`);
     live.hook.observe();
     await settle();
@@ -13860,7 +14357,7 @@ describe('the goal loop', () => {
     });
     await live.hook.pullActivity();
     live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
-      startGenerating(live!.document);
+      startGenerating(live!.document, { send: false });
     });
     live.hook.injectControl();
     live.hook.toggleMenu();
@@ -13887,6 +14384,7 @@ describe('the goal loop', () => {
       { text: 'build the voxel sandbox', mode: 'loop' }
     ]);
 
+    userTurn(live.document, 'accepted-loop-opening', 'build the voxel sandbox', { sent: false });
     live.window.history.replaceState({}, '', `/c/${CHAT}`);
     live.hook.observe();
     await settle();
@@ -13919,7 +14417,7 @@ describe('the goal loop', () => {
       goal_open: () => ({ ok: true, data: { reply: 'one cycle stop', model: MODEL } })
     });
     live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
-      startGenerating(live!.document);
+      startGenerating(live!.document, { send: false });
     });
 
     // New Chat, reached from a chat rather than loaded fresh: the route drops its id while
@@ -13952,6 +14450,7 @@ describe('the goal loop', () => {
     }
 
     // And the goal still binds to the chat ChatGPT names, as the loop it was written as.
+    userTurn(live.document, 'accepted-prior-chat-opening', 'one cycle stop', { sent: false });
     live.window.history.replaceState({}, '', `/c/${CHAT}`);
     live.hook.observe();
     await settle();
@@ -14520,9 +15019,11 @@ describe('app Stop command uses current native turn proof', () => {
     window.addEventListener('message', answer);
     try {
       prose(live.document, section, 'late-native-final', 'First words and the complete final answer.');
-      await new Promise(resolve => globalThis.setTimeout(resolve, 20));
-      await live.hook.flush();
-      expect(emitted(live.sent, 'assistant_message').some(row => row.event.text === 'First words and the complete final answer.')).toBe(true);
+      // Wait for the observed publication, not a 20ms scheduling guess under the full suite.
+      await vi.waitFor(async () => {
+        await live!.hook.flush();
+        expect(emitted(live!.sent, 'assistant_message').some(row => row.event.text === 'First words and the complete final answer.')).toBe(true);
+      }, { timeout: 1000, interval: 10 });
       expect(emitted(live.sent, 'turn_end')).toHaveLength(1);
       expect(live.document.visibilityState).toBe('hidden');
     } finally { window.removeEventListener('message', answer); window.setTimeout = instant; }
@@ -14580,5 +15081,108 @@ describe('app Stop command uses current native turn proof', () => {
     });
     expect(await live!.runtimeMessage(h.request)).toEqual({ ok: false });
     expect(h.clicks()).toBe(0);
+  });
+});
+
+describe('resume irreversible boundary audit', () => {
+  it('does not send a user-replaced draft after awaiting destination dispatch', async () => {
+    const commandId = 'cmd-resume-draft-race';
+    const token = '0123456789abcdef0123456789abcdef';
+    let page: Document;
+    const submitted: string[] = [];
+    live = await harness(`https://chatgpt.com/?clf=${commandId}`, {
+      redeem: () => ({ ok: true, command: { id: commandId, type: 'resume', text: `[[CLF-RESUME:${token}]] handoff`, agent: null } }),
+      compact: message => {
+        if (message.destinationAttempt) return { ok: true, data: { allowed: true } };
+        if (message.destinationDispatch) { page.querySelector('#prompt-textarea')!.textContent = 'UNRELATED USER DRAFT'; return { ok: true, data: { armed: true } }; }
+        return { ok: true, data: {} };
+      }, ack: () => ({ ok: true })
+    }, document => {
+      page = document;
+      document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+        submitted.push(document.querySelector('#prompt-textarea')!.textContent || '');
+        document.querySelector('#prompt-textarea')!.textContent = '';
+      });
+    });
+    await settle(200);
+    expect(submitted).toEqual([]);
+    expect(live.document.querySelector('#prompt-textarea')!.textContent).toBe('UNRELATED USER DRAFT');
+  });
+  it('does not release an ambiguous dispatched resume merely because the editor was replaced', async () => {
+    const commandId = 'cmd-resume-editor-after-click';
+    const token = '0123456789abcdef0123456789abcdef';
+    let clicks = 0;
+    live = await harness(`https://chatgpt.com/?clf=${commandId}`, {
+      redeem: () => ({ ok: true, command: { id: commandId, type: 'resume', text: `[[CLF-RESUME:${token}]] handoff`, agent: null } }),
+      compact: () => ({ ok: true, data: {} }), ack: () => ({ ok: true })
+    }, document => {
+      document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+        clicks++;
+        const box = document.querySelector('#prompt-textarea')!;
+        const replacement = box.cloneNode(false); box.replaceWith(replacement);
+      });
+    });
+    await settle(200);
+    expect(clicks).toBe(1);
+    expect(live.sent.filter(message => message.type === 'compact' && message.destinationLost)).toEqual([]);
+    live.dom.reconfigure({ url: 'https://chatgpt.com/c/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' });
+    userTurn(live.document, 'ambiguous-destination', 'provider response after the editor replacement', { sent: false });
+    live.hook.observe(); await settle(200); await live.hook.flush();
+    expect(emitted(live.sent, 'user_message')).toHaveLength(0);
+  });
+  it('does not ACK an unrelated route reached after submit cleared the fresh composer', async () => {
+    const commandId = 'cmd-resume-route-after-send';
+    const token = '0123456789abcdef0123456789abcdef';
+    const unrelated = 'bbbbbbbb-1111-4222-8333-444444444444';
+    live = await harness(`https://chatgpt.com/?clf=${commandId}`, {
+      redeem: () => ({ ok: true, command: { id: commandId, type: 'resume', text: `[[CLF-RESUME:${token}]] handoff`, agent: null } }),
+      ack: () => ({ ok: true })
+    }, (document, dom) => {
+      document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+        document.querySelector('#prompt-textarea')!.textContent = '';
+        void Promise.resolve().then(() => dom.window.history.pushState({}, '', `/c/${unrelated}`));
+      });
+    });
+    await settle(200);
+    expect(live.sent.filter(message => message.type === 'ack' && message.conversationId === unrelated)).toEqual([]);
+  });
+});
+
+
+describe('stable final eligibility during compaction custody', () => {
+  it.each([
+    { handoff: false, busy: true },
+    { handoff: false, busy: false },
+    { handoff: true, busy: true },
+    { handoff: true, busy: false }
+  ])('files only the ordinary final independently of the compaction ticket: %j', async ({ handoff, busy }) => {
+    const token = '0123456789abcdef0123456789abcdef';
+    live = await harness(undefined, {
+      activity: () => ({ ok: true, data: { entries: [], stream: [], nextSince: 0, pendingTools: 0,
+        job: busy ? { sessionId: 's1', stage: 'asking', busy: true, token, sourceSend: { state: 'dispatched-unresolved' } } : null,
+        goal: { enabled: true, hasKey: true, mode: 'loop', draft: null }
+      } }),
+      compact: () => ({ ok: false, error: 'stale_document' })
+    });
+    startGenerating(live.document);
+    live.hook.observe(); await settle();
+    const section = assistantTurn(live.document, 'ordinary-or-handoff', []);
+    prose(live.document, section, 'terminal-answer', 'B_DONE 552');
+    live.hook.observe(); await settle();
+    await bindFiberTurns([{ section, turn: {
+      turnId: 'ordinary-or-handoff', endMessageId: 'terminal-answer', calls: [],
+      messages: [
+        ...(handoff ? [{ messageId: 'handoff-user', rawMessageId: 'handoff-user', role: 'user', stable: true,
+          rawText: `[[CLF-HANDOFF:${token}]] Write the brief.`, renderedHtml: '' }] : []),
+        { messageId: 'terminal-answer', rawMessageId: 'terminal-answer', role: 'assistant', stable: true,
+          rawText: 'B_DONE 552', renderedHtml: '' }
+      ]
+    } }]);
+    await live.hook.flush();
+    const final = emitted(live.sent, 'assistant_message').map(({ event }) => event)
+      .find(event => event.messageId === 'terminal-answer' && event.final);
+    expect(final?.turnId).toBeTruthy();
+    expect(final?.goalEligible === true).toBe(!handoff);
+    if (busy) expect(live.sent.filter(message => message.type === 'goal_draft')).toEqual([]);
   });
 });

--- a/test/continuation.test.ts
+++ b/test/continuation.test.ts
@@ -55,6 +55,7 @@ const {
   attachSummary,
   beginContinuationDestinationSendNow,
   beginContinuationSourceSendNow,
+  bindContinuationSourceMessageNow,
   bindContinuationDestinationMessageNow,
   claimContinuationNow,
   commitContinuation,
@@ -1416,5 +1417,45 @@ describe('the window in which a replacement chat is expected', () => {
       conversationId: 'worker-old-owner',
       state: 'sleeping'
     });
+  });
+});
+
+/**
+ * Issue #21: a handoff that was still being written got declared dead at ten minutes.
+ *
+ * The deadline is a limit on *waiting*, but it was measured from the moment the transaction
+ * opened — so a brief ChatGPT was still generating looked exactly like one nobody had touched.
+ * On a 730k-token chat under Pro reasoning the generation took longer than that, and the reported
+ * consequence was worse than a lost handoff: once the running continuation expired,
+ * auto-compaction treated the compaction itself as an eligible turn, stopped it, and started
+ * another one on top.
+ *
+ * The renewal is deliberately not a longer timeout. A chat that has genuinely gone quiet still
+ * expires on the original clock, which the second test here is for.
+ */
+describe('an exact handoff response owns its waiting deadline', () => {
+  it('survives growing output and restart but expires after unchanged snapshots', async () => {
+    vi.useFakeTimers();
+    try {
+      const session = await createSession({ title: 'long handoff', conversationId: CHAT_A });
+      const opened = await openContinuationNow(session.id, CHAT_A);
+      await beginContinuationSourceSendNow(opened.token);
+      await dispatchContinuationSourceSendNow(opened.token);
+      await bindContinuationSourceMessageNow(opened.token, 'exact-user-message');
+      vi.setSystemTime(Date.now() + CONTINUATION_TTL_MS - 60_000);
+      expect(await bindContinuationSourceMessageNow(opened.token, 'wrong-message', 500)).toBe(false);
+      expect(await bindContinuationSourceMessageNow('wrong-token', 'exact-user-message', 500)).toBe(false);
+      expect(await bindContinuationSourceMessageNow(opened.token, 'exact-user-message', 500)).toBe(true);
+      vi.setSystemTime(Date.now() + 2 * 60_000);
+      expect(continuationByToken(opened.token)?.state).toBe('awaiting-summary');
+      const snapshot = snapshotContinuations();
+      resetContinuationsForTests();
+      await restoreContinuations(snapshot);
+      expect(continuationByToken(opened.token)?.state).toBe('awaiting-summary');
+      expect(await bindContinuationSourceMessageNow(opened.token, 'exact-user-message', 500)).toBe(true);
+      vi.setSystemTime(Date.now() + CONTINUATION_TTL_MS);
+      expect(continuationByToken(opened.token)?.state).toBe('aborted');
+      expect(await bindContinuationSourceMessageNow(opened.token, 'exact-user-message', 1000)).toBe(false);
+    } finally { vi.useRealTimers(); }
   });
 });

--- a/test/desktop-input-maintenance.test.ts
+++ b/test/desktop-input-maintenance.test.ts
@@ -50,6 +50,90 @@ async function worker(inputs: Array<{ id: string; conversationId: string | null 
 }
 
 describe('one browser maintenance flight per desktop outbox publication', () => {
+  it.each(['closed', 'navigated'])('does not reopen an elected input tab after it is %s, including browser restart', async reason => {
+    const input = { id: firstId, conversationId: null };
+    const h = await worker([input]);
+    await h.maintain();
+    expect(h.create).toHaveBeenCalledTimes(1);
+    if (reason === 'closed') h.tabs.length = 0;
+    else { h.tabs[0]!.url = 'https://chatgpt.com/'; delete h.tabs[0]!.pendingUrl; }
+    await h.maintain(); await h.maintain();
+    expect(h.create).toHaveBeenCalledTimes(1);
+    const restarted = await worker([input], undefined, h.localSaved);
+    await restarted.maintain();
+    expect(restarted.create).not.toHaveBeenCalled();
+  });
+  it('spends input opening authority before creation and permits a new explicit operation', async () => {
+    const inputs = [{ id: firstId, conversationId: null }];
+    const h = await worker(inputs);
+    h.create.mockImplementationOnce(async () => { throw new Error('Chrome rejected creation'); });
+    await expect(h.maintain()).rejects.toThrow('Chrome rejected creation'); await h.maintain();
+    expect(h.create).toHaveBeenCalledTimes(1);
+    inputs.splice(0, 1, { id: secondId, conversationId: null });
+    await h.maintain();
+    expect(h.create).toHaveBeenCalledTimes(2);
+  });
+  it('does not create behind a failed custody write', async () => {
+    const h = await worker([{ id: firstId, conversationId: null }]);
+    h.local.set.mockImplementation(async value => {
+      if ('inputOpenings' in value) throw new Error('disk full');
+      Object.assign(h.localSaved, value);
+    });
+    await expect(h.maintain()).rejects.toThrow('disk full'); await h.maintain();
+    expect(h.create).not.toHaveBeenCalled();
+  });
+  it('restores the pre-create checkpoint without reopening after a crash before tab-id persistence', async () => {
+    const input = { id: firstId, conversationId: null };
+    const h = await worker([input], undefined, { inputOpenings: { [firstId]: { tab: null } } });
+    await h.maintain();
+    expect(h.create).not.toHaveBeenCalled();
+    h.tabs.push({ id: 9, url: `https://chatgpt.com/?cos-input=${firstId}` });
+    await h.maintain();
+    expect(h.sendMessage).toHaveBeenCalledWith(9, expect.objectContaining({ type: 'clf-desktop-input', id: firstId }));
+    expect(h.create).not.toHaveBeenCalled();
+  });
+  it('does not confuse a temporarily withheld offer with retired opening authority', async () => {
+    const input = { id: firstId, conversationId: null };
+    const inputs = [input];
+    const h = await worker(inputs);
+    await h.maintain(); h.tabs.length = 0;
+    inputs.length = 0;
+    await h.maintain();
+    inputs.push(input);
+    await h.maintain();
+    expect(h.create).toHaveBeenCalledTimes(1);
+  });
+  it('closes an explicitly retired temporary planner without requiring another work tab', async () => {
+    const h = await worker([{ id: firstId, conversationId: null, owner: '7:planner:1', lifetime: 'temporary-planner', close: true, retire: true } as any]);
+    h.tabs.push({ id: 7, url: `https://chatgpt.com/?temporary-chat=true&cos-input=${firstId}` });
+    await h.authorizeDocument({ tab: { id: 7 }, documentId: 'planner', frameId: 0, url: h.tabs[0]!.url }, { navigationEpoch: 1 });
+    h.sendMessage.mockImplementation(async () => ({ safe: true } as never));
+    await h.maintain();
+    expect(h.remove).toHaveBeenCalledWith(7);
+    expect(h.create).not.toHaveBeenCalled();
+  });
+  it('never opens a helper for passive model observation, including repeated maintenance', async () => {
+    const h = await worker([]);
+    const request = { nonce: firstId, expiresAt: Date.now() + 60000, allowOpen: false };
+    await h.inspectModels(request, true); await h.inspectModels(request, true);
+    expect(h.create).not.toHaveBeenCalled();
+    h.tabs.push({ id: 8, url: `https://chatgpt.com/c/${secondId}` });
+    await h.inspectModels(request, true);
+    expect(h.sendMessage).toHaveBeenCalledWith(8, expect.objectContaining({ type: 'clf-model-catalog' }));
+    expect(h.create).not.toHaveBeenCalled();
+  });
+  it('retains model discovery custody when a user closes its elected tab', async () => {
+    const h = await worker([]);
+    const request = { nonce: firstId, expiresAt: Date.now() + 60000 };
+    await h.inspectModels(request, true);
+    expect(h.create).toHaveBeenCalledTimes(1);
+    h.tabs.length = 0;
+    await h.inspectModels(request, true); await h.inspectModels(request, true);
+    expect(h.create).toHaveBeenCalledTimes(1);
+    // Only a new explicit request can authorize another tab.
+    await h.inspectModels({ ...request, nonce: secondId }, true);
+    expect(h.create).toHaveBeenCalledTimes(2);
+  });
   it('does not close a temporary planner when its answer is accepted', async () => {
     const h = await worker([]);
     const url = `https://chatgpt.com/?temporary-chat=true&cos-input=${firstId}`;
@@ -88,12 +172,12 @@ describe('one browser maintenance flight per desktop outbox publication', () => 
     });
     await h.maintain(); expect(h.remove).not.toHaveBeenCalled();
   });
-  it('sizes the owned minimized window from desktop work area without requesting focus or restore', async () => {
+  it('bounds the owned minimized window inside the work area without requesting focus or restore', async () => {
     const h = await worker([{ id: firstId, conversationId: null }]);
     h.fetch.mockResolvedValue({ ok: true, status: 200, json: async () => ({ app: 'chat-on-steroids', bridge: BRIDGE_PROTOCOL, compatible: true, paired: true, ok: true, inputs: [{ id: firstId, conversationId: null }], background: true, browserWorkArea: { x: -1920, y: 0, width: 1920, height: 1040 } }) });
     await h.maintain();
     expect(h.windows.create).toHaveBeenCalledWith(expect.objectContaining({ focused: false, state: 'minimized' }));
-    expect(h.windows.update).toHaveBeenCalledWith(80, { left: -1920, top: 0, width: 1920, height: 1040 });
+    expect(h.windows.update).toHaveBeenCalledWith(80, { left: -1510, top: 120, width: 1100, height: 800 });
     expect(h.windows.update.mock.calls.every(call => !('focused' in (call[1] as object)) && !('state' in (call[1] as object)))).toBe(true);
   });
   it('reuses an idle conversation without opening or navigating a helper', async () => {
@@ -128,15 +212,36 @@ describe('one browser maintenance flight per desktop outbox publication', () => 
     await h.maintain();
     expect(h.create).toHaveBeenCalledTimes(1);
   });
-  it('reuses a warm catalog across requests without navigation or closing it', async () => {
+  it('retires the completed exact dedicated catalog and preserves its opening tombstone', async () => {
     const h = await worker([]);
     h.tabs.push({ id: 7, url: `https://chatgpt.com/?cos-model-catalog=${firstId}` }, { id: 8, url: `https://chatgpt.com/c/${secondId}` });
-    await h.inspectModels({ nonce: secondId, expiresAt: Date.now() + 60000 }, true);
+    await h.authorizeDocument({ tab: { id: 7 }, documentId: 'catalog', frameId: 0, url: h.tabs[0]!.url }, { navigationEpoch: 1 });
+    h.sendMessage.mockImplementation(async (_id, message) => message.type === 'clf-tab-close-check'
+      ? { ok: true, safe: true, conversationId: null, navigationEpoch: 1 } as never : { ok: true, ready: true });
+    h.remove.mockImplementation(async id => { h.tabs.splice(h.tabs.findIndex(tab => tab.id === id), 1); });
+    const request = { nonce: secondId, expiresAt: Date.now() + 60000 };
+    await h.inspectModels(request, true);
+    expect(h.remove.mock.calls).toEqual([[7]]);
+    expect(h.saved.modelCatalogOwner).toEqual({ nonce: secondId, tab: 7 });
+    await h.inspectModels(request, true);
+    await h.inspectModels(null, true);
     expect(h.create).not.toHaveBeenCalled();
     expect(h.update).not.toHaveBeenCalled();
-    expect(h.sendMessage).toHaveBeenCalledWith(7, expect.objectContaining({ type: 'clf-model-catalog', nonce: secondId }));
-    await h.inspectModels(null, true);
+    expect(h.remove).toHaveBeenCalledTimes(1);
+  });
+  it('retires a sole completed catalog on later maintenance after its draft clears', async () => {
+    const h = await worker([]);
+    h.tabs.push({ id: 7, url: `https://chatgpt.com/?cos-model-catalog=${firstId}` });
+    await h.authorizeDocument({ tab: { id: 7 }, documentId: 'catalog', frameId: 0, url: h.tabs[0]!.url }, { navigationEpoch: 1 });
+    let safe = false;
+    h.sendMessage.mockImplementation(async (_id, message) => message.type === 'clf-tab-close-check'
+      ? { ok: true, safe, conversationId: null, navigationEpoch: 1 } as never : { ok: true, ready: true });
+    await h.inspectModels({ nonce: firstId, expiresAt: Date.now() + 60000 }, true);
     expect(h.remove).not.toHaveBeenCalled();
+    safe = true;
+    await h.inspectModels(null, true);
+    expect(h.remove.mock.calls).toEqual([[7]]);
+    expect(h.create).not.toHaveBeenCalled();
   });
   it('preserves a draft on a catalog marker and waits for unreachable old helpers instead of accumulating tabs', async () => {
     const h = await worker([]);
@@ -347,14 +452,14 @@ describe('one browser maintenance flight per desktop outbox publication', () => 
     expect(h.sendMessage).toHaveBeenCalledTimes(2);
   });
 
-  it('releases a failed flight so a later pass can retry and matches exact marker identity', async () => {
+  it('releases a failed flight without repeating its opening and matches exact marker identity', async () => {
     const h = await worker([{ id: firstId, conversationId: null }]);
     h.tabs.push({ id: 50, url: `https://chatgpt.com/?other=cos-input=${firstId}` });
     h.create.mockRejectedValueOnce(new Error('Chrome temporarily refused tab creation'));
     await expect(h.maintain()).rejects.toThrow('temporarily refused');
     await h.maintain();
-    expect(h.create).toHaveBeenCalledTimes(2);
-    expect(h.tabs).toHaveLength(2);
+    expect(h.create).toHaveBeenCalledTimes(1);
+    expect(h.tabs).toHaveLength(1);
   });
 });
 

--- a/test/extension-popup.test.ts
+++ b/test/extension-popup.test.ts
@@ -18,24 +18,39 @@ function openPopup(reload: () => void) {
   return popup.window.document;
 }
 
-it('reloads directly once even when the old worker and preference reads never answer', () => {
+it('omits the debugging reload action even when the worker is unavailable', () => {
   const reload = vi.fn();
   const document = openPopup(reload);
-  const button = document.getElementById('reloadBtn') as HTMLButtonElement;
-  expect(button.closest('details')).toBeNull();
-  button.click(); button.click();
-  expect(reload).toHaveBeenCalledTimes(1);
-  expect(button.disabled).toBe(true);
-  expect(document.getElementById('reloadStatus')?.textContent).toContain('Reopen');
+  expect(document.getElementById('reloadBtn')).toBeNull();
+  expect(document.getElementById('reloadStatus')).toBeNull();
+  expect(script).not.toContain('chrome.runtime.reload');
+  expect(reload).not.toHaveBeenCalled();
 });
 
-it('reports a synchronous Chrome reload failure and allows another explicit attempt', () => {
-  const reload = vi.fn().mockImplementationOnce(() => { throw new Error('Extension context invalidated'); });
-  const document = openPopup(reload);
-  const button = document.getElementById('reloadBtn') as HTMLButtonElement;
-  button.click();
-  expect(button.disabled).toBe(false);
-  expect(document.getElementById('reloadStatus')?.textContent).toContain('Extension context invalidated');
-  button.click();
-  expect(reload).toHaveBeenCalledTimes(2);
+it('starts neutral and requires explicit protocol compatibility before reporting Connected', () => {
+  const document = openPopup(vi.fn());
+  expect(document.getElementById('pill')!.classList.contains('off')).toBe(true);
+  (popup!.window as any).paintHeader({ connected: true, paired: true, port: 8765 });
+  expect(document.getElementById('state')!.textContent).not.toContain('Connected');
+  (popup!.window as any).paintHeader({ connected: true, paired: true, compatible: true, port: 8765 });
+  expect(document.getElementById('state')!.textContent).toContain('Connected');
+});
+
+it('explains manual mismatch recovery with both versions without adding a reload action', () => {
+  const document = openPopup(vi.fn());
+  (popup!.window as any).paintAlert({ connected: true, paired: true, compatible: false, appVersion: '2.0.7', appProtocol: 13, extensionVersion: '2.0.6', extensionProtocol: 12 }, null);
+  const alert = document.getElementById('alert')!;
+  expect(alert.textContent).toContain('2.0.7'); expect(alert.textContent).toContain('2.0.6');
+  expect(alert.textContent).toContain('protocol 13'); expect(alert.textContent).toContain('protocol 12');
+  expect(alert.textContent).toContain('Developer mode'); expect(alert.textContent).toContain('Open extension folder');
+  expect(document.getElementById('reloadBtn')).toBeNull();
+});
+
+it('keeps blocked delivery distinct from network unreachability and requires pairing too', () => {
+  const document = openPopup(vi.fn());
+  (popup!.window as any).paintHeader({ connected: true, paired: false, compatible: true, port: 8765 });
+  expect(document.getElementById('state')!.textContent).not.toContain('Connected');
+  const result = (popup!.window as any).pipeline({ isChat: true, recorder: true, page: { events: 1 }, pending: 1 }, false);
+  expect(result.why[1]).toContain('protocol compatibility');
+  expect(result.why[1]).not.toContain('not reachable');
 });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -39,8 +39,8 @@ describe('extension release metadata', () => {
     expect(lock.version).toBe(APP_VERSION);
     expect(lock.packages?.['']?.version).toBe(APP_VERSION);
     expect(manifest.version).toBe(APP_VERSION);
-    expect(BRIDGE_PROTOCOL).toBe(12);
-    expect(backgroundSource).toContain('const BRIDGE_PROTOCOL = 12;');
+    expect(BRIDGE_PROTOCOL).toBe(13);
+    expect(backgroundSource).toContain('const BRIDGE_PROTOCOL = 13;');
   });
 
   /**
@@ -449,7 +449,7 @@ class FakeStorageArea {
 }
 
 interface WorkerHarness {
-  send(message: Record<string, unknown>, tabId?: number, documentId?: string): Promise<any>;
+  send(message: Record<string, unknown>, tabId?: number, documentId?: string, senderUrl?: string): Promise<any>;
   /** Fires Chrome's real tab-close lifecycle event. */
   closeTab(tabId: number): Promise<void>;
   /** Fires only Chrome's navigation-start signal, without inventing a replacement document. */
@@ -699,7 +699,7 @@ function loadWorker(options: {
         });
       }
     },
-    send(message, tabId = 1, documentId = documentFor(tabId)) {
+    send(message, tabId = 1, documentId = documentFor(tabId), senderUrl) {
       if (message.type === 'bind' && typeof message.conversationId === 'string') {
         knownTabs.set(tabId, {
           ...knownTabs.get(tabId),
@@ -711,7 +711,7 @@ function loadWorker(options: {
       }
       return new Promise((resolve, reject) => {
         try {
-          const keep = listener!(message, { tab: { id: tabId }, documentId, frameId: 0 }, resolve);
+          const keep = listener!(message, { tab: { id: tabId }, documentId, frameId: 0, url: senderUrl }, resolve);
           if (keep !== true) reject(new Error('listener did not keep the response channel open'));
         } catch (err) {
           reject(err);
@@ -778,7 +778,7 @@ describe('exact chat recovery from a fresh Chrome tab scan', () => {
    * app does it. `asked` records what a receipt actually quoted, so a test can tell the
    * difference between a pass that reported the repair and one that reported something else.
    */
-  function appWith(repair: string | null) {
+  function appWith(repair: string | null, browserOnly = false) {
     const asked: string[] = [];
     const actions: string[] = [];
     const failedActions: string[] = [];
@@ -802,13 +802,29 @@ describe('exact chat recovery from a fresh Chrome tab scan', () => {
         if (repaired && repaired === token) outstanding = null;
         if (!outstanding) return response(200, { ok: true, repairs: [] });
         token = `tok-${(minted += 1)}`;
-        return response(200, { ok: true, repairs: [{ conversationId: outstanding, token }] });
+        return response(200, { ok: true, browserOnly, repairs: [{ conversationId: outstanding, token }] });
       }
       return response(404, {});
     });
     return { fetch, asked, actions, failedActions, arm: (id: string) => { outstanding = id; } };
   }
 
+  it('browser-only recovery waits for the missing chat and then reloads its exact existing tab', async () => {
+    const { fetch, asked } = appWith(OTHER, true);
+    const worker = loadWorker({ local: new FakeStorageArea(paired), session: new FakeStorageArea(), fetch });
+    await worker.registerTab(41);
+    await worker.send({ type: 'bind', conversationId: CHAT }, 41);
+    await worker.fireAlarm(); await worker.fireAlarm();
+    expect(worker.tabsCreate).not.toHaveBeenCalled();
+    expect(worker.tabsReload).not.toHaveBeenCalled();
+    expect(asked.every(item => item === 'status')).toBe(true);
+    await worker.registerTab(42);
+    await worker.send({ type: 'bind', conversationId: OTHER }, 42);
+    await worker.fireAlarm();
+    expect(worker.tabsReload).toHaveBeenCalledWith(42);
+    expect(worker.tabsCreate).not.toHaveBeenCalled();
+    expect(asked).toContain(`repaired:${OTHER}`);
+  });
   it('reloads the exact tab holding the chat the app named, and reports it once', async () => {
     const { fetch, asked, actions } = appWith(CHAT);
     const worker = loadWorker({ local: new FakeStorageArea(paired), session: new FakeStorageArea(), fetch });
@@ -889,11 +905,10 @@ describe('exact chat recovery from a fresh Chrome tab scan', () => {
   });
 
   /**
-   * A repair the app wants in front of the user — an automatic compaction's pickup — raises the
-   * exact tab and its window before the reload, and opens a missing chat in front. A background
-   * tab is a throttled one, and the page this brings back has a handoff to send.
+   * Automatic compaction selects its exact tab before reload while preserving
+   * OS focus on the user's current app, even when Chrome is minimized.
    */
-  it('raises the tab first when the app asks for the repair in front, and opens a missing chat in front', async () => {
+  it('selects the repair tab before reload without activating the Chrome window', async () => {
     let outstanding: string | null = CHAT;
     let token = '';
     let minted = 0;
@@ -916,7 +931,7 @@ describe('exact chat recovery from a fresh Chrome tab scan', () => {
 
     await worker.fireAlarm();
     expect(worker.tabsUpdate).toHaveBeenCalledWith(51, { active: true });
-    expect(worker.windowsUpdate).toHaveBeenCalledWith(7, { focused: true });
+    expect(worker.windowsUpdate).not.toHaveBeenCalled();
     expect(worker.tabsReload).toHaveBeenCalledWith(51);
     const raised = worker.tabsUpdate.mock.invocationCallOrder.find(
       (_order, index) => worker.tabsUpdate.mock.calls[index]?.[1]?.active === true
@@ -1155,15 +1170,16 @@ describe('active agent tab discard protection', () => {
 
 describe('app-owned retained tab pool', () => {
   const id = (n: number) => `aaaaaaaa-bbbb-4ccc-8ddd-${String(n).padStart(12, '0')}`;
-  async function budget(options: { safe?: (tab: number) => boolean; changed?: number; keep?: number; recent?: number; protectDuplicate?: boolean; reverseActivity?: boolean } = {}) {
+  async function budget(options: { safe?: (tab: number) => boolean; changed?: number; keep?: number; recent?: number; protectDuplicate?: boolean; reverseActivity?: boolean; retired?: boolean; idle?: boolean; ordinary?: number } = {}) {
     const tabs = [1, 2, 3, 4, 5, 6].map(n => ({ id: n, windowId: n === 5 ? 9 : 7, url: `https://chatgpt.com/c/${id(n === 4 ? 3 : n)}`, active: n === 5, lastAccessed: n === options.recent ? Date.now() : 0 }));
     const worker = loadWorker({
       local: new FakeStorageArea({ port: 8765, token: 'paired-token' }),
       session: new FakeStorageArea({ tabDocuments: Object.fromEntries(tabs.map(tab => [tab.id, `doc-${tab.id}`])), tabEpochs: Object.fromEntries(tabs.map(tab => [tab.id, 0])) }),
       fetch: async input => response(200, new URL(input).pathname === '/hello' ? { app: 'chat-on-steroids', paired: true } : {
-        ok: true, repairs: [], tabsToKeepOpen: options.keep ?? 2,
+        ok: true, repairs: [], tabsToKeepOpen: options.keep ?? 2, retiredConversations: options.retired ? [id(2), id(5)] : [],
+        workerConversations: [1, 2, 3, 5].filter(n => n !== options.ordinary).map(id), sleepingWorkerConversations: [2, 3, 5].map(id),
         conversationActivityAt: Object.fromEntries([1, 2, 3, 5].map(n => [id(n), (options.reverseActivity ? 10 - n : n) * 1000])),
-        managedConversations: [1, 2, 3, 5].map(id), nonDiscardableConversations: [id(1), ...(options.protectDuplicate ? [id(3)] : [])], closableConversations: options.keep === 20 ? [] : [2, 3, 5].map(id)
+        managedConversations: [1, 2, 3, 5].map(id), nonDiscardableConversations: [id(1), ...(options.protectDuplicate ? [id(3)] : [])], closableConversations: options.idle ? [2, 3, 5].map(id) : []
       }),
       tabsQuery: async () => tabs,
       windowsGet: async () => ({ focused: true }),
@@ -1173,15 +1189,29 @@ describe('app-owned retained tab pool', () => {
     await worker.fireAlarm();
     return worker;
   }
-  it('retains the worker-sized pool, preserving manual chats and active work', async () => {
+  it('evicts oldest sleepers immediately for worker capacity, preserving manual chats and active work', async () => {
     const worker = await budget();
     expect(worker.tabsRemove.mock.calls.map(call => call[0])).toEqual([4, 2, 3]);
     expect(worker.tabsRemove).not.toHaveBeenCalledWith(1); // live app work
     expect(worker.tabsRemove).not.toHaveBeenCalledWith(6); // unrelated manual chat
   });
+  it('retires sleeping workers below the pool limit while preserving drafts and live work', async () => {
+    const worker = await budget({ keep: 20, retired: true, safe: n => n !== 5 });
+    expect(worker.tabsRemove.mock.calls.map(call => call[0])).toEqual([4, 2]);
+    expect(worker.tabsRemove).not.toHaveBeenCalledWith(5);
+    expect(worker.tabsRemove).not.toHaveBeenCalledWith(1);
+  });
   it('keeps idle conversations below the pool limit while removing an idle duplicate', async () => {
     const worker = await budget({ keep: 20 });
     expect(worker.tabsRemove.mock.calls.map(call => call[0])).toEqual([4]);
+  });
+  it('does not charge a prime or helper tab against worker capacity', async () => {
+    const worker = await budget({ ordinary: 1 });
+    expect(worker.tabsRemove.mock.calls.map(call => call[0])).toEqual([4, 2]);
+  });
+  it('closes every expired idle managed chat even below the worker budget', async () => {
+    const worker = await budget({ keep: 20, idle: true });
+    expect(worker.tabsRemove.mock.calls.map(call => call[0])).toEqual([4, 2, 3, 5]);
   });
   it('does not use tab selection as model activity', async () => {
     const worker = await budget({ recent: 5 });
@@ -1258,7 +1288,8 @@ describe('worker settings authority', () => {
       }
       return response(404, {});
     });
-    const worker = loadWorker({ local: new FakeStorageArea(paired), session: new FakeStorageArea(), fetch });
+    const worker = loadWorker({ local: new FakeStorageArea(paired), session: new FakeStorageArea(), fetch,
+      tabsGet: async () => ({ id: 44, url: `https://chatgpt.com/c/${CHAT}` }) });
     await worker.registerTab(44);
     await worker.send({ type: 'bind', conversationId: CHAT }, 44);
     const token = '0123456789abcdef0123456789abcdef';
@@ -1272,6 +1303,29 @@ describe('worker settings authority', () => {
       expect.objectContaining({ conversationId: CHAT, token, sourceDispatch: true }),
       expect.objectContaining({ conversationId: CHAT, token, destinationDispatch: true })
     ]);
+  });
+
+  it.each(['new-chat', 'other-chat', 'pending-navigation'])('checks the current Chrome route for compaction after %s', async scenario => {
+    const currentUrl = scenario === 'other-chat' ? 'https://chatgpt.com/c/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+      : `https://chatgpt.com/g/g-p-abcdef1234567890abcdef1234567890/c/${CHAT}`;
+    const posted: Record<string, unknown>[] = [];
+    const fetch = vi.fn(async (input: string, init: Record<string, unknown> = {}) => {
+      if (new URL(input).pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
+      if (new URL(input).pathname === '/compact') posted.push(JSON.parse(String(init.body)));
+      return response(200, { ok: true });
+    });
+    const worker = loadWorker({ local: new FakeStorageArea(paired), session: new FakeStorageArea(), fetch,
+      tabsGet: async () => ({ id: 44, url: currentUrl, ...(scenario === 'pending-navigation' ? { pendingUrl: 'https://chatgpt.com/' } : {}) }) });
+    await worker.registerTab(44);
+    const reply = await worker.send({ type: 'compact', conversationId: CHAT, ticket: true }, 44, undefined, 'https://chatgpt.com/');
+    if (scenario === 'new-chat') {
+      expect(reply).toMatchObject({ ok: true });
+      expect(posted).toHaveLength(1);
+      expect(posted[0]).toMatchObject({ conversationId: CHAT, project: expect.any(String) });
+    } else {
+      expect(reply).toMatchObject({ ok: false, error: 'stale_document' });
+      expect(posted).toEqual([]);
+    }
   });
 
   /**
@@ -1301,7 +1355,7 @@ describe('worker settings authority', () => {
       session: new FakeStorageArea(),
       fetch,
       // Chat A's tab, in the background instance's window, third from the left.
-      tabsGet: async () => ({ id: 45, windowId: 9, index: 2 }) as never
+      tabsGet: async () => ({ id: 45, windowId: 9, index: 2, url: `https://chatgpt.com/c/${CHAT}` }) as never
     });
     await worker.registerTab(45);
     await worker.send({ type: 'bind', conversationId: CHAT }, 45);
@@ -1339,7 +1393,7 @@ describe('worker settings authority', () => {
       local: new FakeStorageArea(paired),
       session: new FakeStorageArea(),
       fetch,
-      tabsGet: async () => ({ id: 46, windowId: 9, index: 0 }) as never
+      tabsGet: async () => ({ id: 46, windowId: 9, index: 0, url: `https://chatgpt.com/c/${CHAT}` }) as never
     });
     await worker.registerTab(46);
     await worker.send({ type: 'bind', conversationId: CHAT }, 46);
@@ -1649,11 +1703,15 @@ describe('extension revival delivery', () => {
   const revival = { id: 'cmd-wake', conversationId: CHAT };
 
   const app = (route: 'status' | 'activity' = 'status') =>
-    vi.fn(async (input: string) => {
+    vi.fn(async (input: string, init: Record<string, unknown> = {}) => {
       const url = new URL(input);
       if (url.pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
       if (url.pathname === `/${route}`) {
         return response(200, { ok: true, recoveryMonitoring: true, repairs: [], revival });
+      }
+      if (url.pathname === '/commands/revivals/pending') {
+        const body = JSON.parse(String(init.body || '{}'));
+        return response(200, { pending: body.entries.map((entry: { id: string }) => entry.id) });
       }
       return response(404, {});
     });
@@ -1734,7 +1792,17 @@ describe('extension revival delivery', () => {
     expect(worker.tabsCreate).not.toHaveBeenCalled();
   });
 
-  it('opens one replacement when a complete exact tab cannot receive or be repaired', async () => {
+  it('does not turn a failed browser scan into absence or an opening permit', async () => {
+    const worker = loadWorker({
+      local: new FakeStorageArea(paired), session: new FakeStorageArea({ recoveryMonitoring: true }),
+      fetch: app(), tabsQuery: async () => { throw new Error('browser snapshot unavailable'); }
+    });
+    await worker.fireAlarm();
+    await worker.fireAlarm();
+    expect(worker.tabsCreate).not.toHaveBeenCalled();
+  });
+
+  it('keeps an inaccessible complete exact tab as the only revival target', async () => {
     const worker = loadWorker({
       local: new FakeStorageArea(paired),
       session: new FakeStorageArea({ recoveryMonitoring: true }),
@@ -1750,8 +1818,8 @@ describe('extension revival delivery', () => {
 
     await worker.fireAlarm();
 
-    expect(worker.tabsCreate).toHaveBeenCalledTimes(1);
-    expect(String(worker.tabsCreate.mock.calls[0]?.[0]?.url || '')).toContain(`/c/${CHAT}`);
+    await worker.fireAlarm();
+    expect(worker.tabsCreate).not.toHaveBeenCalled();
   });
 
   it('takes the fast path from any live activity poll without waiting for the alarm', async () => {
@@ -1781,7 +1849,7 @@ describe('extension revival delivery', () => {
     expect(worker.tabsCreate).not.toHaveBeenCalled();
   });
 
-  it('persists revival identity before routing and recreates a closed tab after browser restart', async () => {
+  it('persists revival custody and never recreates its user-closed tab after browser restart', async () => {
     const local = new FakeStorageArea(paired);
     const first = loadWorker({ local, session: new FakeStorageArea(), fetch: app() });
     await first.registerTab(4, 'document-4-live');
@@ -1801,10 +1869,57 @@ describe('extension revival delivery', () => {
       fetch: app(),
       tabsQuery: async () => []
     });
-    await vi.waitFor(() => expect(restarted.tabsCreate).toHaveBeenCalledTimes(1));
-    const opened = String(restarted.tabsCreate.mock.calls[0]?.[0]?.url || '');
-    expect(opened).toContain(`/c/${CHAT}`);
-    expect(opened).toContain(`clf=${revival.id}`);
+    await restarted.fireAlarm();
+    expect(restarted.tabsCreate).not.toHaveBeenCalled();
+    expect(local.data.deferredRevivals).toMatchObject([{ ...revival, openingSpent: true }]);
+  });
+
+  it('persists the first revival opening before Chrome and never repeats it across restart', async () => {
+    const local = new FakeStorageArea({ ...paired, deferredRevivals: [revival] });
+    const first = loadWorker({ local, session: new FakeStorageArea(), fetch: app(), tabsQuery: async () => [] });
+    await vi.waitFor(() => expect(first.tabsCreate).toHaveBeenCalledTimes(1));
+    expect(local.data.deferredRevivals).toMatchObject([{ ...revival, openingSpent: true }]);
+    await first.fireAlarm();
+    expect(first.tabsCreate).toHaveBeenCalledTimes(1);
+    const restarted = loadWorker({ local, session: new FakeStorageArea(), fetch: app(), tabsQuery: async () => [] });
+    await restarted.fireAlarm();
+    expect(restarted.tabsCreate).not.toHaveBeenCalled();
+  });
+
+  it('prunes a stale deferred revival before browser startup can recreate its ChatGPT tab', async () => {
+    const local = new FakeStorageArea({
+      ...paired,
+      deferredRevivals: [{ id: 'cmd-dead-after-restart', conversationId: CHAT, queuedAt: Date.now() }]
+    });
+    const fetch = vi.fn(async (input: string) => {
+      const url = new URL(input);
+      if (url.pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
+      if (url.pathname === '/commands/revivals/pending') return response(200, { pending: [] });
+      return response(404, {});
+    });
+
+    const restarted = loadWorker({ local, session: new FakeStorageArea(), fetch, tabsQuery: async () => [] });
+    await vi.waitFor(() => expect(fetch.mock.calls.some(([input]) => new URL(String(input)).pathname === '/commands/revivals/pending')).toBe(true));
+
+    expect(restarted.tabsCreate).not.toHaveBeenCalled();
+    expect(local.data.deferredRevivals).toEqual([]);
+  });
+
+  it('fails closed when deferred-revival validation is unavailable instead of opening an unproven tab', async () => {
+    const marker = { id: 'cmd-validation-unavailable', conversationId: CHAT, queuedAt: Date.now() };
+    const local = new FakeStorageArea({ ...paired, deferredRevivals: [marker] });
+    const fetch = vi.fn(async (input: string) => {
+      const url = new URL(input);
+      if (url.pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
+      if (url.pathname === '/commands/revivals/pending') return response(503, { error: 'bridge_recovering' });
+      return response(404, {});
+    });
+
+    const restarted = loadWorker({ local, session: new FakeStorageArea(), fetch, tabsQuery: async () => [] });
+    await vi.waitFor(() => expect(fetch.mock.calls.some(([input]) => new URL(String(input)).pathname === '/commands/revivals/pending')).toBe(true));
+
+    expect(restarted.tabsCreate).not.toHaveBeenCalled();
+    expect(local.data.deferredRevivals).toMatchObject([marker]);
   });
 
   it('replaces an obsolete deferred wake for the same worker conversation', async () => {
@@ -2275,7 +2390,7 @@ describe('extension observation journal', () => {
     ]);
   });
 
-  it('raises only the exact owned Goal tab and never opens a duplicate', async () => {
+  it('selects only the exact owned Goal tab without activating Chrome or opening a duplicate', async () => {
     const conversationId = '22222222-3333-4444-5555-666666666666';
     const local = new FakeStorageArea({ port: 8765, token: 'paired-token' });
     const session = new FakeStorageArea();
@@ -2290,8 +2405,7 @@ describe('extension observation journal', () => {
     });
     expect(worker.tabsUpdate).toHaveBeenCalledTimes(1);
     expect(worker.tabsUpdate).toHaveBeenCalledWith(73, { active: true });
-    expect(worker.windowsUpdate).toHaveBeenCalledTimes(1);
-    expect(worker.windowsUpdate).toHaveBeenCalledWith(7, { focused: true });
+    expect(worker.windowsUpdate).not.toHaveBeenCalled();
     expect(worker.tabsCreate).not.toHaveBeenCalled();
 
     const other = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
@@ -2300,7 +2414,7 @@ describe('extension observation journal', () => {
       error: 'stale_conversation'
     });
     expect(worker.tabsUpdate).toHaveBeenCalledTimes(1);
-    expect(worker.windowsUpdate).toHaveBeenCalledTimes(1);
+    expect(worker.windowsUpdate).not.toHaveBeenCalled();
     expect(worker.tabsCreate).not.toHaveBeenCalled();
   });
 
@@ -3203,4 +3317,24 @@ describe('the goal opening, which waits on a model', () => {
     // And it is the goal opening that spends it. Nothing else here waits on a model.
     expect(backgroundSource).toContain("await call('/goal/open', {\n      method: 'POST',\n      timeoutMs: MODEL_REQUEST_TIMEOUT_MS,");
   });
+});
+
+
+it.each(['matching', 'wrong-document', 'unsafe-draft', 'newer-navigation'])('retires a cancelled helper only under its exact safe claim: %s', async scenario => {
+  const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+  const tab = { id: 71, url: `https://chatgpt.com/c/${conversationId}`, active: false };
+  const claims = [{ id: 'old-input', owner: '71:doc:0', conversationId }, { id: 'new-input', owner: '71:doc:0', conversationId }];
+  const tabsRemove = vi.fn();
+  const sendMessage = vi.fn(async (..._args: unknown[]) => ({ safe: scenario !== 'unsafe-draft', conversationId, navigationEpoch: 0 }));
+  const code = backgroundSource.slice(backgroundSource.indexOf('async function pruneManagedTabs('), backgroundSource.indexOf('\nfunction maintain(', backgroundSource.indexOf('async function pruneManagedTabs(')));
+  const prune = vm.runInNewContext(`${code}\npruneManagedTabs`, {
+    cleanConversationId: (id: string) => id, conversationForTab: () => conversationId,
+    conversationFromUrl: (url: string) => url.split('/c/')[1], tabDocuments: { '71': scenario === 'wrong-document' ? 'replacement' : 'doc' },
+    tabEpochs: { '71': 0 }, ownsDocument: () => true, journalCountForConversation: () => 0,
+    chrome: { tabs: { get: async () => ({ ...tab, ...(scenario === 'newer-navigation' ? { pendingUrl: 'https://chatgpt.com/' } : {}) }),
+      sendMessage, remove: tabsRemove } }
+  });
+  await prune([tab], { managedConversations: [conversationId], retiredConversations: [conversationId], cancelledDecisionClaims: claims }, new Set(), new Set());
+  expect(tabsRemove).toHaveBeenCalledTimes(scenario === 'matching' ? 1 : 0);
+  if (scenario === 'matching') expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({ cancelledDecisions: claims });
 });

--- a/test/feature-parity.test.ts
+++ b/test/feature-parity.test.ts
@@ -64,6 +64,7 @@ describe('portable browser-backed feature parity', () => {
       'apply_patch',
       'exec_command',
       'write_stdin',
+      'download_artifact',
       'session',
       'agents',
       'session_finish'

--- a/test/fiber.test.ts
+++ b/test/fiber.test.ts
@@ -311,8 +311,9 @@ async function scan(
   }
 
   const elements = fibers.map((fiber) => {
-    const row = document.createElement('button');
-    row.setAttribute('aria-label', 'Open tool call list');
+    const row = document.createElement('span');
+    row.className = 'group/tool-message';
+    row.setAttribute('aria-label', '工具呼び出し一覧');
     // React hangs the Fiber off a key with a per-build random suffix.
     (row as unknown as Record<string, unknown>)['__reactFiber$qlrmvxwbkkq'] = fiber;
     document.body.append(row);

--- a/test/goal.test.ts
+++ b/test/goal.test.ts
@@ -110,6 +110,23 @@ it('keeps a withdrawn synthetic reply revoked when the deletion write fails and 
   } finally { spy.mockRestore(); }
 });
 
+it('projects the driver for each mode and preserves the active draft identity', async () => {
+  const config = defaultConfig();
+  await saveConfig({ ...config, goal: { ...config.goal, enabled: true, mode: 'loop', backend: 'api',
+    loopBackend: 'chatgpt', helperModel: 'gpt-5.6-sol', model: 'z-ai/glm-5.3-flash' } });
+  expect(goal.goalProgressFor('loop')).toMatchObject({ backend: 'chatgpt', model: 'gpt-5.6-sol' });
+  expect(goal.goalProgressFor('goal')).toMatchObject({ backend: 'api', model: 'z-ai/glm-5.3-flash', provider: 'openrouter' });
+  const conversationId = 'progress-driver-snapshot';
+  const session = await createSession({ conversationId, title: 'Progress identity' });
+  goal.startGoalDraft({ conversationId, sessionId: session.id, turnId: 'progress-turn', deferStart: true });
+  const draft = goal.goalViewFor(conversationId);
+  expect(draft).toMatchObject({ backend: 'chatgpt', model: 'gpt-5.6-sol' });
+  await saveConfig({ ...config, goal: { ...config.goal, backend: 'api', loopBackend: 'api', model: 'local-model',
+    provider: { kind: 'custom', baseUrl: 'http://localhost:11434/v1' } } });
+  expect(goal.goalProgressFor('loop', draft)).toMatchObject({ backend: 'chatgpt', model: 'gpt-5.6-sol' });
+  expect(goal.goalProgressFor('loop')).toMatchObject({ backend: 'api', model: 'local-model', provider: 'custom' });
+});
+
 describe('the instruction the goal model is given', () => {
   /**
    * The failure this prompt is written against is a model that answers *about* the
@@ -203,6 +220,19 @@ describe('the instruction the goal model is given', () => {
 });
 
 describe('what leaves this machine', () => {
+  it('preserves transient API retry classification and Retry-After for finish follow-ups', async () => {
+    await saveConfig({ ...defaultConfig(), goal: { ...defaultConfig().goal, loopBackend: 'api' } });
+    const session = await createSession({ title: 'finish retry', conversationId: 'finish-api-retry' });
+    const context = [{ role: 'user' as const, content: 'Finish checking the project' }];
+    globalThis.fetch = vi.fn(async () => new Response('busy', { status: 429, headers: { 'Retry-After': '37' } }));
+    await expect(goal.draftFastFollowup(session.id, undefined, context)).rejects.toMatchObject({ retryable: true, retryAfterMs: 37000 });
+    globalThis.fetch = vi.fn(async () => new Response('bad key', { status: 401 }));
+    await expect(goal.draftFastFollowup(session.id, undefined, context)).rejects.toMatchObject({ retryable: false });
+    globalThis.fetch = vi.fn(async () => { throw new TypeError('network disconnected'); });
+    await expect(goal.draftFastFollowup(session.id, undefined, context)).rejects.toMatchObject({ retryable: true });
+    const timeout = AbortSignal.abort(new DOMException('Timed out', 'TimeoutError'));
+    await expect(goal.draftFastFollowup(session.id, timeout, context)).rejects.toMatchObject({ retryable: true });
+  });
   it.each([false, true])('shares the bounded tool-context policy with fast finish follow-ups (%s)', async (includeToolCalls) => {
     await saveConfig({ ...defaultConfig(), goal: { ...defaultConfig().goal, enabled: true, backend: 'api', loopBackend: 'api', includeToolCalls } });
     const session = await createSession({ title: 'tool context', conversationId: `tool-context-${includeToolCalls}` });
@@ -2359,4 +2389,222 @@ it('never owes or generates a browser continuation for Astra even with Goal arme
   goal.beginGoalDraft(conversationId, draft.token);
   await vi.waitFor(() => expect(goal.goalViewFor(conversationId)?.stage).toBe('no-reply'));
   expect(fetch).not.toHaveBeenCalled();
+});
+
+describe('a custom OpenAI-compatible provider', () => {
+  async function useCustom(over: Record<string, unknown> = {}): Promise<void> {
+    await saveConfig({
+      ...defaultConfig(),
+      goal: {
+        ...defaultConfig().goal,
+        enabled: true,
+        // The api backend is the only one that fetches; the other backends never read
+        // the provider block.
+        backend: 'api',
+        loopBackend: 'api',
+        model: 'llama3.1',
+        reasoning: 'default',
+        provider: { kind: 'custom', baseUrl: 'http://localhost:11434/v1' },
+        ...over
+      }
+    });
+    // Keyless unless the test stores one: a local server usually needs no secret, and the
+    // OpenRouter key from the outer beforeEach must never leak into a custom request.
+    await setSecret('customProviderApiKey', '');
+  }
+
+  async function userSession(conversationId: string): Promise<{ id: string }> {
+    const session = await createSession({ title: 'goal', conversationId });
+    await appendEvent(session.id, {
+      time: 1_000,
+      source: 'extension',
+      kind: 'user_message',
+      message: { text: 'build the parser', truncated: false, chars: 16 }
+    });
+    return session;
+  }
+
+  it('posts plain chat completions with no vendor fields and no key when keyless', async () => {
+    await useCustom();
+    const session = await userSession('c-custom-1');
+    let sent: any = null;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      sent = { url, headers: init.headers, body: JSON.parse(String(init.body)) };
+      return decision('continue', 'check the tokenizer first');
+    }) as never;
+
+    goal.startGoalDraft({ sessionId: session.id, conversationId: 'c-custom-1', turnId: 'g-1' });
+    const view = await settled('c-custom-1');
+
+    expect(view.stage).toBe('ready');
+    expect(sent.url).toBe('http://localhost:11434/v1/chat/completions');
+    expect(sent.headers).not.toHaveProperty('authorization');
+    expect(sent.headers).not.toHaveProperty('HTTP-Referer');
+    expect(sent.headers).not.toHaveProperty('X-Title');
+    expect(sent.body.model).toBe('llama3.1');
+    // run() always streams to the panel consumer on this base; the bounded parse is unchanged.
+    expect(sent.body.stream).toBe(true);
+    expect(sent.body).not.toHaveProperty('plugins');
+    expect(sent.body).not.toHaveProperty('provider');
+    expect(sent.body).not.toHaveProperty('reasoning');
+    expect(sent.body.response_format).toMatchObject({
+      type: 'json_schema',
+      json_schema: { name: 'goal_decision', strict: true }
+    });
+  });
+
+  it('sends the custom key and the bare reasoning effort when both are configured', async () => {
+    await useCustom({ reasoning: 'high' });
+    await setSecret('customProviderApiKey', 'sk-custom-test');
+    const session = await userSession('c-custom-2');
+    let sent: any = null;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      sent = { url, headers: init.headers, body: JSON.parse(String(init.body)) };
+      return decision('stop');
+    }) as never;
+
+    goal.startGoalDraft({ sessionId: session.id, conversationId: 'c-custom-2', turnId: 'g-1' });
+    const view = await settled('c-custom-2');
+
+    expect(view.stage).toBe('no-reply');
+    expect((sent.headers as Record<string, string>).authorization).toBe('Bearer sk-custom-test');
+    // `exclude` is OpenRouter vocabulary; a custom endpoint gets the effort alone.
+    expect(sent.body.reasoning_effort).toBe('high');
+    expect(sent.body).not.toHaveProperty('reasoning');
+  });
+
+  it('fails settled on an invalid base URL instead of retrying forever', async () => {
+    await useCustom();
+    await saveConfig({
+      ...defaultConfig(),
+      goal: {
+        ...defaultConfig().goal,
+        enabled: true,
+        backend: 'api',
+        model: 'llama3.1',
+        provider: { kind: 'custom', baseUrl: 'nota url' }
+      }
+    });
+    const session = await userSession('c-custom-3');
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return decision('continue', 'never reached');
+    }) as never;
+
+    goal.startGoalDraft({ sessionId: session.id, conversationId: 'c-custom-3', turnId: 'g-1' });
+    const view = await settled('c-custom-3');
+
+    expect(view.stage).toBe('failed');
+    expect(view.error).toMatch(/^invalid_provider/);
+    expect(view.retryable).toBe(false);
+    expect(calls).toBe(0);
+  });
+
+  it('keeps a reserved draft endpoint, credential, model and reasoning together after settings change', async () => {
+    await useCustom({ reasoning: 'high' });
+    await setSecret('customProviderApiKey', 'sk-custom-reserved');
+    const session = await userSession('reserved-settings');
+    const draft = goal.startGoalDraft({ sessionId: session.id, conversationId: 'reserved-settings', turnId: 'g-1', deferStart: true });
+    await saveConfig({ ...defaultConfig(), goal: { ...defaultConfig().goal, enabled: true, backend: 'api', model: 'different-model', reasoning: 'low', provider: { kind: 'openrouter', baseUrl: '' } } });
+    const requests: Array<{ url: string; init: RequestInit }> = [];
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      requests.push({ url, init });
+      return decision('stop');
+    }) as never;
+    expect(goal.beginGoalDraft('reserved-settings', draft.token)).toBe(true);
+    expect((await settled('reserved-settings')).stage).toBe('no-reply');
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe('http://localhost:11434/v1/chat/completions');
+    expect(requests[0]?.init).toMatchObject({ redirect: 'error', headers: { authorization: 'Bearer sk-custom-reserved' } });
+    expect(JSON.parse(String(requests[0]?.init.body))).toMatchObject({ model: 'llama3.1', reasoning_effort: 'high' });
+  });
+
+  it('keeps a planner endpoint, credential and model together across an awaited settings change', async () => {
+    await useCustom();
+    await setSecret('customProviderApiKey', 'sk-custom-snapshot');
+    const secrets = await import('../src/main/secrets.js');
+    const readKey = secrets.getSecret;
+    const lookup = vi.spyOn(secrets, 'getSecret').mockImplementationOnce(async key => {
+      const value = await readKey(key);
+      const changed = defaultConfig();
+      await saveConfig({ ...changed, goal: { ...changed.goal, backend: 'api', model: 'different-model', provider: { kind: 'custom', baseUrl: 'https://new-endpoint.example/v1' } } });
+      return value;
+    });
+    const requests: Array<{ url: string; init: RequestInit }> = [];
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      requests.push({ url, init });
+      return decision('continue', JSON.stringify({ stages: ['Implement the parser', 'Verify the parser'] }));
+    }) as never;
+    try {
+      expect(await goal.draftTaskPlan('Implement a parser', 'api')).toHaveLength(2);
+      expect(lookup).toHaveBeenCalledWith('customProviderApiKey');
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.url).toBe('http://localhost:11434/v1/chat/completions');
+      expect(requests[0]?.init).toMatchObject({ redirect: 'error', headers: { authorization: 'Bearer sk-custom-snapshot' } });
+      expect(JSON.parse(String(requests[0]?.init.body)).model).toBe('llama3.1');
+    } finally { lookup.mockRestore(); }
+  });
+
+  it('reads a vanilla OpenAI model list, and an empty one when unreachable', async () => {
+    await useCustom();
+    globalThis.fetch = (async (url: string) => {
+      expect(String(url)).toBe('http://localhost:11434/v1/models');
+      return Response.json({ data: [{ id: 'llama3.1' }, { id: 'qwen3:8b', created: 1_700_000_000 }] });
+    }) as never;
+    const page = await goal.listGoalModels(0, 20);
+    expect(page.models.map((model) => model.id).sort()).toEqual(['llama3.1', 'qwen3:8b']);
+    expect(page.models.find((model) => model.id === 'llama3.1')?.name).toBe('llama3.1');
+
+    globalThis.fetch = (async () => {
+      throw new TypeError('fetch failed');
+    }) as never;
+    // A different endpoint is a different cache scope, so this really exercises the
+    // failure path rather than the five-minute catalogue cache from the fetch above.
+    await saveConfig({
+      ...defaultConfig(),
+      goal: {
+        ...defaultConfig().goal,
+        enabled: true,
+        model: 'llama3.1',
+        provider: { kind: 'custom', baseUrl: 'http://localhost:11435/v1' }
+      }
+    });
+    const empty = await goal.listGoalModels(0, 20);
+    expect(empty).toEqual({ models: [], total: 0 });
+  });
+
+  it('requires a key for OpenRouter but not for a custom endpoint', async () => {
+    await saveConfig({
+      ...defaultConfig(),
+      goal: {
+        ...defaultConfig().goal,
+        backend: 'api',
+        provider: { kind: 'custom', baseUrl: 'http://localhost:11434/v1' }
+      }
+    });
+    await setSecret('openRouterApiKey', '');
+    await setSecret('customProviderApiKey', '');
+    expect(await goal.goalKeyPresent()).toBe(true);
+
+    await saveConfig({
+      ...defaultConfig(),
+      goal: { ...defaultConfig().goal, backend: 'api', provider: { kind: 'openrouter', baseUrl: '' } }
+    });
+    expect(await goal.goalKeyPresent()).toBe(false);
+    await setSecret('openRouterApiKey', 'sk-or-test');
+    expect(await goal.goalKeyPresent()).toBe(true);
+  });
+
+  it('accepts https and loopback http base URLs and refuses the rest', () => {
+    const open = (baseUrl: string) => goal.resolveGoalBaseUrl({ kind: 'custom', baseUrl });
+    expect(open('https://llm.example.com/v1/')).toBe('https://llm.example.com/v1');
+    expect(open('http://localhost:11434/v1')).toBe('http://localhost:11434/v1');
+    expect(open('http://127.0.0.1:11434')).toBe('http://127.0.0.1:11434');
+    expect(open('http://[::1]:11434/v1')).toBe('http://[::1]:11434/v1');
+    for (const bad of ['notaurl', '', 'http://llm.example.com/v1', 'https://user:pass@llm.example.com/v1', 'ftp://llm.example.com', 'https://llm.example/v1?secret=value', 'https://llm.example/v1#route']) {
+      expect(() => open(bad), bad).toThrow(/^invalid_provider/);
+    }
+    expect(goal.resolveGoalBaseUrl({ kind: 'openrouter', baseUrl: '' })).toBe('https://openrouter.ai/api/v1');
+  });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -33,6 +33,14 @@ export const DIR_LINK: 'junction' | 'dir' = process.platform === 'win32' ? 'junc
 
 export const IS_WINDOWS = process.platform === 'win32';
 
+/** Pause an existing async boundary; entry is observable and release is idempotent. */
+export function faultGate(): { entered: Promise<void>; hold(): Promise<void>; release(): void } {
+  let entered!: () => void, release!: () => void;
+  const reached = new Promise<void>(resolve => { entered = resolve; });
+  const held = new Promise<void>(resolve => { release = resolve; });
+  return { entered: reached, hold: () => { entered(); return held; }, release };
+}
+
 /**
  * A handoff brief long enough to be one.
  *

--- a/test/input-delivery-integration.test.ts
+++ b/test/input-delivery-integration.test.ts
@@ -21,7 +21,7 @@ vi.mock('../src/main/connection.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/main/connection.js')>();
   return { ...actual, connect: async () => {}, getStatus: () => ({ ...actual.getStatus(), state: 'connected' }) };
 });
-vi.mock('../src/main/browser.js', () => ({ openInPreferredBrowser: async () => 'chrome.exe' }));
+vi.mock('../src/main/browser.js', () => ({ openInPreferredBrowser: async () => 'chrome.exe', isPreferredBrowserRunning: async () => null }));
 const { defaultConfig, initConfigPath, saveConfig } = await import('../src/main/config.js');
 const { initSecretsPath } = await import('../src/main/secrets.js');
 const { initDurableStore, flushDurable, resetDurableForTests, writeDurableNow } = await import('../src/main/durable.js');
@@ -53,8 +53,23 @@ beforeAll(async () => {
 });
 beforeEach(async () => {
   await writeDurableNow('session-input', []);
+  await writeDurableNow('plugin-refresh', []);
   goal.resetGoalStateForTests(); input.resetInputForTests(); pushed.mockClear();
   await saveConfig({ ...defaultConfig(), goal: { ...defaultConfig().goal, enabled: false } });
+});
+it('serves staged attachment bytes only to the exact unsent browser input owner', async () => {
+  const { stageInputAttachment } = await import('../src/main/session/input-attachments.js');
+  const file = await stageInputAttachment({ text: 'Attachment payload' }, new Set());
+  const other = await stageInputAttachment({ text: 'Different input' }, new Set([file.id]));
+  const row = await input.enqueueInput({ ...message(null, 'off'), mode: 'auto', attachments: [file] });
+  const request = { id: row.id, owner: 'document-one', conversationId: null, attachmentId: file.id, offset: 0 };
+  expect((await post('/input/attachment', request)).status).toBe(409);
+  await post('/input/claim', { id: row.id, owner: request.owner, conversationId: null, requiresAuthorization: true });
+  expect((await post('/input/attachment', { ...request, owner: 'document-two' })).status).toBe(409);
+  expect((await post('/input/attachment', { ...request, attachmentId: other.id })).status).toBe(409);
+  expect(Buffer.from((await post('/input/attachment', request)).body.chunk, 'base64').toString()).toBe('Attachment payload');
+  expect((await post('/input/claim', { ...request, authorize: true })).body.ok).toBe(true);
+  expect((await post('/input/attachment', request)).status).toBe(409);
 });
 it('revokes a claimed send via IPC, fences pre-send authorization and records a late exact receipt', async () => {
   const row = message(null, 'goal');
@@ -134,6 +149,7 @@ describe('IPC input delivery and Goal control integration', () => {
     await input.cancelInput(later.id);
   });
   it('requires an exact plugin claim and matching schema before a refresh completion', async () => {
+    await saveConfig({ ...defaultConfig(), ui: { ...defaultConfig().ui, autoRefreshPlugins: true } });
     const { publishPluginSurface, resetPluginRefreshForTests } = await import('../src/main/plugin-refresh.js');
     resetPluginRefreshForTests();
     const tools = [{ name: 'read', description: 'Read a file', inputSchema: { type: 'object', properties: {} } }];
@@ -146,6 +162,43 @@ describe('IPC input delivery and Goal control integration', () => {
     expect((await post('/plugin-refresh', { ...identity, action: 'claim', connectorName: 'Chat On Steroids Core', tools: [{ ...tools[0], description: 'Old declaration' }] })).body.ok).toBe(true);
     expect((await post('/plugin-refresh', { ...identity, action: 'complete', tools: [] })).body.ok).toBe(false);
     expect((await post('/plugin-refresh', { ...identity, action: 'complete', tools, versionId: 'asdk_app_v_synthetic' })).body.ok).toBe(true);
+    resetPluginRefreshForTests();
+  });
+  it('defaults automatic plugin refresh off and revokes an already offered claim without removing the backend', async () => {
+    const plugin = await import('../src/main/plugin-refresh.js');
+    plugin.resetPluginRefreshForTests();
+    await writeDurableNow('plugin-refresh', []);
+    const tools = [{ name: 'read', description: 'Current declaration', inputSchema: { type: 'object', properties: {} } }];
+    plugin.publishPluginSurface('core', 'Chat On Steroids Core', 'test', '', tools);
+    const saved = (await plugin.pendingPluginRefreshes())[0]!;
+    expect(saved).toBeDefined();
+    expect((await post('/plugin-refresh', { action: 'pending' })).body.requests).toEqual([]);
+    expect((await post('/status', { openConversations: [] })).body.pluginRefreshRequests).toEqual([]);
+    const configure = (enabled: boolean) => saveConfig({ ...defaultConfig(), ui: { ...defaultConfig().ui, autoRefreshPlugins: enabled } });
+    await configure(true);
+    expect((await post('/plugin-refresh', { action: 'pending' })).body.requests[0].id).toBe(saved.id);
+    expect((await post('/status', { openConversations: [] })).body.pluginRefreshRequests).toHaveLength(1);
+    const claim = { action: 'claim', id: saved.id, appId: 'asdk_app_off_on_test', connectorName: 'Chat On Steroids Core', tools: [{ ...tools[0], description: 'Older declaration' }] };
+    await configure(false);
+    expect((await post('/plugin-refresh', claim)).body).toMatchObject({ ok: false, error: 'automatic_refresh_disabled' });
+    await configure(true);
+    expect((await post('/plugin-refresh', claim)).body.ok).toBe(true);
+    await configure(false);
+    // A click already accepted while enabled may still report its real result.
+    expect((await post('/plugin-refresh', { ...claim, action: 'complete', tools })).body.ok).toBe(true);
+    plugin.resetPluginRefreshForTests();
+  });
+  it('accepts a manual plugin-refresh terminal state and removes it from browser pickup', async () => {
+    await saveConfig({ ...defaultConfig(), ui: { ...defaultConfig().ui, autoRefreshPlugins: true } });
+    const { publishPluginSurface, resetPluginRefreshForTests } = await import('../src/main/plugin-refresh.js');
+    resetPluginRefreshForTests();
+    const tools = [{ name: 'read', description: 'Read current', inputSchema: { type: 'object', properties: {} } }];
+    const installed = [{ ...tools[0], description: 'Read old' }];
+    publishPluginSurface('core', 'Chat On Steroids Core', 'test', 'Synthetic instructions', tools);
+    const request = (await post('/plugin-refresh', { action: 'pending' })).body.requests[0];
+    const manual = await post('/plugin-refresh', { ...request, appId: 'asdk_app_synthetic', action: 'manual', connectorName: 'Chat On Steroids Core', tools: installed, error: 'Recreate or republish this custom app.' });
+    expect(manual.body.ok).toBe(true);
+    expect((await post('/plugin-refresh', { action: 'pending' })).body.requests).toEqual([]);
     resetPluginRefreshForTests();
   });
   it.each(['browser', 'tool'] as const)('records %s receipt text and pixels through the real IPC hook', async (transport) => {
@@ -403,4 +456,24 @@ it.each(['auto', 'finish'] as const)('adds one short reminder to every later Ast
   expect(restored.deliveryText?.split(finishInstruction(3))).toHaveLength(2);
   await input.cancelInput(request.id);
   await saveConfig(config);
+});
+
+it('retires a late-confirmed cancelled desktop send after two minutes even as the only managed chat', async () => {
+  const conversationId = randomUUID();
+  const row = await input.enqueueInput({ ...message(null, 'off'), mode: 'auto' });
+  expect((await post('/input/claim', { id: row.id, owner: 'cancelled-send-document', conversationId: null })).status).toBe(200);
+  await input.cancelInput(row.id);
+  expect((await post('/input/ack', { id: row.id, owner: 'cancelled-send-document', conversationId })).status).toBe(200);
+  expect((await input.listInputs()).find(item => item.id === row.id)).toMatchObject({ state: 'cancelled', conversationId, deliveredAt: expect.any(Number) });
+  const now = Date.now();
+  const clock = vi.spyOn(Date, 'now').mockReturnValue(now + 119_000);
+  try {
+    const before = (await post('/status', { openConversations: [conversationId] })).body;
+    expect(before.managedConversations).toContain(conversationId);
+    expect(before.retiredConversations).not.toContain(conversationId);
+    clock.mockReturnValue(now + 120_001);
+    const after = (await post('/status', { openConversations: [conversationId] })).body;
+    expect(after.retiredConversations).toContain(conversationId);
+    expect(after.closableConversations).toContain(conversationId);
+  } finally { clock.mockRestore(); }
 });

--- a/test/input-startup.test.ts
+++ b/test/input-startup.test.ts
@@ -4,7 +4,7 @@ const ports = vi.hoisted(() => ({ backgroundChats: false, connect: vi.fn(), stat
   browser: { connected: false, present: false, lastSeenAt: null as number | null }, open: vi.fn(), bridge: vi.fn(), enqueue: vi.fn(), cancel: vi.fn(), note: vi.fn(), rows: [] as InputEntry[], listeners: new Set<() => void>() }));
 vi.mock('../src/main/connection.js', () => ({ connect: ports.connect, getStatus: () => ports.status, onStatusChange: (fn: () => void) => { ports.listeners.add(fn); return () => ports.listeners.delete(fn); } }));
 vi.mock('../src/main/bridge.js', () => ({ bridgeStatus: async () => ports.browser, browserWakeConnected: () => ports.browser.connected, startBridge: ports.bridge }));
-vi.mock('../src/main/browser.js', () => ({ openInPreferredBrowser: ports.open }));
+vi.mock('../src/main/browser.js', () => ({ openInPreferredBrowser: ports.open, isPreferredBrowserRunning: async () => null }));
 vi.mock('../src/main/config.js', () => ({ getConfig: () => ({ ui: { backgroundChats: ports.backgroundChats } }) }));
 vi.mock('../src/main/session/input.js', () => ({ enqueueInput: ports.enqueue, cancelInput: ports.cancel, noteInputStartupError: ports.note, listInputs: async () => ports.rows }));
 import { sendDesktopInput, cancelDesktopInput, retryQueuedInputBrowser, resetInputStartupForTests } from '../src/main/session/start-input.js';
@@ -82,11 +82,10 @@ it('cancels a first send while waiting for connection without publishing or open
   expect(ports.enqueue).not.toHaveBeenCalled();
   expect(ports.open).not.toHaveBeenCalled();
 });
-it('starts a direct send immediately with fresh presence but a disconnected wake transport', async () => {
+it('leaves delivery with the existing browser while its wake transport reconnects', async () => {
   ports.browser = { connected: false, present: true, lastSeenAt: Date.now() };
   await sendDesktopInput(request);
-  expect(ports.open).toHaveBeenCalledTimes(1);
-  expect(ports.open.mock.calls[0]?.[0]).toContain(`cos-input=${request.id}`);
+  expect(ports.open).not.toHaveBeenCalled();
   expect(ports.rows[0]).toMatchObject({ state: 'queued', error: undefined });
 });
 it('preserves background placement for a cold authored send and its explicit retry', async () => {

--- a/test/ipc.test.ts
+++ b/test/ipc.test.ts
@@ -84,12 +84,36 @@ const removeRoot = (payload: unknown): Promise<any> => handlers.get('roots:remov
 const sessionEvents = (payload: unknown): Promise<any> => handlers.get('sessions:events')!(null, payload) as Promise<any>;
 const sessionList = (): Promise<any> => handlers.get('sessions:list')!(null, undefined) as Promise<any>;
 
-it('validates dropped image count and decodes bytes through the existing image authority', async () => {
-  const drop = (payload: unknown) => handlers.get('sessions:dropImages')!(null, payload) as Promise<any>;
-  expect(await drop({ paths: [] })).toMatchObject({ ok: false });
-  expect(await drop({ paths: Array(5).fill('image.png') })).toMatchObject({ ok: false });
-  expect(await drop({ paths: [''] })).toMatchObject({ ok: false });
-  expect(await drop({ paths: [path.join(process.cwd(), 'package.json')] })).toMatchObject({ ok: false });
+it('validates dropped file count and stages arbitrary native file types', async () => {
+  const drop = (payload: unknown) => handlers.get('sessions:dropFiles')!(null, payload) as Promise<any>;
+  expect(await drop({ files: [] })).toMatchObject({ ok: false });
+  expect(await drop({ files: Array(21).fill('image.png') })).toMatchObject({ ok: false });
+  expect(await drop({ files: [''] })).toMatchObject({ ok: false });
+  expect(await drop({ files: [path.join(process.cwd(), 'package.json')] })).toMatchObject({ ok: true, data: [expect.objectContaining({ name: 'package.json', mimeType: 'application/json' })] });
+});
+
+it('publishes Goal draft progress through the session refresh channel without a new transcript event', async () => {
+  const { startGoalDraft, resetGoalStateForTests } = await import('../src/main/goal.js');
+  const session = await createSession({ title: 'Goal progress', conversationId: 'ipc-goal-progress' });
+  currentWindow = { setBackgroundColor: vi.fn(), isDestroyed: () => false, webContents: { send: vi.fn() } };
+  try {
+    startGoalDraft({ conversationId: session.conversationId!, sessionId: session.id, turnId: 'finished-turn', deferStart: true });
+    expect(currentWindow.webContents.send).toHaveBeenCalledWith('session:changed');
+  } finally {
+    resetGoalStateForTests();
+  }
+});
+
+it('stages clipboard image bytes with a preview through the general attachment owner', async () => {
+  const drop = (payload: unknown) => handlers.get('sessions:dropFiles')!(null, payload) as Promise<any>;
+  expect(await drop({ files: [] })).toMatchObject({ ok: false });
+  expect(await drop({ files: [{ name: 'huge.png', bytes: new Uint8Array(12 * 1024 * 1024 + 1) }] })).toMatchObject({ ok: false });
+  const sharp = (await import('sharp')).default;
+  const bytes = await sharp({ create: { width: 12, height: 8, channels: 3, background: '#123456' } }).png().toBuffer();
+  const pasted = await drop({ files: [{ name: 'screenshot.png', bytes: new Uint8Array(bytes) }] });
+  expect(pasted).toMatchObject({ ok: true, data: [{ name: 'screenshot.png', size: bytes.length, mimeType: 'image/png', preview: expect.stringMatching(/^data:image\/webp;base64,/) }] });
+  const { readInputAttachmentChunk } = await import('../src/main/session/input-attachments.js');
+  expect(await readInputAttachmentChunk(pasted.data[0], 0)).toBe(bytes.toString('base64'));
 });
 
 it('does not authorize the composer Generate Goal action from an absent or stale finish wait', async () => {
@@ -482,7 +506,78 @@ describe('bounded IPC identities and OS launch results', () => {
   });
 });
 
+describe('ChatGPT browser settings', () => {
+  it('persists Edge and keeps it through an unrelated stale renderer save', async () => {
+    const base = defaultConfig();
+    await saveConfig(base);
+    const result = await save({ ...base, ui: { ...base.ui, chatBrowser: 'edge' } }, base);
+    expect(result.ok, result.error).toBe(true);
+    expect(JSON.parse(await fs.readFile(path.join(dir, 'config.json'), 'utf8')).ui.chatBrowser).toBe('edge');
+    const stale = await save({ ...base, ui: { ...base.ui, theme: 'light' } }, base);
+    expect(stale.ok, stale.error).toBe(true);
+    expect(getConfig().ui).toMatchObject({ chatBrowser: 'edge', theme: 'light' });
+    const current = getConfig();
+    expect((await save({ ...current, ui: { ...current.ui, chatBrowser: 'unsupported' } }, current)).ok).toBe(false);
+    expect(getConfig().ui.chatBrowser).toBe('edge');
+  });
+});
+
 describe('settings writes from more than one UI', () => {
+  it('changes login registration only on a changed preference and reports failure after other effects', async () => {
+    const lifecycle = await import('../src/main/window-lifecycle.js');
+    const connection = await import('../src/main/connection.js');
+    const applied = vi.spyOn(connection, 'applySettings');
+    const login = vi.spyOn(lifecycle, 'applyLoginStartup').mockImplementation(() => { throw new Error('login registration refused'); });
+    try {
+      const base = defaultConfig();
+      await saveConfig(base);
+      const cosmetic = await save({ ...base, ui: { ...base.ui, theme: 'light' } }, base);
+      expect(cosmetic.ok, cosmetic.error).toBe(true);
+      expect(login).not.toHaveBeenCalled();
+      applied.mockClear();
+      const current = getConfig();
+      const changed = await save({ ...current, ui: { ...current.ui, theme: 'dark', startAtLogin: true } }, current);
+      expect(changed.ok).toBe(false);
+      expect(changed.error).toContain('login registration refused');
+      expect(getConfig().ui.startAtLogin).toBe(true);
+      expect(nativeTheme.themeSource).toBe('dark');
+      expect(applied).toHaveBeenCalledOnce();
+      expect(login).toHaveBeenCalledOnce();
+      expect(applied.mock.invocationCallOrder[0]).toBeLessThan(login.mock.invocationCallOrder[0]!);
+    } finally { login.mockRestore(); applied.mockRestore(); }
+  });
+  it('rotates only the active Goal provider and exposes key presence without the secret', async () => {
+    const base = defaultConfig();
+    await saveConfig({ ...base, goal: { ...base.goal, provider: { kind: 'custom', baseUrl: 'http://localhost:11434/v1' } } });
+    const goal = await import('../src/main/goal.js');
+    const retired = vi.spyOn(goal, 'retireGoalDrafts');
+    try {
+      await handlers.get('secret:set')!({}, { key: 'openRouterApiKey', value: 'synthetic-inactive-key' });
+      expect(retired).not.toHaveBeenCalled();
+      const response = await handlers.get('secret:set')!({}, { key: 'customProviderApiKey', value: 'synthetic-active-key' });
+      expect(retired).toHaveBeenCalledTimes(1);
+      expect(response).toMatchObject({ ok: true, data: { hasCustomProviderKey: true } });
+      expect(JSON.stringify(response)).not.toContain('synthetic-active-key');
+    } finally { retired.mockRestore(); }
+  });
+  it('persists connector instructions through IPC, preserves concurrent edits, and allows explicit clearing', async () => {
+    const base = defaultConfig(); await saveConfig(base);
+    const wanted = { ...base, mcp: { instructions: 'Use the approved project only.' }, ui: { ...base.ui, browserOnly: true } };
+    expect((await save(wanted, base)).ok).toBe(true);
+    expect(JSON.parse(await fs.readFile(path.join(dir, 'config.json'), 'utf8')).mcp).toEqual(wanted.mcp);
+    expect(getConfig().ui.browserOnly).toBe(true);
+    expect((await save({ ...base, ui: { ...base.ui, minimizeToTray: !base.ui.minimizeToTray } }, base)).ok).toBe(true);
+    expect(getConfig().mcp).toEqual(wanted.mcp);
+    expect(getConfig().ui.browserOnly).toBe(true);
+    const legacy = { ...base } as any; delete legacy.mcp;
+    expect((await save(legacy, legacy)).ok).toBe(true);
+    expect(getConfig().mcp).toEqual(wanted.mcp);
+    const current = getConfig();
+    expect((await save({ ...current, mcp: { instructions: '' } }, current)).ok).toBe(true);
+    expect(getConfig().mcp.instructions).toBe('');
+    expect((await save({ ...current, mcp: { instructions: 'x'.repeat(4001) } }, current)).ok).toBe(false);
+    expect(getConfig().mcp.instructions).toBe('');
+  });
   it('saves helper settings and tab retention through the renderer schema and merge boundary', async () => {
     const base = defaultConfig();
     await saveConfig(base);
@@ -739,6 +834,62 @@ describe('the goal model id', () => {
     const reply = await save(settings({ record: false, multiAgent: false }));
     expect(reply.ok, reply.error).toBe(true);
     expect(getConfig().goal.model).toBe(defaultConfig().goal.model);
+  });
+
+  it('accepts a bare endpoint id while custom and stores the base URL verbatim', async () => {
+    const patch = {
+      ...settings({ record: false, multiAgent: false }),
+      goal: {
+        ...defaultConfig().goal,
+        provider: { kind: 'custom' as const, baseUrl: 'http://localhost:11434/v1/' },
+        model: 'llama3.1'
+      }
+    };
+    const reply = await save(patch);
+    expect(reply.ok, reply.error).toBe(true);
+    expect(getConfig().goal.provider).toEqual({ kind: 'custom', baseUrl: 'http://localhost:11434/v1/' });
+    expect(getConfig().goal.model).toBe('llama3.1');
+  });
+
+  it('still refuses a bare id while on OpenRouter, and an unknown provider kind', async () => {
+    const custom = {
+      ...settings({ record: false, multiAgent: false }),
+      goal: {
+        ...defaultConfig().goal,
+        provider: { kind: 'custom' as const, baseUrl: 'http://localhost:11434/v1' },
+        model: 'llama3.1'
+      }
+    };
+    // Same model, OpenRouter provider: the vendor/model shape still applies.
+    const openrouter = {
+      ...custom,
+      goal: { ...custom.goal, provider: { kind: 'openrouter' as const, baseUrl: '' } }
+    };
+    expect((await save(openrouter)).ok).toBe(false);
+    const unknown = {
+      ...custom,
+      goal: { ...custom.goal, provider: { kind: 'own' as never, baseUrl: '' } }
+    };
+    expect((await save(unknown)).ok).toBe(false);
+  });
+});
+
+describe('the custom provider key slot', () => {
+  const storeSecret = (payload: unknown): Promise<any> =>
+    handlers.get('secret:set')!(null, payload) as Promise<any>;
+
+  it('stores a custom key in its own slot and refuses an unnamed one', async () => {
+    const prior = await handlers.get('state:get')!(null, undefined) as any;
+    const stored = await storeSecret({ value: 'sk-custom-1', key: 'customProviderApiKey' });
+    expect(stored.ok, stored.error).toBe(true);
+    expect(stored.data.hasCustomProviderKey).toBe(true);
+    // The OpenRouter slot is untouched: naming is exact, never a shared bucket.
+    expect(stored.data.hasGoalKey).toBe(prior.data.hasGoalKey);
+    const cleared = await storeSecret({ value: '', key: 'customProviderApiKey' });
+    expect(cleared.ok).toBe(true);
+    expect(cleared.data.hasCustomProviderKey).toBe(false);
+    const refused = await storeSecret({ value: 'x', key: 'nobodyDefinedThis' });
+    expect(refused.ok).toBe(false);
   });
 });
 

--- a/test/mcp-user-instructions.test.ts
+++ b/test/mcp-user-instructions.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The user's own standing instructions, appended to what each connector says about itself.
+ *
+ * Issue #85: there was no persistent way to add anything, so the only route was patching
+ * `app.asar` — which an update overwrites. This is a settings field instead.
+ *
+ * Two properties are worth defending in tests rather than in review. It goes **last**, because
+ * everything above it is what the app can actually promise about its own tools and a preference
+ * must not quietly redefine one. And it is **attributed**, so the model can tell a standing
+ * instruction from this user apart from the connector's description of itself — those carry
+ * different authority, and running them together hides that.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isAsyncEncryptionAvailable: async () => true,
+    getSelectedStorageBackend: () => 'gnome_libsecret',
+    encryptStringAsync: async (value: string) => Buffer.from(value, 'utf8'),
+    decryptStringAsync: async (buffer: Buffer) => ({ result: buffer.toString('utf8'), shouldReEncrypt: false })
+  },
+  clipboard: { readText: () => '', writeText: () => undefined },
+  shell: { openExternal: async () => undefined }
+}));
+
+const { MAX_MCP_INSTRUCTIONS_CHARS, defaultConfig, getConfig, initConfigPath, saveConfig } = await import(
+  '../src/main/config.js'
+);
+const { serverInstructions } = await import('../src/main/mcp/instructions.js');
+const { makeTempDir, removeTempDir } = await import('./helpers.js');
+const { CAPABILITIES } = await import('../src/shared/types.js');
+type Capabilities = import('../src/shared/types.js').Capabilities;
+
+let dir: string;
+
+const allCapabilities = (): Capabilities =>
+  Object.fromEntries(CAPABILITIES.map((name) => [name, true])) as Capabilities;
+
+const ctx = {
+  roots: [],
+  caps: allCapabilities(),
+  readOnly: false,
+  sessionTools: false,
+  agentTools: false
+};
+
+const HEADING = "The user's own standing instructions for this connector:";
+
+async function withInstructions(instructions: string): Promise<void> {
+  const config = getConfig();
+  await saveConfig({ ...config, mcp: { ...config.mcp, instructions } });
+}
+
+beforeAll(async () => {
+  dir = await makeTempDir('clf-mcp-instructions-');
+  initConfigPath(dir);
+  await saveConfig(defaultConfig());
+});
+
+afterAll(async () => {
+  await removeTempDir(dir);
+});
+
+beforeEach(async () => {
+  await withInstructions('');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('the user’s own connector instructions', () => {
+  it('adds nothing at all when empty, not even the heading', () => {
+    expect(defaultConfig().mcp.instructions).toBe('');
+    for (const surface of ['core', 'desktop'] as const) {
+      const text = serverInstructions(ctx, surface, 'win32');
+      expect(text, surface).not.toContain(HEADING);
+    }
+  });
+
+  it.each(['core', 'desktop'] as const)('appends them last on the %s connector, attributed', async (surface) => {
+    const mine = 'Always run the test suite before saying a change works.';
+    await withInstructions(mine);
+
+    const text = serverInstructions(ctx, surface, 'win32');
+    expect(text).toContain(HEADING);
+    expect(text).toContain(mine);
+    // Last: nothing the app authored may follow, or a preference would be read as overriding
+    // guidance that comes after it.
+    expect(text.trimEnd().endsWith(mine)).toBe(true);
+    // And the heading immediately precedes it, so the attribution cannot drift away.
+    expect(text.indexOf(HEADING)).toBeLessThan(text.indexOf(mine));
+  });
+
+  it('leaves everything the app says about itself intact', async () => {
+    const before = serverInstructions(ctx, 'core', 'win32');
+    await withInstructions('Prefer pnpm.');
+    const after = serverInstructions(ctx, 'core', 'win32');
+
+    // Added to, never edited: the connector's own description is unchanged character for
+    // character, and only the attributed block is new.
+    expect(after.startsWith(before)).toBe(true);
+    expect(after.slice(before.length)).toContain('Prefer pnpm.');
+  });
+
+  it('survives a reload, which is the whole point of it being a setting', async () => {
+    await withInstructions('Never force-push.');
+    initConfigPath(dir);
+    expect(getConfig().mcp.instructions).toBe('Never force-push.');
+    expect(serverInstructions(ctx, 'core', 'win32')).toContain('Never force-push.');
+  });
+
+  it('trims surrounding whitespace rather than emitting a blank block', async () => {
+    await withInstructions('   \n  \t ');
+    expect(getConfig().mcp.instructions).toBe('');
+    expect(serverInstructions(ctx, 'core', 'win32')).not.toContain(HEADING);
+  });
+
+  it('caps an over-long value instead of rejecting the whole config', async () => {
+    // Repaired, not rejected. This is free text a person typed, and one over-long field must
+    // not send every root and every permission through conservative recovery.
+    await withInstructions('x'.repeat(MAX_MCP_INSTRUCTIONS_CHARS + 500));
+    const stored = getConfig().mcp.instructions;
+    expect(stored.length).toBe(MAX_MCP_INSTRUCTIONS_CHARS);
+    // And the rest of the config is still the real one, not the conservative fallback.
+    expect(getConfig().readOnly).toBe(false);
+    expect(serverInstructions(ctx, 'core', 'win32')).toContain(stored);
+  });
+});

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -169,6 +169,7 @@ async function call(surface: SurfaceId, method: string, params: unknown = {}): P
 const core = (method: string, params: unknown = {}): Promise<any> => call('core', method, params);
 const desktop = (method: string, params: unknown = {}): Promise<any> => call('desktop', method, params);
 
+const { REASONING_EFFORTS } = await import('../src/shared/session.js');
 const PROTOCOL_2026 = '2026-07-28';
 const META_VERSION = 'io.modelcontextprotocol/protocolVersion';
 const META_CAPABILITIES = 'io.modelcontextprotocol/clientCapabilities';
@@ -592,7 +593,7 @@ describe('surface boundaries', () => {
     everything();
     const names = toolNames(await core('tools/list'));
     // find is absent because exec_command is present — they are mutually exclusive.
-    expect(names).toEqual(['agents', 'apply_patch', 'exec_command', 'read', 'session', 'view_image', 'write_stdin']);
+    expect(names).toEqual(['agents', 'apply_patch', 'download_artifact', 'exec_command', 'read', 'session', 'view_image', 'write_stdin']);
     for (const name of surfaceDefinition('desktop').tools) expect(names, name).not.toContain(name);
   });
 
@@ -630,6 +631,39 @@ describe('surface boundaries', () => {
     // And an ordinary read from a worker's chat carries nothing at all.
     const call1 = await core('tools/call', { name: 'read', arguments: { paths: ['/workspace/src/app.ts'] } });
     expect(failed(call1)).toBe(false);
+  });
+
+  /**
+   * The prime has to be able to say which model each worker gets — issue #67.
+   *
+   * The broker has accepted per-worker `model` and `reasoning_effort` for a while, validates
+   * both before creating anything, and has tests for the rejection path. What it did not have
+   * was any way for a caller to send them: the `workers` object is `.strict()`, so a spawn
+   * naming a model was rejected outright rather than honoured. This asserts the surface, since
+   * that gate is the one seam the broker's own tests cannot see.
+   */
+  it('lets a spawn choose a model and reasoning level per worker', async () => {
+    everything();
+    const agentsTool = toolList(await core('tools/list')).find((tool) => tool.name === 'agents')!;
+    const worker = agentsTool.inputSchema.properties.workers.items;
+
+    expect(Object.keys(worker.properties).sort()).toEqual(['label', 'model', 'reasoning_effort', 'task']);
+    // Only `task` is required: omitting both keeps exactly the previous behaviour, which is
+    // the account default, or whatever the user chose in settings.
+    expect(worker.required).toEqual(['task']);
+    expect(worker.additionalProperties).toBe(false);
+
+    // Declared as an enum so the caller can discover the vocabulary instead of guessing at it
+    // and having the spawn fail. `pro` belongs here: a worker is a real ChatGPT browser chat.
+    expect(worker.properties.reasoning_effort.enum).toEqual([...REASONING_EFFORTS]);
+    expect(worker.properties.model.type).toBe('string');
+
+    // The task description used to tell the model the opposite — that model and reasoning were
+    // fixed in app settings. A caller that believes that will never pass either field.
+    expect(worker.properties.task.description).not.toMatch(/predefined by the user/i);
+    for (const field of ['model', 'reasoning_effort']) {
+      expect(worker.properties[field].description, field).toMatch(/app settings/i);
+    }
   });
 
   it('removes the agents tool entirely once multi-agent is switched off', async () => {
@@ -769,9 +803,9 @@ describe('surface boundaries', () => {
     const coreTools = toolList(await core('tools/list'));
     const desktopTools = toolList(await desktop('tools/list'));
 
-    // Counts are the design: Core is capped at seven live schemas because find and the exec
+    // Counts are the design: Core is capped at eight live schemas because find and the exec
     // pair cannot both exist, and Desktop is two.
-    expect(coreTools).toHaveLength(7);
+    expect(coreTools).toHaveLength(8);
     expect(desktopTools).toHaveLength(2);
 
     // And the size, which is what a discovery pull actually costs the model on every

--- a/test/model-catalog-workflow.test.ts
+++ b/test/model-catalog-workflow.test.ts
@@ -17,7 +17,7 @@ it.each([false, true])('holds cold discovery until composer hydration without a 
   const dom = new JSDOM('<html><body></body></html>');
   const ask = vi.fn(async () => ({ ok: true }));
   const clear = vi.fn(() => true);
-  const context = vm.createContext({ URL, Date, setTimeout, clearTimeout, document: dom.window.document,
+  const context = vm.createContext({ URL, Date, setTimeout, clearTimeout, pageViewChecks: new Set(), document: dom.window.document,
     MutationObserver: dom.window.MutationObserver, alive: true, epoch: 1, conversationId: null,
     generating: false, desktopInputBusy: false, modelCatalogBusy: false,
     location: { pathname: '/', href: `https://chatgpt.com/?cos-model-catalog=${nonce}` }, ask,
@@ -34,6 +34,7 @@ it.each([false, true])('holds cold discovery until composer hydration without a 
   dom.window.document.body.append(composer);
   expect(await pending).toBe(!navigated);
   expect(ask).toHaveBeenCalledTimes(navigated ? 0 : 1);
+  expect(context.pageViewChecks.size).toBe(0);
   expect(clear).not.toHaveBeenCalled();
   dom.window.close();
 });

--- a/test/model-picker-state.test.ts
+++ b/test/model-picker-state.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'node:fs';
+import { JSDOM } from 'jsdom';
+import { afterEach, expect, it, vi } from 'vitest';
+
+const domSource = readFileSync(new URL('../extension/chatgpt-dom.js', import.meta.url), 'utf8');
+const fiberSource = readFileSync(new URL('../extension/fiber.js', import.meta.url), 'utf8');
+let page: JSDOM;
+afterEach(() => { page?.window.close(); });
+function fixture() {
+  page = new JSDOM('<form><div id="prompt-textarea" contenteditable="true"></div><div data-testid="composer-trailing-actions"><button type="button" aria-haspopup="menu">Denkaufwand</button><button data-testid="send-button">Senden</button></div></form>', { url: 'https://chatgpt.com/', runScripts: 'outside-only' });
+  const win = page.window, doc = win.document;
+  Object.defineProperty(win.HTMLElement.prototype, 'getClientRects', { value() { return this.hidden ? [] : [{}]; } });
+  win.postMessage = (data: unknown) => queueMicrotask(() => win.dispatchEvent(new win.MessageEvent('message', { data, source: win as unknown as Window, origin: win.location.origin })));
+  const choice = (bucket: number, modelSlug: string, thinkingEffort: string, available = true) => ({ bucket, modelSlug, thinkingEffort,
+    availability: { status: available ? 'available' : 'upgrade_required' },
+    category: { modelLane: modelSlug.endsWith('pro') ? 'pro' : 'thinking', shortLabel: modelSlug.startsWith('future') ? 'Neues Modell' : modelSlug.endsWith('pro') ? '6 Pro' : '5.6 Sol' } });
+  const versions = [{ id: 'latest', displayTextForIntelligence: 'Aktuell', enabled: true }, { id: 'future', displayTextForIntelligence: 'Neues Modell', enabled: true }];
+  const selections = [[choice(1, 'gpt-5-6-thinking', 'standard'), choice(2, 'gpt-5-6-thinking', 'extended'), choice(3, 'gpt-6-pro', 'standard', false)],
+    [choice(10, 'future-model', 'low'), choice(11, 'future-model', 'ultra')]];
+  const state = { bucketSelections: selections[0]!, currentBucket: 2, selectedVersionEntry: versions[0]!, currentSelection: selections[0]![1]! };
+  const props = { modelsData: { versions }, composerIntelligencePickerState: state, modelSwitcherDenialsBySlug: {}, conversation: { privateSecret: 'must-never-cross' } };
+  const trigger = doc.querySelector('button')!;
+  const actions = vi.fn();
+  let frozen = false;
+  const render = () => {
+    let panel = doc.querySelector('[data-testid="composer-intelligence-picker-content"]') as HTMLElement;
+    if (!panel) { panel = doc.createElement('div'); panel.dataset.testid = 'composer-intelligence-picker-content'; doc.body.append(panel); }
+    (panel as any).__reactFiber$test = { memoizedProps: props, return: null };
+    panel.innerHTML = '<div role="menuitem" aria-expanded="false">Modell auswählen</div><div role="menuitem" aria-keyshortcuts="ArrowLeft ArrowRight" aria-label="Leistung"></div>';
+    panel.querySelector('[aria-expanded]')!.addEventListener('click', () => {
+      panel.innerHTML = '';
+      for (const version of versions) {
+        const row = doc.createElement('div'); row.setAttribute('role', 'menuitemradio'); row.textContent = version.displayTextForIntelligence;
+        row.addEventListener('keydown', event => { if (event.key !== 'Enter') return; actions('version'); if (frozen) return;
+          state.selectedVersionEntry = version; state.bucketSelections = selections[versions.indexOf(version)]!;
+          state.currentBucket = state.bucketSelections[0]!.bucket; state.currentSelection = state.bucketSelections[0]!; render(); }); panel.append(row);
+      }
+    });
+    panel.querySelector('[aria-keyshortcuts]')!.addEventListener('keydown', (event: any) => {
+      actions('effort'); if (frozen) return;
+      const at = state.bucketSelections.findIndex(c => c.bucket === state.currentBucket) + (event.key === 'ArrowRight' ? 1 : -1);
+      if (!state.bucketSelections[at]) return;
+      state.currentBucket = state.bucketSelections[at]!.bucket; state.currentSelection = state.bucketSelections[at]!; render();
+    });
+  };
+  trigger.addEventListener('keydown', event => {
+    if (event.key === 'Enter') render();
+    if (event.key === 'Escape') doc.querySelector('[data-testid="composer-intelligence-picker-content"]')?.remove();
+  });
+  win.eval(fiberSource); win.eval(domSource);
+  return { api: (win as any).CLF_DOM, state, props, actions, freeze: () => { frozen = true; } };
+}
+it('reads localized nested models and future efforts from account state, excludes locked choices, and restores selection', async () => {
+  const f = fixture();
+  expect(await f.api.inspectModelSettings()).toEqual([
+    { id: 'gpt-5-6-thinking', label: 'GPT-5.6 Sol', efforts: ['medium', 'high'] },
+    { id: 'future-model', label: 'Neues Modell', efforts: ['low', 'ultra'] }
+  ]);
+  expect(f.state.selectedVersionEntry.id).toBe('latest'); expect(f.state.currentBucket).toBe(2);
+  // Only restore the original High once; discovery never sweeps every power level.
+  expect(f.actions.mock.calls.filter(([action]) => action === 'effort')).toHaveLength(1);
+});
+it('confirms the exact model and effort and refuses visible upgrade-only entries', async () => {
+  const f = fixture();
+  expect(await f.api.selectModelSettings('future-model', 'ultra')).toBe(true);
+  expect(f.state.currentSelection).toMatchObject({ modelSlug: 'future-model', thinkingEffort: 'ultra' });
+  expect(await f.api.selectModelSettings('gpt-6-pro', 'pro')).toBe(false);
+  expect(f.state.currentSelection).toMatchObject({ modelSlug: 'future-model', thinkingEffort: 'ultra' });
+});
+it('reads an already-open version submenu and restores its original exact power', async () => {
+  const f = fixture();
+  page.window.document.querySelector('button')!.dispatchEvent(new page.window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+  (page.window.document.querySelector('[aria-expanded]') as HTMLElement).click();
+  expect(page.window.document.querySelectorAll('[role=menuitemradio]')).toHaveLength(2);
+  expect(await f.api.inspectModelSettings()).toHaveLength(2);
+  expect(f.state.selectedVersionEntry.id).toBe('latest');
+  expect(f.state.currentSelection).toMatchObject({ modelSlug: 'gpt-5-6-thinking', thinkingEffort: 'extended' });
+});
+it('invalidates mounted selection proof when provider state becomes unrecognized', async () => {
+  const f = fixture();
+  page.window.document.querySelector('button')!.dispatchEvent(new page.window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+  const read = async () => {
+    await new Promise<void>(resolve => {
+      const receive = (event: MessageEvent) => { if (event.data?.source === 'clf-picker-reply') { page.window.removeEventListener('message', receive as any); resolve(); } };
+      page.window.addEventListener('message', receive as any);
+      page.window.postMessage({ source: 'clf-picker-ask', nonce: 'fixture' }, page.window.location.origin);
+    });
+    return f.api.visibleModelSelection();
+  };
+  expect(await read()).toEqual({ model: 'gpt-5-6-thinking', reasoningEffort: 'high' });
+  f.state.currentSelection.thinkingEffort = 'unknown-provider-value';
+  expect(await read()).toBeNull();
+});
+it('keeps an explicit model denial unavailable even when the preset is visible', async () => {
+  const f = fixture(); (f.props.modelSwitcherDenialsBySlug as any)['future-model'] = { reason: 'workspace_policy' };
+  expect(await f.api.inspectModelSettings()).toEqual([{ id: 'gpt-5-6-thinking', label: 'GPT-5.6 Sol', efforts: ['medium', 'high'] }]);
+});
+it('does not mutate the picker after navigation ownership is lost', async () => {
+  const f = fixture(); expect(await f.api.selectModelSettings('future-model', 'ultra', () => false)).toBe(false);
+  expect(f.actions).not.toHaveBeenCalled();
+});
+it('projects an allowlist rather than leaking conversation props through the bridge', async () => {
+  const f = fixture(); const replies: unknown[] = [];
+  page.window.addEventListener('message', event => { if (event.data?.source === 'clf-picker-reply') replies.push(event.data); });
+  await f.api.inspectModelSettings();
+  expect(replies.length).toBeGreaterThan(0);
+  expect(JSON.stringify(replies)).not.toMatch(/privateSecret|must-never-cross|conversation|modelsData/);
+});

--- a/test/packaging.test.ts
+++ b/test/packaging.test.ts
@@ -420,6 +420,7 @@ describe('cross-platform packaging targets', () => {
     expect(builder.mac.category).toBe('public.app-category.developer-tools');
     expect(builder.mac.minimumSystemVersion).toBe('13.0');
     expect(builder.mac.artifactName).toBe('Chat-On-Steroids-macOS-${arch}.${ext}');
+    expect(builder.mac.extendInfo.NSUserNotificationAlertStyle).toBe('alert');
     const nativePrep = readFileSync(path.join(root, 'scripts', 'prepare-packaging-native.mjs'), 'utf8');
     expect(nativePrep).toContain("await chmod(path.join(payloadRoot, 'node-pty', 'prebuilds', prebuildDir, 'spawn-helper'), 0o755)");
     for (const marker of [

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -21,6 +21,7 @@ const allCapabilities = (): Capabilities => ({
   move: true,
   deleteFile: true,
   command: true,
+  saveArtifact: true,
   screen: true,
   control: true,
   clipboardRead: true,

--- a/test/plugin-refresh-browser-creation.test.ts
+++ b/test/plugin-refresh-browser-creation.test.ts
@@ -5,13 +5,47 @@ import { expect, it, vi } from 'vitest';
 const source = readFileSync(new URL('../extension/background.js', import.meta.url), 'utf8');
 const workflow = source.slice(source.indexOf('let pluginRefreshFlight = null;'), source.indexOf('async function catalogProbe('));
 
+it('keeps one operation on its original tab after marker loss, worker restart, and user closure', async () => {
+  const id = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+  const saved: Record<string, unknown> = {};
+  let tab: { id: number; url: string } | null = null;
+  const create = vi.fn(async (url: string) => (tab = { id: 8, url }));
+  const update = vi.fn(async (_id: number, patch: { url: string }) => { if (tab) tab.url = patch.url; return tab; });
+  const storage = { session: { get: async () => saved, set: async (next: object) => { Object.assign(saved, next); } } };
+  const start = () => {
+    const context = vm.createContext({ URL, setTimeout, clearTimeout, CHATGPT_TAB_URLS: ['https://chatgpt.com/*'], createChatTab: create,
+      call: async () => ({ ok: true, data: { requests: [{ id, appId: null }] } }),
+      chrome: { storage, tabs: { query: async () => tab ? [tab] : [], get: async () => { if (!tab) throw Error('closed'); return tab; }, update, sendMessage: async () => ({ ok: true }) } } });
+    vm.runInContext(`${workflow}\nglobalThis.run = inspectRequestedPluginRefresh;`, context); return context;
+  };
+  await start().run([{}], true);
+  expect(create).toHaveBeenCalledTimes(1);
+  tab!.url = 'https://chatgpt.com/#settings/Plugins/plugin_asdk_app_synthetic';
+  await start().run([{}], true);
+  expect(create).toHaveBeenCalledTimes(1);
+  expect(update).toHaveBeenCalledWith(8, { url: `https://chatgpt.com/?cos-plugin-refresh=${id}#settings/Plugins/plugin_asdk_app_synthetic` });
+  tab = null;
+  await start().run([{}], true); await start().run([{}], true);
+  expect(create).toHaveBeenCalledTimes(1);
+});
+
+it('does not create a plugin helper in browser-only mode', async () => {
+  const create = vi.fn();
+  const context = vm.createContext({ URL, setTimeout, clearTimeout, CHATGPT_TAB_URLS: ['https://chatgpt.com/*'], createChatTab: create,
+    call: async () => ({ ok: true, data: { requests: [{ id: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee' }] } }),
+    chrome: { storage: { session: { get: async () => ({}) } }, tabs: { query: async () => [] } } });
+  vm.runInContext(`${workflow}\nglobalThis.run = inspectRequestedPluginRefresh;`, context);
+  await context.run([{}], true, true);
+  expect(create).not.toHaveBeenCalled();
+});
+
 it('records browser creation failure before claim and retries the same obligation', async () => {
   const request = { id: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee', appId: 'asdk_app_synthetic' };
   const call = vi.fn(async (_path: string, init: { body: string }) => JSON.parse(init.body).action === 'pending'
     ? { ok: true, data: { requests: [request] } } : { ok: true });
   const createChatTab = vi.fn().mockRejectedValueOnce(new Error('window size rejected')).mockResolvedValueOnce({ id: 8 });
   const context = vm.createContext({ call, createChatTab, URL, setTimeout, clearTimeout,
-    CHATGPT_TAB_URLS: ['https://chatgpt.com/*'], chrome: { tabs: { query: async () => [] } } });
+    CHATGPT_TAB_URLS: ['https://chatgpt.com/*'], chrome: { storage: { session: { get: async () => ({}), set: async () => {} } }, tabs: { query: async () => [] } } });
   vm.runInContext(`${workflow}\nglobalThis.run = inspectRequestedPluginRefresh;`, context);
   await context.run([{}], true);
   const actions = call.mock.calls.map(([, init]) => JSON.parse(init.body));

--- a/test/plugin-refresh-dom.test.ts
+++ b/test/plugin-refresh-dom.test.ts
@@ -2,67 +2,76 @@ import { readFileSync } from 'node:fs';
 import { JSDOM } from 'jsdom';
 import { afterEach, expect, it } from 'vitest';
 const source = readFileSync(new URL('../extension/chatgpt-dom.js', import.meta.url), 'utf8');
+const fiber = readFileSync(new URL('../extension/fiber.js', import.meta.url), 'utf8');
 let dom: JSDOM;
 afterEach(() => dom?.window.close());
-const tool = { name: 'read', description: 'Read an exact file.', inputSchema: { type: 'object', properties: { path: { type: 'string', description: 'A path with {braces} and "quotes"' } }, required: ['path'] } };
+const tool = { name: 'read', description: 'Read an exact file.', inputSchema: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] } };
 function page() {
-  dom = new JSDOM('<button id="plugins-tab">Plugins</button><section role="tabpanel" aria-labelledby="plugins-tab"><h2>Chat On Steroids Core</h2><div class="actions"><article><h3>read</h3>\nPUBLIC WRITE\n<p>Read an exact file.</p>\nINPUT SCHEMA\n<button>Copy input schema</button><pre></pre>\nMETADATA\nVisibility public</article></div><footer>Information\n<button>Refresh</button>\nApp Id asdk_app_synthetic\nVersion Id asdk_app_v_synthetic</footer></section>', { runScripts: 'outside-only', url: 'https://chatgpt.com/plugins' });
-  dom.window.document.querySelector('pre')!.textContent = JSON.stringify(tool.inputSchema);
-  Object.defineProperty(dom.window.HTMLElement.prototype, 'getClientRects', { value() { return [{}]; } });
-  dom.window.eval(source);
-  return (dom.window as any).CLF_DOM;
+  dom = new JSDOM('<section role="tabpanel" aria-labelledby="settings-trigger-Plugins"><h2>Chat On Steroids Core</h2><button id="schema">Schema kopieren</button><footer><button id="refresh">Aktualisieren</button></footer></section>', { runScripts: 'outside-only', url: 'https://chatgpt.com/#settings/Plugins/plugin_asdk_app_synthetic' });
+  const win = dom.window;
+  Object.defineProperty(win.HTMLElement.prototype, 'getClientRects', { value() { return this.hidden ? [] : [{}]; } });
+  win.postMessage = (data: unknown) => queueMicrotask(() => win.dispatchEvent(new win.MessageEvent('message', { data, source: win as unknown as Window, origin: win.location.origin })));
+  const props = { connector: { id: 'asdk_app_synthetic', name: 'Chat On Steroids Core', app_metadata: { version_id: 'asdk_app_v_synthetic' }, owners: ['never-copy'] },
+    actions: [{ name: tool.name, description: tool.description, description_model: null, params: tool.inputSchema }], isLoadingActions: false };
+  (win.document.getElementById('schema') as any).__reactFiber$fixture = { memoizedProps: props };
+  (win.document.getElementById('refresh') as any).__reactFiber$fixture = { memoizedProps: { details: [{ title: 'App-Kennung', value: props.connector.id }], reportEntity: { id: props.connector.id, entityType: 'connector' }, headerTrailingContent: {} } };
+  win.eval(fiber); win.eval(source);
+  return { api: (win as any).CLF_DOM, props };
 }
-it('reads exact visible plugin identity and full schema without treating a refresh button as success', () => {
-  const api = page();
-  const view = api.pluginRefreshView('Chat On Steroids Core', [tool]);
+it('reads localized installed declarations and the unique native refresh action from provider state', async () => {
+  const { api } = page(); const view = await api.pluginRefreshView('Chat On Steroids Core', [tool]);
   expect(view).toMatchObject({ appId: 'asdk_app_synthetic', versionId: 'asdk_app_v_synthetic', tools: [tool] });
-  expect(view.refresh.textContent).toBe('Refresh');
-  expect(view).not.toHaveProperty('success');
+  expect(view.refresh.textContent).toBe('Aktualisieren'); expect(view).not.toHaveProperty('success');
 });
-it('refuses duplicate app identity and does not substitute expected text for a changed description', () => {
-  const api = page();
-  dom.window.document.querySelector('p')!.textContent = 'Read an exact file. And write it.';
-  expect(api.pluginRefreshView('Chat On Steroids Core', [tool]).tools[0].description).toBe('Read an exact file. And write it.');
-  dom.window.document.querySelector('footer')!.append(' App Id asdk_app_other');
-  expect(api.pluginRefreshView('Chat On Steroids Core', [tool])).toBeNull();
+it('does not substitute expected declarations for changed provider descriptions', async () => {
+  const { api, props } = page(); props.actions[0]!.description = 'Changed declaration.';
+  expect((await api.pluginRefreshView('Chat On Steroids Core', [tool])).tools[0].description).toBe('Changed declaration.');
+  props.actions.push(props.actions[0]!);
+  expect(await api.pluginRefreshView('Chat On Steroids Core')).toBeNull();
 });
-it('reads removed tool declarations without inventing their identity, but refuses the wrong Plugins heading', () => {
-  const api = page();
-  expect(api.pluginRefreshView('Chat On Steroids Desktop', [tool])).toBeNull();
-  dom.window.document.querySelector('h3')!.textContent = 'another_tool';
-  expect(api.pluginRefreshView('Chat On Steroids Core', [tool]).tools).toEqual([{ ...tool, name: 'another_tool' }]);
-  // A mapped connector may still expose a tool that the new schema removed. Identity
-  // and Refresh remain observable; initial enrollment still rejects the unknown set.
-  expect(api.pluginRefreshView('Chat On Steroids Core', [tool], 'asdk_app_synthetic').refresh.textContent).toBe('Refresh');
+it('uses an enrolled App ID through renames, but refuses mismatched IDs and loading schemas', async () => {
+  const { api, props } = page(); props.connector.name = 'Renamed';
+  expect(await api.pluginRefreshView('Chat On Steroids Core')).toBeNull();
+  expect(await api.pluginRefreshView('Chat On Steroids Core', [], 'asdk_app_synthetic')).not.toBeNull();
+  expect(await api.pluginRefreshView('Chat On Steroids Core', [], 'asdk_app_other')).toBeNull();
+  props.isLoadingActions = true;
+  expect(await api.pluginRefreshView('Renamed')).toBeNull();
 });
-it('distinguishes the loading plugin index from a settled missing installation', () => {
-  const api = page();
-  const panel = dom.window.document.querySelector('section')!;
-  panel.innerHTML = '<a href="/plugins">Browse plugins</a>';
+it('rejects oversized or cyclic schemas before projecting them to the isolated world', async () => {
+  const { api, props } = page();
+  const schema = { type: 'object', description: 'x'.repeat(300000) };
+  props.actions[0]!.params = schema as any;
+  expect(await api.pluginRefreshView('Chat On Steroids Core')).toBeNull();
+  props.actions[0]!.params = { type: 'object', properties: {} } as any;
+  (props.actions[0]!.params as any).properties.self = props.actions[0]!.params;
+  expect(await api.pluginRefreshView('Chat On Steroids Core')).toBeNull();
+});
+it('refuses ambiguous native actions and never copies unrelated connector properties', async () => {
+  const { api } = page(); const messages: unknown[] = [];
+  dom.window.addEventListener('message', event => { if (event.data?.source === 'clf-plugin-reply') messages.push(event.data); });
+  await api.pluginRefreshView('Chat On Steroids Core'); expect(JSON.stringify(messages)).not.toContain('never-copy');
+  const button = dom.window.document.getElementById('refresh')!;
+  const copy = button.cloneNode(true) as any; copy.__reactFiber$fixture = (button as any).__reactFiber$fixture; button.after(copy);
+  expect(await api.pluginRefreshView('Chat On Steroids Core')).toBeNull();
+});
+it('discovers exact installed rows across languages and preserves ambiguity', () => {
+  const { api } = page(); const panel = dom.window.document.querySelector('section')!;
+  panel.innerHTML = '<a href="/plugins">Plugins durchsuchen</a>';
   expect(api.pluginInstalledButtons('Chat On Steroids Core')).toBeNull();
-  panel.insertAdjacentHTML('beforeend', '<button><span data-testid="plugin-icon-wrapper"></span><div>Chat On Steroids Desktop</div><span>Allow all</span></button>');
-  expect(api.pluginInstalledButtons('Chat On Steroids Core')).toEqual([]);
-  panel.insertAdjacentHTML('beforeend', '<button><span data-testid="plugin-icon-wrapper"></span><div>Chat On Steroids Core</div><span>Allow all</span></button>');
-  expect(api.pluginInstalledButtons('Chat On Steroids Core')).toEqual([panel.querySelectorAll('button')[1]]);
-});
-it('uses a mapped App ID before a renamed display name and refuses another App ID', () => {
-  const api = page();
-  dom.window.document.querySelector('h2')!.textContent = 'My renamed connector';
-  expect(api.pluginRefreshView('Chat On Steroids Core', [tool], 'asdk_app_synthetic')?.appId).toBe('asdk_app_synthetic');
-  expect(api.pluginRefreshView('Chat On Steroids Core', [tool], 'asdk_app_other')).toBeNull();
-});
-it('reads the live adjacent settings labels and ignores provider schema recommendation badges', () => {
-  const api = page();
-  const panel = dom.window.document.querySelector('section')!;
-  const article = dom.window.document.querySelector('article')!;
-  Object.defineProperty(panel, 'innerText', { value: 'Chat On Steroids Core\nApp Id\nasdk_app_synthetic\nVersion Id\nasdk_app_v_synthetic' });
-  dom.window.document.querySelector('footer')!.textContent = 'App Idasdk_app_syntheticVersion Idasdk_app_v_synthetic';
-  Object.defineProperty(article, 'innerText', { value: `read\nREAD\nOUTPUT SCHEMA RECOMMENDED\nRead an exact file.\nINPUT SCHEMA\n${JSON.stringify(tool.inputSchema)}` });
-  expect(api.pluginRefreshView('Chat On Steroids Core', [tool])).toMatchObject({ appId: 'asdk_app_synthetic', tools: [tool] });
-});
-it('exposes duplicate installed names as ambiguous instead of picking a row', () => {
-  const api = page();
-  const panel = dom.window.document.querySelector('section')!;
-  panel.innerHTML = '<button><span data-testid="plugin-icon-wrapper"></span><div>Chat On Steroids Core</div></button>'.repeat(2);
+  panel.insertAdjacentHTML('beforeend', '<button><span data-testid="plugin-icon-wrapper"></span><div>Chat On Steroids Core</div><span>Alle zulassen</span></button>');
+  expect(api.pluginInstalledButtons('Chat On Steroids Core')).toHaveLength(1);
+  expect(api.pluginInstalledButtons('Chat On Steroids Desktop')).toEqual([]);
+  panel.insertAdjacentHTML('beforeend', panel.querySelector('button')!.outerHTML);
   expect(api.pluginInstalledButtons('Chat On Steroids Core')).toHaveLength(2);
+});
+
+it('observes an exact installed card without a refresh action through the real Fiber bridge', async () => {
+  const { api } = page();
+  const refresh = dom.window.document.getElementById('refresh') as any;
+  const card = { ...refresh.__reactFiber$fixture.memoizedProps, headerTrailingContent: null };
+  (dom.window.document.getElementById('schema') as any).__reactFiber$fixture.return = { memoizedProps: card };
+  refresh.remove();
+  expect(await api.pluginRefreshView('Chat On Steroids Core', [tool])).toMatchObject({ appId: 'asdk_app_synthetic', tools: [tool], refresh: null });
+  delete (dom.window.document.getElementById('schema') as any).__reactFiber$fixture.return;
+  expect(await api.pluginRefreshView('Chat On Steroids Core', [tool])).toBeNull();
 });

--- a/test/plugin-refresh-workflow.test.ts
+++ b/test/plugin-refresh-workflow.test.ts
@@ -7,13 +7,13 @@ const source = readFileSync(new URL('../extension/content.js', import.meta.url),
 const section = source.slice(source.indexOf('  let pluginRefreshBusy = false;'), source.indexOf('  function catalogPageReady('));
 const id = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
 const tools = [{ name: 'read', description: 'Read current.', inputSchema: { type: 'object' } }];
-function workflow(options: { unchanged?: boolean; deny?: boolean; navigateDuringClaim?: boolean } = {}) {
+function workflow(options: { unchanged?: boolean; deny?: boolean; navigateDuringClaim?: boolean; refreshAvailable?: boolean } = {}) {
   let refreshed = false;
   const click = vi.fn(() => { refreshed = true; });
   const context = vm.createContext({ URL, alive: true, generating: false, epoch: 1,
     location: { pathname: '/', href: `https://chatgpt.com/?cos-plugin-refresh=${id}#settings/Plugins/plugin_asdk_app_synthetic` },
     CLF_DOM: { generating: () => false, pluginManagementIdle: () => true,
-      pluginRefreshView: () => ({ appId: 'asdk_app_synthetic', refresh: { click }, tools: options.unchanged || refreshed ? tools : [{ ...tools[0], description: 'Old description.' }] }) }
+      pluginRefreshView: () => ({ appId: 'asdk_app_synthetic', refresh: options.refreshAvailable === false ? null : { click }, tools: options.unchanged || refreshed ? tools : [{ ...tools[0], description: 'Old description.' }] }) }
   });
   const ask = vi.fn(async (message: { action: string }) => {
     if (message.action === 'claim' && options.navigateDuringClaim) context.epoch = 2;
@@ -35,7 +35,7 @@ it.each([false, true])('waits for readable tool schemas before claim (navigation
   let ready = false, refreshed = false;
   const click = vi.fn(() => { refreshed = true; });
   const ask = vi.fn(async () => ({ data: { ok: true } }));
-  const context = vm.createContext({ URL, setTimeout, clearTimeout, MutationObserver: dom.window.MutationObserver,
+  const context = vm.createContext({ URL, setTimeout, clearTimeout, pageViewChecks: new Set(), MutationObserver: dom.window.MutationObserver,
     document: dom.window.document, alive: true, generating: false, epoch: 1, ask,
     location: { pathname: '/', href: `https://chatgpt.com/?cos-plugin-refresh=${id}#settings/Plugins/plugin_asdk_app_synthetic` },
     CLF_DOM: { generating: () => false, pluginManagementIdle: () => true,
@@ -50,6 +50,7 @@ it.each([false, true])('waits for readable tool schemas before claim (navigation
   dom.window.document.body.setAttribute('data-hydrated', 'true');
   expect(await pending).toBe(!navigate);
   expect(click).toHaveBeenCalledTimes(navigate ? 0 : 1);
+  expect(context.pageViewChecks.size).toBe(0);
   expect(ask.mock.calls.length).toBe(navigate ? 0 : 2);
   dom.window.close();
 });
@@ -58,7 +59,7 @@ it('keeps a loading settings index pending and restores custody after its instal
   let buttons: Array<{ click: () => void }> | null = null;
   const location = { pathname: '/', href: `https://chatgpt.com/?cos-plugin-refresh=${id}#settings/Plugins`, replace };
   const context = vm.createContext({ URL, alive: true, generating: false, epoch: 1, ask,
-    location,
+    location, history: { replaceState: replace },
     CLF_DOM: { generating: () => false, pluginManagementIdle: () => true, pluginInstalledButtons: () => buttons,
       pluginRefreshView: () => ({ appId: 'asdk_app_synthetic' }) }
   });
@@ -68,7 +69,7 @@ it('keeps a loading settings index pending and restores custody after its instal
   expect(ask).not.toHaveBeenCalled(); // no durable missing-plugin verdict while loading
   buttons = [{ click: () => { location.href = 'https://chatgpt.com/#settings/Plugins/plugin_asdk_app_synthetic'; } }];
   expect(await run()).toBe(true);
-  expect(replace).toHaveBeenCalledExactlyOnceWith(`https://chatgpt.com/?cos-plugin-refresh=${id}#settings/Plugins/plugin_asdk_app_synthetic`);
+  expect(replace).toHaveBeenCalledExactlyOnceWith(undefined, '', `https://chatgpt.com/?cos-plugin-refresh=${id}#settings/Plugins/plugin_asdk_app_synthetic`);
   expect(ask).not.toHaveBeenCalled();
 });
 it('records an already current schema without clicking Refresh and invalidating old chats', async () => {
@@ -77,13 +78,30 @@ it('records an already current schema without clicking Refresh and invalidating 
   expect(h.click).not.toHaveBeenCalled();
   expect(h.ask.mock.calls.map(([message]) => message.action)).toEqual(['current']);
 });
+it('records an already current schema when the workspace exposes no Refresh control', async () => {
+  const h = workflow({ unchanged: true, refreshAvailable: false });
+  expect(await h.run()).toBe(true);
+  expect(h.click).not.toHaveBeenCalled();
+  expect(h.ask.mock.calls.map(([message]) => message.action)).toEqual(['current']);
+});
+it('stops automatic retry when a changed schema has no Refresh control', async () => {
+  const h = workflow({ refreshAvailable: false });
+  expect(await h.run()).toBe(true);
+  expect(h.click).not.toHaveBeenCalled();
+  expect(h.ask.mock.calls.map(([message]) => message.action)).toEqual(['manual']);
+  expect(h.ask.mock.calls[0]?.[0]).toMatchObject({
+    appId: 'asdk_app_synthetic',
+    connectorName: 'Chat On Steroids Core',
+    tools: [{ name: 'read', description: 'Old description.' }]
+  });
+});
 it('opens an enrolled exact App Id directly in marked settings without name discovery', async () => {
   const background = readFileSync(new URL('../extension/background.js', import.meta.url), 'utf8');
   const code = background.slice(background.indexOf('let pluginRefreshFlight = null;'), background.indexOf('async function catalogProbe('));
-  const create = vi.fn();
+  const create = vi.fn(async () => ({ id: 9 }));
   const context = vm.createContext({ URL, setTimeout, clearTimeout, CHATGPT_TAB_URLS: ['https://chatgpt.com/*'],
     call: async () => ({ ok: true, data: { requests: [{ id, appId: 'asdk_app_synthetic', surface: 'core' }] } }), createChatTab: create,
-    chrome: { tabs: { query: async () => [] } }
+    chrome: { storage: { session: { get: async () => ({}), set: async () => {} } }, tabs: { query: async () => [] } }
   });
   vm.runInContext(`${code}\nglobalThis.run = inspectRequestedPluginRefresh;`, context);
   await (context.run as Function)([{ surface: 'core' }], true);
@@ -100,12 +118,12 @@ it('reuses one owned management tab and preserves unreachable helpers and user c
   const code = background.slice(background.indexOf('let pluginRefreshFlight = null;'), background.indexOf('async function catalogProbe('));
   let requests: object[] = [{ id }];
   const tabs = [{ id: 7, url: `https://chatgpt.com/?cos-plugin-refresh=${id}#settings/Plugins` }, { id: 8, url: 'https://chatgpt.com/c/user-conversation' }];
-  const create = vi.fn();
+  const create = vi.fn(async () => ({ id: 9 }));
   const remove = vi.fn();
   const sendMessage = vi.fn(async (): Promise<object> => ({ ok: true }));
   const context = vm.createContext({ URL, setTimeout, clearTimeout, CHATGPT_TAB_URLS: ['https://chatgpt.com/*'],
     call: async () => ({ ok: true, data: { requests } }), createChatTab: create,
-    chrome: { tabs: { query: async () => tabs, get: async (id: number) => tabs.find(tab => tab.id === id), remove, sendMessage } }
+    chrome: { storage: { session: { get: async () => ({}), set: async () => {} } }, tabs: { query: async () => tabs, get: async (id: number) => tabs.find(tab => tab.id === id), remove, sendMessage } }
   });
   vm.runInContext(`${code}\nglobalThis.run = inspectRequestedPluginRefresh;`, context);
   const run = () => (context.run as Function)([{ surface: 'core' }], true);

--- a/test/plugin-refresh.test.ts
+++ b/test/plugin-refresh.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 const wake = vi.hoisted(() => vi.fn());
 vi.mock('../src/main/browser-wake.js', () => ({ wakeBrowserWork: wake }));
 import { initDurableStore, resetDurableForTests, readDurable, writeDurableNow } from '../src/main/durable.js';
-import { claimPluginRefresh, completePluginRefresh, failPluginRefresh, pendingPluginRefreshes, pluginRefreshPublications, publishPluginSurface, resetPluginRefreshForTests, unpublishPluginSurface } from '../src/main/plugin-refresh.js';
+import { claimPluginRefresh, requireManualPluginRefresh, completePluginRefresh, failPluginRefresh, pendingPluginRefreshes, pluginRefreshPublications, publishPluginSurface, resetPluginRefreshForTests, unpublishPluginSurface } from '../src/main/plugin-refresh.js';
 import { makeTempDir, removeTempDir } from './helpers.js';
 import { buildServer } from '../src/main/mcp/tools.js';
 import { defaultConfig } from '../src/main/config.js';
@@ -88,6 +88,19 @@ it('does not settle a changed contract as already current', async () => {
   publish(); const request = (await pendingPluginRefreshes())[0]!;
   expect(await claimPluginRefresh({ ...request, appId, connectorName: 'Chat On Steroids Core', tools: [{ ...tools[0]!, description: 'Old' }], alreadyCurrent: true })).toBe(false);
   expect(await claim(request)).toBe(true);
+});
+it('durably suppresses automatic retries when the provider requires manual recreation', async () => {
+  publish(); const request = (await pendingPluginRefreshes())[0]!;
+  const installed = [{ ...tools[0]!, description: 'Older installed declaration' }];
+  expect(await requireManualPluginRefresh({ ...request, appId, connectorName: 'Chat On Steroids Core', tools: installed, error: 'Recreate the custom app manually.' })).toBe(true);
+  expect(await pendingPluginRefreshes()).toEqual([]);
+  const stored = (await readDurable('plugin-refresh') as any[])[0];
+  expect(stored).toMatchObject({ appId, attempted: false, manual: true, error: 'Recreate the custom app manually.' });
+  expect(stored.completedSchemaId).not.toBe(stored.schemaId);
+  resetPluginRefreshForTests(); publish();
+  expect(await pendingPluginRefreshes()).toEqual([]);
+  publish('2', [{ ...tools[0]!, description: 'Another local schema' }]);
+  expect((await pendingPluginRefreshes())[0]).toMatchObject({ appId });
 });
 it('keeps an exact app mapping and refuses another installed same-name plugin', async () => {
   publish(); const a = (await pendingPluginRefreshes())[0]!;

--- a/test/preload-images.test.ts
+++ b/test/preload-images.test.ts
@@ -1,0 +1,25 @@
+import { expect, it, vi } from 'vitest';
+
+const { invoke, expose, getPath } = vi.hoisted(() => ({
+  invoke: vi.fn(async () => ({ ok: true, data: [] })), expose: vi.fn(), getPath: vi.fn((file: any) => file.path ?? '')
+}));
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: expose },
+  ipcRenderer: { invoke },
+  webUtils: { getPathForFile: getPath }
+}));
+
+it('transports pathless clipboard bytes and disk paths through one bounded image import', async () => {
+  await import('../src/preload/index.js');
+  const api = expose.mock.calls[0]![1];
+  const bytes = new Uint8Array([1, 2, 3]);
+  const arrayBuffer = vi.fn(async () => bytes.buffer);
+  await api.dropFiles([{ name: 'clipboard.png', size: 3, arrayBuffer }, { name: 'disk.png', size: 3, path: '/disk.png' }]);
+  expect(invoke).toHaveBeenCalledWith('sessions:dropFiles', { files: [{ name: 'clipboard.png', bytes }, '/disk.png'] });
+  expect(arrayBuffer).toHaveBeenCalledOnce();
+  invoke.mockClear(); arrayBuffer.mockClear();
+  expect(await api.dropFiles([{ name: 'huge.png', size: 12 * 1024 * 1024 + 1, arrayBuffer }])).toMatchObject({ ok: false });
+  expect(await api.dropFiles(Array(21).fill({ name: 'clipboard.png', size: 3, arrayBuffer }))).toMatchObject({ ok: false });
+  expect(arrayBuffer).not.toHaveBeenCalled();
+  expect(invoke).not.toHaveBeenCalled();
+});

--- a/test/progress-context.test.ts
+++ b/test/progress-context.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { emptyEvidence, runningToolProgress, trackInFlight, type CallContext } from '../src/main/mcp/call-context.js';
+
+const context = (conversationId: string | null): CallContext => ({ startedAt: 1234, transportKey: null, agent: null,
+  caller: { transportKey: null, requestId: null, conversationId }, outcome: null, evidence: emptyEvidence() });
+
+describe('truthful tool wait projection', () => {
+  it('reports exact local work until the handler returns, without charging unrelated or anonymous work', async () => {
+    let release!: () => void;
+    const held = new Promise<void>(resolve => { release = resolve; });
+    const jobs = [context('prime'), context('worker'), context(null)].map(call => trackInFlight(call, () => held));
+    try {
+      expect(runningToolProgress('prime')).toEqual({ count: 1, since: 1234 });
+      expect(runningToolProgress('unrelated')).toBeNull();
+    } finally { release(); await Promise.all(jobs); }
+    expect(runningToolProgress('prime')).toBeNull();
+  });
+});

--- a/test/project-successor.test.ts
+++ b/test/project-successor.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Compact & Resume has to create the replacement chat inside the Project the source chat is in.
+ *
+ * A ChatGPT Project is expressed only in the address. `/g/<project>/c/<id>` is a chat filed
+ * under a Project, and a conversation created from anywhere else is not in it — there is no
+ * parameter, header or later call that moves it. So the successor's URL is the whole mechanism,
+ * and issue #84 is that all three places that build one hardcoded the site root.
+ *
+ * Two details drive most of what is asserted here:
+ *
+ * The slug in a chat's path is not the Project's identity. ChatGPT appends the Project's current
+ * display name to it, so the same Project reads as `g-p-<hex>-example-project` on a chat and
+ * as `g-p-<hex>` on the Project's own page. Carrying the chat's slug across verbatim would build
+ * an address containing a name that a rename invalidates, so only the `g-p-<hex>` head is ever
+ * stored or emitted.
+ *
+ * And the browser is the only thing that can see it, while the app is the only thing that
+ * survives a restart. That is why the Project is observed from the page, written onto the
+ * continuation, and read back from there by the fallback that runs when no page is left.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isAsyncEncryptionAvailable: async () => true,
+    getSelectedStorageBackend: () => 'gnome_libsecret',
+    encryptStringAsync: async (value: string) => Buffer.from(value, 'utf8'),
+    decryptStringAsync: async (buffer: Buffer) => ({ result: buffer.toString('utf8'), shouldReEncrypt: false })
+  },
+  clipboard: { readText: () => '', writeText: () => undefined },
+  shell: { openExternal: async () => undefined }
+}));
+
+const { defaultConfig, initConfigPath, saveConfig } = await import('../src/main/config.js');
+const { commandUrl } = await import('../src/main/bridge.js');
+const {
+  continuationByToken,
+  beginContinuationSourceSendNow,
+  dispatchContinuationSourceSendNow,
+  normalizeProjectId,
+  openContinuationNow,
+  resetContinuationsForTests,
+  restoreContinuations,
+  snapshotContinuations
+} = await import('../src/main/session/continuation.js');
+const { createSession, initSessionStore, resetSessionStoreForTests } = await import('../src/main/session/store.js');
+const { makeTempDir, removeTempDir } = await import('./helpers.js');
+
+let dir: string;
+
+const vm = await import('node:vm');
+const { readFileSync } = await import('node:fs');
+
+const backgroundSource = readFileSync(new URL('../extension/background.js', import.meta.url), 'utf8');
+// The worker is evaluated as a classic script, where an ES import is a parse error. There is
+// none today; strip any that appears rather than failing on a change unrelated to this file,
+// and supply the binding through the context, as test/extension.test.ts does.
+const workerSource = backgroundSource.replace(/^import .*$/gm, '');
+
+
+/** Synthetic identifiers preserving the observed Project route shape. */
+const PROJECT = 'g-p-11111111222233334444555555555555';
+const NAMED_SLUG = 'g-p-11111111222233334444555555555555-example-project';
+const CHAT_IN_PROJECT = 'abababab-1111-4222-8333-444444444444';
+const CHAT_A = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+beforeAll(async () => {
+  dir = await makeTempDir('clf-project-successor-');
+  initConfigPath(dir);
+  initSessionStore(dir);
+  await saveConfig(defaultConfig());
+});
+
+afterAll(async () => {
+  await removeTempDir(dir);
+});
+
+beforeEach(async () => {
+  resetContinuationsForTests();
+  await resetSessionStoreForTests();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('the Project identity carried between a chat and its successor', () => {
+  it('accepts only the routing id, and never the display name appended to it', () => {
+    expect(normalizeProjectId(PROJECT)).toBe(PROJECT);
+    // The form that actually appears in a Project chat's own path. Normalising it is the whole
+    // point: the app stores what `/g/<id>/project` is addressed by, not what a rename can change.
+    expect(normalizeProjectId(NAMED_SLUG)).toBeNull();
+    expect(normalizeProjectId(PROJECT.toUpperCase())).toBe(PROJECT);
+  });
+
+  it.each([
+    ['a custom GPT, which is served from /g/ but is not a Project', 'g-abc123def456'],
+    ['a path segment escape', `${PROJECT}/../../etc`],
+    ['a query smuggled into the id', `${PROJECT}?x=1`],
+    ['too few hex digits', 'g-p-6a93d6fe7f008191be6262248831c7d'],
+    ['too many hex digits', 'g-p-11111111222233334444555555555555a'],
+    ['non-hex characters', 'g-p-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'],
+    ['an empty value', ''],
+    ['a non-string', 42]
+  ])('refuses %s', (_why, value) => {
+    expect(normalizeProjectId(value)).toBeNull();
+  });
+});
+
+describe('the URL the app opens when no page places the chat', () => {
+  it('starts a successor from the Project page so the new chat is created inside it', () => {
+    const url = commandUrl('cmd-1', null, null, PROJECT);
+    expect(url.startsWith(`https://chatgpt.com/g/${PROJECT}/project?`)).toBe(true);
+    // The marker still rides in both places, for the same reason it always did: ChatGPT
+    // rewrites its own query during boot and which of the two survives has changed between
+    // builds. Carrying a Project must not quietly cost the fragment.
+    expect(url).toContain('clf=cmd-1');
+    expect(url.endsWith('#clf=cmd-1')).toBe(true);
+  });
+
+  it('keeps opening at the site root for a chat that is in no Project', () => {
+    expect(commandUrl('cmd-2')).toBe('https://chatgpt.com/?clf=cmd-2#clf=cmd-2');
+    expect(commandUrl('cmd-2', null, null, null)).toBe('https://chatgpt.com/?clf=cmd-2#clf=cmd-2');
+  });
+
+  it('falls back to the root rather than building an address from an unusable value', () => {
+    // Degrading to exactly the old behaviour is the point. A value this app does not recognise
+    // must never become a path, because a wrong Project page is worse than no Project at all.
+    for (const bad of [NAMED_SLUG, 'g-abc123', '../evil', `${PROJECT}/x`, '']) {
+      expect(commandUrl('cmd-3', null, null, bad)).toBe('https://chatgpt.com/?clf=cmd-3#clf=cmd-3');
+    }
+  });
+
+  it('carries a Project alongside a requested model and reasoning level', () => {
+    const url = commandUrl('cmd-4', 'gpt-5.6-sol', 'high', PROJECT);
+    expect(url.startsWith(`https://chatgpt.com/g/${PROJECT}/project?`)).toBe(true);
+    expect(url).toContain('model=gpt-5.6-sol');
+    expect(url).toContain('reasoning_effort=high');
+  });
+});
+
+describe('the Project surviving a restart', () => {
+  it('captures Project scope at source-send admission even when an automatic ticket predates the page', async () => {
+    const session = await createSession({ title: 'Restarted automatic ticket', conversationId: CHAT_A });
+    const opened = await openContinuationNow(session.id, CHAT_A, true);
+    expect(opened.project).toBeNull();
+    expect((await beginContinuationSourceSendNow(opened.token, PROJECT))?.allowed).toBe(true);
+    expect(continuationByToken(opened.token)?.project).toBe(PROJECT);
+    await dispatchContinuationSourceSendNow(opened.token);
+    expect((await beginContinuationSourceSendNow(opened.token, null))?.allowed).toBe(false);
+    const snapshot = snapshotContinuations();
+    resetContinuationsForTests();
+    await restoreContinuations(snapshot);
+    expect(continuationByToken(opened.token)?.project).toBe(PROJECT);
+  });
+
+  it('writes the Project onto the continuation and restores it', async () => {
+    const session = await createSession({ title: 'Compacting inside a Project', conversationId: CHAT_A });
+    const opened = await openContinuationNow(session.id, CHAT_A, false, PROJECT);
+    expect(opened.project).toBe(PROJECT);
+
+    // The process ends here. Nothing in the app's own session record says which Project the
+    // chat is filed under, and the tab that could have said so is gone with the browser.
+    const snapshot = snapshotContinuations();
+    resetContinuationsForTests();
+    expect(continuationByToken(opened.token)).toBeNull();
+
+    await restoreContinuations(snapshot);
+    expect(continuationByToken(opened.token)?.project).toBe(PROJECT);
+    expect(commandUrl('cmd-5', null, null, continuationByToken(opened.token)?.project)).toContain(
+      `/g/${PROJECT}/project?`
+    );
+  });
+
+  it('opens a non-Project chat with no Project, before and after a restart', async () => {
+    const session = await createSession({ title: 'Compacting at the root', conversationId: CHAT_A });
+    const opened = await openContinuationNow(session.id, CHAT_A, false, null);
+    expect(opened.project).toBeNull();
+
+    const snapshot = snapshotContinuations();
+    resetContinuationsForTests();
+    await restoreContinuations(snapshot);
+    expect(continuationByToken(opened.token)?.project).toBeNull();
+  });
+
+  it('reads a record written before Project affinity existed as no Project', async () => {
+    const session = await createSession({ title: 'Older record', conversationId: CHAT_A });
+    const opened = await openContinuationNow(session.id, CHAT_A, false, PROJECT);
+    const snapshot = JSON.parse(JSON.stringify(snapshotContinuations()));
+    // Exactly what an older build wrote: the field is simply not there.
+    for (const entry of snapshot.entries) delete entry.project;
+
+    resetContinuationsForTests();
+    await restoreContinuations(snapshot);
+    // Restored and usable, just without a Project — never dropped, and never a crash.
+    expect(continuationByToken(opened.token)).not.toBeNull();
+    expect(continuationByToken(opened.token)?.project).toBeNull();
+  });
+
+  it('refuses a Project value that a tampered or corrupt record carries', async () => {
+    const session = await createSession({ title: 'Corrupt record', conversationId: CHAT_A });
+    const opened = await openContinuationNow(session.id, CHAT_A, false, PROJECT);
+    const snapshot = JSON.parse(JSON.stringify(snapshotContinuations()));
+    for (const entry of snapshot.entries) entry.project = `${PROJECT}/../../../attacker`;
+
+    resetContinuationsForTests();
+    await restoreContinuations(snapshot);
+    // The continuation is still honoured; only the unusable Project is dropped, which puts the
+    // successor back at the root instead of at an address assembled from a stored string.
+    expect(continuationByToken(opened.token)).not.toBeNull();
+    expect(continuationByToken(opened.token)?.project).toBeNull();
+  });
+
+  it('normalizes at the boundary, so a named slug never reaches a stored record', async () => {
+    const session = await createSession({ title: 'Named slug offered', conversationId: CHAT_A });
+    const opened = await openContinuationNow(session.id, CHAT_A, false, NAMED_SLUG);
+    expect(opened.project).toBeNull();
+  });
+});
+
+/**
+ * The path the reported bug actually takes.
+ *
+ * Compact & Resume names chat A's own conversation on its placement offer, so the successor is
+ * created by the extension in chat A's window — not by the OS opener. Asserted by running the
+ * real service worker and reading the tab it creates, because the whole failure was that a URL
+ * built correctly everywhere else was still built at the root here.
+ */
+describe('the chat the extension creates beside its source', () => {
+  type Created = { id: number; url?: string; pendingUrl?: string; windowId?: number; index?: number };
+  interface Probe {
+    placeSuccessorChat(raw: unknown, tabId: number | null): Promise<void>;
+    projectFromUrl(value: unknown): string | null;
+    successorChatBase(offered: unknown, observed: unknown): string;
+  }
+
+  function worker(home: Created | null) {
+    const created: Created[] = [];
+    const tabs: Created[] = home ? [home] : [];
+    const event = { addListener: () => {} };
+    const store = (saved: Record<string, unknown>) => ({
+      get: async () => ({ ...saved }),
+      set: async (value: object) => { Object.assign(saved, value); },
+      remove: async () => {}
+    });
+    const makeTab = async (options: Created) => {
+      const tab = { ...options, id: 100 + created.length };
+      created.push(tab);
+      return tab;
+    };
+    const context = vm.createContext({
+      chrome: {
+        storage: { local: store({ port: 8765, token: 'test-pairing' }), session: store({}) },
+        windows: {
+          get: async (id: number) => ({ id }),
+          // The minimized window a background worker chat is created in, with its first tab.
+          create: async ({ url }: { url: string }) => ({ id: 80, tabs: [await makeTab({ url, windowId: 80 } as Created)] }),
+          update: () => {}
+        },
+        tabs: {
+          query: async () => [...tabs],
+          get: async (id: number) => {
+            const tab = tabs.find(entry => entry.id === id);
+            if (!tab) throw new Error('no such tab');
+            return tab;
+          },
+          create: makeTab,
+          update: async () => undefined,
+          remove: async () => undefined,
+          sendMessage: async () => ({ ok: true }),
+          onCreated: event, onUpdated: event, onRemoved: event
+        },
+        runtime: { getManifest: () => ({ version: '2.0.6' }), onMessage: event, onInstalled: event, onStartup: event },
+        alarms: { onAlarm: event, create: () => {}, clear: async () => true },
+        scripting: { executeScript: async () => [], insertCSS: async () => {} }
+      },
+      fetch: async () => ({ ok: true, status: 200, json: async () => ({ ok: true }) }),
+      URL, URLSearchParams, AbortController, setTimeout, clearTimeout, TextEncoder, console,
+      browserDriverModule: { installBrowserDriverLifecycle() {}, sweepStaleDrivenGroups: async () => {} }
+    });
+    vm.runInContext(`${workerSource}
+globalThis.probe = { placeSuccessorChat, projectFromUrl, successorChatBase };`, context);
+    return { api: (context as unknown as { probe: Probe }).probe, created };
+  }
+
+  const chatInProject = `https://chatgpt.com/g/${NAMED_SLUG}/c/${CHAT_IN_PROJECT}`;
+  const offer = (extra: Record<string, unknown> = {}) => ({ id: 'cmd-9', model: null, reasoningEffort: null, ...extra });
+
+  it('creates the successor on the Project page when the source chat is in one', async () => {
+    const h = worker({ id: 7, url: chatInProject, windowId: 3, index: 1 });
+    await h.api.placeSuccessorChat(offer({ project: PROJECT }), 7);
+    expect(h.created).toHaveLength(1);
+    expect(h.created[0]!.url!.startsWith(`https://chatgpt.com/g/${PROJECT}/project?`)).toBe(true);
+    expect(h.created[0]!.url).toContain('clf=cmd-9');
+    // Still beside the chat it continues, and still in that chat's own window.
+    expect(h.created[0]!.windowId).toBe(3);
+    expect(h.created[0]!.index).toBe(2);
+  });
+
+  it('does not inherit a Project from the visible tab when the command names none', async () => {
+    // An app that predates the offer field, or a path with no continuation to record it on.
+    const h = worker({ id: 7, url: chatInProject, windowId: 3, index: 0 });
+    await h.api.placeSuccessorChat(offer({ project: null, active: false }), 7);
+    expect(h.created[0]!.url!.startsWith('https://chatgpt.com/?')).toBe(true);
+  });
+
+  it('trusts the app over the tab, because only the app remembers across a restart', async () => {
+    // Chat A has already been navigated away to the root in this tab; the offer is still right.
+    const h = worker({ id: 7, url: 'https://chatgpt.com/', windowId: 3, index: 0 });
+    await h.api.placeSuccessorChat(offer({ project: PROJECT }), 7);
+    expect(h.created[0]!.url!.startsWith(`https://chatgpt.com/g/${PROJECT}/project?`)).toBe(true);
+  });
+
+  it('creates a background worker chat in the Project the app named', async () => {
+    const h = worker(null);
+    await h.api.placeSuccessorChat(offer({ project: PROJECT, background: true }), null);
+    expect(h.created[0]!.url!.startsWith(`https://chatgpt.com/g/${PROJECT}/project?`)).toBe(true);
+  });
+
+  it('leaves a chat outside any Project exactly where it was created before', async () => {
+    const h = worker({ id: 7, url: `https://chatgpt.com/c/${CHAT_IN_PROJECT}`, windowId: 3, index: 0 });
+    await h.api.placeSuccessorChat(offer(), 7);
+    expect(h.created[0]!.url!.startsWith('https://chatgpt.com/?')).toBe(true);
+  });
+
+  it('refuses a named slug and an unrelated /g/ route from either source', () => {
+    // A custom GPT is served from /g/ too and is not a Project.
+    expect(h1(`https://chatgpt.com/g/g-abc123/c/${CHAT_IN_PROJECT}`)).toBeNull();
+    expect(h1(`http://chatgpt.com/g/${NAMED_SLUG}/c/x`)).toBeNull();
+    expect(h1(`https://evil.example/g/${NAMED_SLUG}/c/x`)).toBeNull();
+    expect(h1(chatInProject)).toBe(PROJECT);
+
+    const { api } = worker(null);
+    // The display-name form is refused as an offered value and falls back to what was observed.
+    expect(api.successorChatBase(NAMED_SLUG, chatInProject)).toBe(
+      'https://chatgpt.com/'
+    );
+    expect(api.successorChatBase(NAMED_SLUG, null)).toBe('https://chatgpt.com/');
+  });
+
+  function h1(url: string): string | null {
+    return worker(null).api.projectFromUrl(url);
+  }
+});

--- a/test/renderer-chat-models.test.ts
+++ b/test/renderer-chat-models.test.ts
@@ -6,6 +6,45 @@ import { readFile } from 'node:fs/promises';
 let dom: JSDOM;
 afterEach(() => { dom?.window.close(); vi.unstubAllGlobals(); vi.resetModules(); });
 
+it('opening an empty or pending picker requests models immediately without a separate refresh', async () => {
+  dom = new JSDOM(await readFile('src/renderer/index.html', 'utf8'));
+  vi.stubGlobal('window', dom.window); vi.stubGlobal('document', dom.window.document);
+  const pending = { state: 'pending', requestedAt: 1, observedAt: null, models: [] };
+  const requestChatModels = vi.fn(async () => ({ ok: true, data: pending }));
+  Object.assign(dom.window, { api: { requestChatModels } });
+  const { initChatModels } = await import('../src/renderer/chat-models.js');
+  initChatModels();
+  const menu = dom.window.document.getElementById('modelMenu') as HTMLDetailsElement;
+  menu.open = true;
+  await new Promise(resolve => setTimeout(resolve, 0));
+  expect(requestChatModels).toHaveBeenCalledTimes(1);
+  expect(dom.window.document.getElementById('composerPowerTitle')!.textContent).toBe('Loading models…');
+  menu.open = false;
+  await new Promise(resolve => setTimeout(resolve, 0));
+  menu.open = true;
+  await new Promise(resolve => setTimeout(resolve, 0));
+  expect(requestChatModels).toHaveBeenCalledTimes(2);
+});
+
+it('excludes GPT-5.5 from the composer slider without excluding future observed models or settings choices', async () => {
+  dom = new JSDOM(await readFile('src/renderer/index.html', 'utf8'));
+  vi.stubGlobal('window', dom.window); vi.stubGlobal('document', dom.window.document);
+  const models = [
+    { id: 'old', label: 'GPT-5.5', efforts: ['medium', 'high', 'pro'] },
+    { id: 'sol', label: 'GPT-5.6 Sol', efforts: ['medium', 'high'] },
+    { id: 'future', label: 'GPT-7', efforts: ['high'] }
+  ];
+  Object.assign(dom.window, { api: { getChatModels: async () => ({ ok: true, data: { state: 'ready', requestedAt: 1, observedAt: 2, models } }) } });
+  const { initChatModels, applyChatModels, confirmedComposerModel } = await import('../src/renderer/chat-models.js');
+  initChatModels(); applyChatModels({ multiAgent: {}, goal: {} } as Config); await Promise.resolve();
+  const slider = dom.window.document.querySelector<HTMLInputElement>('#composerPowerChoices input')!;
+  expect(slider.max).toBe('2');
+  expect([...dom.window.document.querySelectorAll<HTMLOptionElement>('#composerModel option')].map(option => option.value)).toEqual(['sol', 'future']);
+  expect([...dom.window.document.querySelectorAll<HTMLOptionElement>('#workerModel option')].some(option => option.value === 'old')).toBe(true);
+  slider.value = '2'; slider.dispatchEvent(new dom.window.Event('input'));
+  expect(confirmedComposerModel()).toEqual({ model: 'future', reasoningEffort: 'high' });
+});
+
 it('binds composer selection to the selected session across delayed catalog, user edits and A-B-A navigation', async () => {
   dom = new JSDOM(await readFile('src/renderer/index.html', 'utf8'));
   vi.stubGlobal('window', dom.window); vi.stubGlobal('document', dom.window.document);
@@ -47,17 +86,17 @@ it('renders the two observed Pro generations separately and sends their exact se
   initChatModels(() => paintContextMeter(null, config, confirmedComposerModel()));
   applyChatModels(config); await Promise.resolve();
   const slider = dom.window.document.querySelector<HTMLInputElement>('#composerPowerChoices input')!;
-  slider.value = '1'; slider.dispatchEvent(new dom.window.Event('input'));
+  slider.value = '2'; slider.dispatchEvent(new dom.window.Event('input'));
   expect(dom.window.document.getElementById('composerModelLabel')!.textContent).toBe('GPT-5.6 Pro');
   expect(confirmedComposerModel()).toEqual({ model: 'gpt-5.6-sol', reasoningEffort: 'pro' });
   expect(dom.window.document.getElementById('contextMeterInfo')!.textContent).toContain('Auto-compaction off for Pro');
-  slider.value = '2'; slider.dispatchEvent(new dom.window.Event('input'));
+  slider.value = '0'; slider.dispatchEvent(new dom.window.Event('input'));
   expect(dom.window.document.getElementById('contextMeterInfo')!.textContent).toContain('Auto-compaction off for Pro');
   expect(dom.window.document.getElementById('contextMeterArc')!.getAttribute('stroke-dasharray')).toBe('0 37.7');
   expect(dom.window.document.getElementById('composerModelLabel')!.textContent).toBe('GPT-6 Pro');
   expect(slider.getAttribute('aria-valuetext')).toBe('GPT-6 Pro');
   expect(confirmedComposerModel()).toEqual({ model: 'gpt-6-pro', reasoningEffort: 'pro' });
-  slider.value = '0'; slider.dispatchEvent(new dom.window.Event('input'));
+  slider.value = '1'; slider.dispatchEvent(new dom.window.Event('input'));
   expect(dom.window.document.getElementById('contextMeterInfo')!.textContent).toMatch(/Auto-compaction at 400[,.]000 tokens/);
 });
 
@@ -75,7 +114,7 @@ it('replaces loading with the backend failure reason and an enabled retry contro
   const config = { multiAgent: {}, goal: {} } as Config;
   applyChatModels(config); await Promise.resolve();
   const retry = dom.window.document.getElementById('refreshComposerModels') as HTMLButtonElement;
-  expect(retry.disabled).toBe(true);
+  expect(retry.disabled).toBe(false);
   getChatModels.mockResolvedValue({ ok: true, data: failed });
   applyChatModels(config); await Promise.resolve();
   expect(retry.disabled).toBe(false); expect(retry.hidden).toBe(false);
@@ -157,7 +196,7 @@ it('offers only observed models, prefers supported GPT-6 High, and replaces a re
   expect([...select('composerReasoning').options].some(option => option.value === 'high')).toBe(false);
 });
 
-it('limits the stepped composer to observed Sol Low upwards and Astra without inventing Pro access', async () => {
+it('keeps observed composer choices in provider order except the user-excluded GPT-5.5 section', async () => {
   dom = new JSDOM(await readFile('src/renderer/index.html', 'utf8'));
   vi.stubGlobal('window', dom.window); vi.stubGlobal('document', dom.window.document);
   const models = [
@@ -177,11 +216,11 @@ it('limits the stepped composer to observed Sol Low upwards and Astra without in
   expect(header.querySelector('#composerPowerTitle')).not.toBeNull();
   expect(header.querySelector('#composerPowerModel')).not.toBeNull();
   expect(header.querySelector('#refreshComposerModels')).not.toBeNull();
-  const expected = [['sol', 'low'], ['sol', 'medium'], ['sol', 'high'], ['astra', 'high']];
+  const expected = [['astra', 'high'], ['sol', 'low'], ['sol', 'medium'], ['sol', 'high']];
   for (const [index, [model, reasoningEffort]] of expected.entries()) {
     slider.value = String(index); slider.dispatchEvent(new dom.window.Event('input'));
     expect(confirmedComposerModel()).toEqual({ model, reasoningEffort });
-    expect(slider.getAttribute('aria-valuetext')).not.toMatch(/Instant|5\.5|Pro|Minimal/);
+    expect(slider.getAttribute('aria-valuetext')).not.toMatch(/Instant|Minimal/);
   }
   expect(doc.querySelector('.power-track')!.getAttribute('style')).toContain('--power-position: 100%');
   const effort = doc.getElementById('composerReasoning') as HTMLSelectElement;

--- a/test/renderer-state.test.ts
+++ b/test/renderer-state.test.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { JSDOM } from 'jsdom';
 import { afterEach, expect, it, vi } from 'vitest';
-import { DEFAULT_GOAL_SYSTEM_PROMPT } from '../src/shared/goal.js';
+import { DEFAULT_GOAL_MODEL, DEFAULT_GOAL_SYSTEM_PROMPT } from '../src/shared/goal.js';
 
 let dom: JSDOM | null = null;
 afterEach(() => {
@@ -313,7 +313,8 @@ interface GoalMount {
 async function mountChat(
   overrides: Record<string, unknown> = {},
   models: any[] = [],
-  apiOverrides: Record<string, (...args: any[]) => any> = {}
+  apiOverrides: Record<string, (...args: any[]) => any> = {},
+  initialGoal: Record<string, unknown> = {}
 ): Promise<GoalMount> {
   const html = await fs.readFile(path.join(process.cwd(), 'src', 'renderer', 'index.html'), 'utf8');
   dom = new JSDOM(html, { url: 'https://local.test/', pretendToBeVisual: true });
@@ -350,7 +351,8 @@ async function mountChat(
       enabled: false,
       model: 'deepseek/deepseek-v4-flash',
       reasoning: 'default' as const,
-      prompt: DEFAULT_GOAL_SYSTEM_PROMPT
+      prompt: DEFAULT_GOAL_SYSTEM_PROMPT,
+      ...initialGoal
     }
   };
   const state: any = {
@@ -419,6 +421,88 @@ async function mountChat(
 }
 
 const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+it('attaches pasted screenshot files with previews while preserving ordinary text paste', async () => {
+  const dropFiles = vi.fn(async () => ({ ok: true, data: [{ id: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee', name: 'screenshot.png', size: 4, mimeType: 'image/png', preview: 'data:image/webp;base64,AAAA' }] }));
+  const mounted = await mountChat({}, [], { dropFiles });
+  const w = mounted.window, input = w.document.getElementById('chatInput')!;
+  const file = new w.File(['image'], 'screenshot.png', { type: 'image/png' });
+  const paste = new w.Event('paste', { bubbles: true, cancelable: true });
+  Object.defineProperty(paste, 'clipboardData', { value: { files: [file] } });
+  input.dispatchEvent(paste);
+  await vi.waitFor(() => expect(dropFiles).toHaveBeenCalledWith([file]));
+  expect(paste.defaultPrevented).toBe(true);
+  await vi.waitFor(() => expect(w.document.querySelector('img[src="data:image/webp;base64,AAAA"]')).not.toBeNull());
+  const text = new w.Event('paste', { bubbles: true, cancelable: true });
+  Object.defineProperty(text, 'clipboardData', { value: { files: [] } });
+  input.dispatchEvent(text);
+  expect(text.defaultPrevented).toBe(false);
+  const overflow = new w.Event('paste', { bubbles: true, cancelable: true });
+  Object.defineProperty(overflow, 'clipboardData', { value: { files: Array(20).fill(file) } });
+  input.dispatchEvent(overflow);
+  expect(overflow.defaultPrevented).toBe(true);
+  expect(dropFiles).toHaveBeenCalledTimes(1);
+});
+
+it('preserves the selected OpenRouter model through an unchanged custom-provider round trip', async () => {
+  const mounted = await mountChat();
+  const w = mounted.window;
+  const original = 'z-ai/glm-5.3-flash';
+  mounted.state.config.goal = { ...mounted.state.config.goal, model: original, provider: { kind: 'openrouter', baseUrl: '' } };
+  mounted.push(mounted.state);
+  const provider = w.document.getElementById('goalProvider') as HTMLSelectElement;
+  provider.value = 'custom'; provider.dispatchEvent(new w.Event('change', { bubbles: true }));
+  await vi.waitFor(() => expect(mounted.calls).toHaveLength(1));
+  // Repainting custom settings must not replace the hidden OpenRouter picker's model.
+  mounted.push({ ...mounted.state, hasCustomProviderKey: false });
+  provider.value = 'openrouter'; provider.dispatchEvent(new w.Event('change', { bubbles: true }));
+  await vi.waitFor(() => expect(mounted.calls).toHaveLength(2));
+  expect(mounted.calls[1].goal).toMatchObject({ provider: { kind: 'openrouter' }, model: original });
+  expect(w.document.getElementById('goalModelName')!.textContent).toBe(original);
+});
+
+it('uses the OpenRouter default when opened directly on an unrelated custom deployment', async () => {
+  const mounted = await mountChat({}, [], {}, { model: 'llama3.1', provider: { kind: 'custom', baseUrl: 'http://localhost:8000/v1' } });
+  const provider = mounted.window.document.getElementById('goalProvider') as HTMLSelectElement;
+  provider.value = 'openrouter';
+  provider.dispatchEvent(new mounted.window.Event('change', { bubbles: true }));
+  await vi.waitFor(() => expect(mounted.calls).toHaveLength(1));
+  expect(mounted.calls[0].goal).toMatchObject({ provider: { kind: 'openrouter' }, model: DEFAULT_GOAL_MODEL });
+});
+
+it('saves a custom deployment id and returns to the known OpenRouter model', async () => {
+  const mounted = await mountChat();
+  const w = mounted.window;
+  const provider = w.document.getElementById('goalProvider') as HTMLSelectElement;
+  provider.value = 'custom';
+  provider.dispatchEvent(new w.Event('change', { bubbles: true }));
+  await vi.waitFor(() => expect(mounted.calls).toHaveLength(1));
+  expect(mounted.calls[0].goal.provider.kind).toBe('custom');
+  expect(w.document.getElementById('goalCustomPanel')?.hidden).toBe(false);
+  const model = w.document.getElementById('goalCustomModel') as HTMLInputElement;
+  model.value = 'llama3.1';
+  model.dispatchEvent(new w.Event('change', { bubbles: true }));
+  await vi.waitFor(() => expect(mounted.calls).toHaveLength(2));
+  expect(mounted.calls[1].goal.model).toBe('llama3.1');
+  provider.value = 'openrouter';
+  provider.dispatchEvent(new w.Event('change', { bubbles: true }));
+  await vi.waitFor(() => expect(mounted.calls).toHaveLength(3));
+  expect(mounted.calls[2].goal).toMatchObject({ provider: { kind: 'openrouter' }, model: 'deepseek/deepseek-v4-flash' });
+});
+
+it('saves the ChatGPT browser choice from its settings control and restores it on state push', async () => {
+  const mounted = await mountChat();
+  const w = mounted.window;
+  const browser = w.document.getElementById('chatBrowser') as HTMLSelectElement;
+  expect(browser.value).toBe('chrome'); // older config has no field
+  browser.value = 'edge';
+  browser.dispatchEvent(new w.Event('change', { bubbles: true }));
+  await vi.waitFor(() => expect(mounted.calls).toHaveLength(1));
+  expect(mounted.calls[0].ui.chatBrowser).toBe('edge');
+  expect(browser.value).toBe('edge');
+  mounted.push({ ...mounted.state, config: { ...mounted.state.config, ui: { ...mounted.state.config.ui, chatBrowser: 'chrome' } } });
+  expect(browser.value).toBe('chrome');
+});
 
 it('preserves native Desktop permissions when saving unrelated settings on Linux', async () => {
   const mounted = await mountChat({

--- a/test/renderer-timeline.test.ts
+++ b/test/renderer-timeline.test.ts
@@ -347,11 +347,11 @@ it('shows original user text while retaining transport instructions outside the 
   expect(w.document.body.textContent).toContain('hello');
 });
 
-it('appends dropped images to the originating composer draft and caps attachments', async () => {
+it('appends dropped files to the originating composer draft and caps attachments', async () => {
   const { w } = await boot([], false);
   const api = (w as any).api;
-  const image = { name: 'dropped.webp', dataUrl: 'data:image/webp;base64,YQ==' };
-  api.dropImages = vi.fn(async () => ({ ok: true, data: [image] }));
+  const image = { id: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee', name: 'dropped.md', size: 12, mimeType: 'text/markdown' };
+  api.dropFiles = vi.fn(async () => ({ ok: true, data: [image] }));
   const composer = w.document.getElementById('composer')!;
   const drop = (count: number) => {
     const event = new w.Event('drop', { bubbles: true, cancelable: true });
@@ -361,11 +361,12 @@ it('appends dropped images to the originating composer draft and caps attachment
   };
   expect(drop(1).defaultPrevented).toBe(true);
   await settle();
-  expect(w.document.querySelectorAll('#composerImages img')).toHaveLength(1);
-  drop(4);
+  expect(w.document.querySelectorAll('#composerImages .attachment-card')).toHaveLength(1);
+  expect(w.document.getElementById('composerImages')!.textContent).toContain('dropped.md');
+  drop(20);
   await settle();
-  expect(api.dropImages).toHaveBeenCalledTimes(1);
-  expect(w.document.querySelectorAll('#composerImages img')).toHaveLength(1);
+  expect(api.dropFiles).toHaveBeenCalledTimes(1);
+  expect(w.document.querySelectorAll('#composerImages .attachment-card')).toHaveLength(1);
 });
 
 it('Share a folder creates a sidebar project and keeps it when an older list refresh finishes', async () => {
@@ -886,6 +887,10 @@ it('keeps editable stages until the composer sends the first stage exactly once'
   await settle();
   expect(live.sent).toHaveLength(1);
   expect(live.sent[0]).toMatchObject({ text: 'Build the edited foundation', stages: ['Verify it'] });
+  expect(w.document.getElementById('taskPlanPreview')!.hidden).toBe(true);
+  expect(w.document.getElementById('finishQueue')!.hidden).toBe(false);
+  expect(w.document.getElementById('finishQueue')!.textContent).toContain('Verify it');
+  expect(w.document.querySelector('[aria-label="Plan stage · waiting for the first message to be sent"]')).not.toBeNull();
 });
 
 it('disables empty task actions and confirms saving without the old helper sentence', async () => {

--- a/test/renderer-usage.test.ts
+++ b/test/renderer-usage.test.ts
@@ -57,3 +57,26 @@ it('edits the canonical formula controls and per-model rates without reloading r
   expect(field('usageDivisor').value).toBe('4'); expect(field('usageMultiplier').value).toBe('1');
   expect(cost()).toContain('0.70');
 });
+
+it('shows the Sol picker alias rate and preserves an explicitly cleared rate after reload', async () => {
+  dom = new JSDOM(readFileSync(new URL('../src/renderer/index.html', import.meta.url), 'utf8'), { url: 'https://local.test/' });
+  vi.stubGlobal('window', dom.window); vi.stubGlobal('document', dom.window.document); vi.stubGlobal('localStorage', dom.window.localStorage);
+  const models = [{ model: 'gpt-5-6-thinking', reasoningEffort: 'high', assumed: false, tokens: 427245 }];
+  const data: UsageOverview = { tokens: 427245, models, days: [{ date: '2026-09-07', tokens: 427245, models }], sessions: 1, limits: [] };
+  const getUsage = vi.fn(async () => ({ ok: true, data }));
+  Object.assign(dom.window, { api: { getUsage, getChatModels: async () => ({ ok: true, data: { models: [] } }) } });
+  const usage = await import('../src/renderer/usage.js');
+  usage.initUsage(); await usage.refreshUsage();
+  const rate = () => dom.window.document.querySelector('input[aria-label="gpt-5-6-thinking cached-input USD per million tokens"]') as HTMLInputElement;
+  expect(rate().value).toBe('0.4');
+  expect(dom.window.document.getElementById('usageTotalCost')!.textContent).toContain('0.21');
+  expect(dom.window.document.getElementById('usageDays')!.textContent).not.toContain('Rate unknown');
+  rate().value = ''; rate().dispatchEvent(new dom.window.Event('input'));
+  expect(getUsage).toHaveBeenCalledTimes(1);
+  expect(dom.window.document.getElementById('usageDays')!.textContent).toContain('Rate unknown');
+  vi.resetModules();
+  const restored = await import('../src/renderer/usage.js');
+  restored.initUsage(); await restored.refreshUsage();
+  expect(rate().value).toBe('');
+  expect(dom.window.document.getElementById('usageDays')!.textContent).toContain('Rate unknown');
+});

--- a/test/resume.test.ts
+++ b/test/resume.test.ts
@@ -240,7 +240,7 @@ describe('the whole move, when it works', () => {
     const stored = await capture(continuation);
     expect(pendingCommands()).toHaveLength(1);
     // Handed to A's browser, not to the OS — and exactly one chat either way.
-    expect(stored.body.placement).toEqual({ id: pendingCommands()[0]!.id, model: null, reasoningEffort: null });
+    expect(stored.body.placement).toEqual({ id: pendingCommands()[0]!.id, model: null, reasoningEffort: null, active: true, homeConversationId: CHAT_A, project: null });
     expect(opened).toHaveLength(0);
   });
 });

--- a/test/session-finish.test.ts
+++ b/test/session-finish.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
+import { TaskRequestError } from '../src/main/task-request.js';
 const hooks = vi.hoisted(() => ({ caller: { sessionId: '', conversationId: '' }, startedAt: 2000, followup: vi.fn(), enqueue: vi.fn(), hasInput: true, delivered: [] as Array<{ id: string; sessionId: string; text: string; state: string }>, inputListeners: new Set<() => void>() }));
 vi.mock('../src/main/session/input.js', () => ({
   hasEligibleToolInput: async () => hooks.hasInput,
@@ -15,6 +16,7 @@ vi.mock('../src/main/mcp/call-context.js', async (importOriginal) => ({
 }));
 const { defaultConfig, initConfigPath, saveConfig } = await import('../src/main/config.js');
 const { initSessionStore, createSession, getSession, rebindSession, appendEvent, readRecentEvents, flushSessions, resetSessionStoreForTests, observeSessionModel } = await import('../src/main/session/store.js');
+const { resetRecorderForTests } = await import('../src/main/session/recorder.js');
 const { announceSessionFinish: announceTransport, settleSessionFinishForTests, requestSessionFinishGoal, sessionFinishWaiting, setFinishNotifier, releaseSessionFinish, sessionFinishHeld } = await import('../src/main/session/finish.js');
 const { makeTempDir, removeTempDir } = await import('./helpers.js');
 async function announceSessionFinish(sessionId: string, summary: string): Promise<string> {
@@ -42,9 +44,54 @@ beforeEach(async () => {
   hooks.caller = { sessionId, conversationId }; hooks.startedAt = 2000;
   await appendEvent(sessionId, { source: 'extension', kind: 'turn_start', turnId: 'turn-one', time: 1000 });
 });
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  vi.useRealTimers(); vi.restoreAllMocks();
+  // Switching clocks discards fake timers, but the recorder still owns its pending
+  // notification handle. Clear that owner too or later End turn notifications never fire.
+  resetRecorderForTests();
+});
 afterAll(async () => { setFinishNotifier(null); resetSessionStoreForTests(); await removeTempDir(directory); });
 describe('session finish turn identity', () => {
+  it('keeps one Goal operation through transient retries and queues its eventual result once', async () => {
+    let fail!: (error: Error) => void;
+    hooks.followup.mockImplementationOnce(() => new Promise((_resolve, reject) => { fail = reject; }));
+    await announceTransport(sessionId, 'Ready');
+    await vi.waitFor(() => expect(fail).toBeTypeOf('function'));
+    vi.useFakeTimers();
+    fail(new TaskRequestError('rate_limited: busy', true));
+    await vi.advanceTimersByTimeAsync(0);
+    await announceTransport(sessionId, 'Still waiting');
+    await vi.advanceTimersByTimeAsync(14999);
+    expect(hooks.followup).toHaveBeenCalledTimes(1);
+    expect(hooks.enqueue).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    vi.useRealTimers();
+    await settleSessionFinishForTests();
+    expect(hooks.followup).toHaveBeenCalledTimes(2);
+    expect(hooks.enqueue).toHaveBeenCalledTimes(1);
+    expect(hooks.enqueue).toHaveBeenCalledWith(expect.objectContaining({ sessionId, mode: 'auto', text: 'Check the remaining requirement' }),
+      { turnId: 'turn-one', periodic: false });
+    await announceSessionFinish(sessionId, 'Again');
+    expect(hooks.followup).toHaveBeenCalledTimes(2);
+  });
+  it.each(['new input', 'turn release'])('cancels a pending Goal retry on %s', async reason => {
+    let fail!: (error: Error) => void;
+    hooks.followup.mockImplementationOnce(() => new Promise((_resolve, reject) => { fail = reject; }));
+    await announceTransport(sessionId, 'Ready');
+    await vi.waitFor(() => expect(fail).toBeTypeOf('function'));
+    vi.useFakeTimers();
+    fail(new TaskRequestError('http_503: busy', true));
+    await vi.advanceTimersByTimeAsync(0);
+    if (reason === 'new input') {
+      hooks.delivered.push({ id: 'new-user-work', sessionId, text: 'Changed instructions', state: 'sent' });
+      for (const listener of hooks.inputListeners) listener();
+    } else await releaseSessionFinish(sessionId, 'turn-one');
+    vi.useRealTimers();
+    await settleSessionFinishForTests();
+    expect(hooks.followup).toHaveBeenCalledTimes(1);
+    expect(hooks.enqueue).not.toHaveBeenCalled();
+    expect(hooks.inputListeners.size).toBe(0);
+  });
   it('uses the armed Astra switch as Loop at finish and suppresses Notify', async () => {
     await observeSessionModel(sessionId, hooks.caller.conversationId, 'gpt-6-pro', Date.now());
     await saveConfig({ ...defaultConfig(), ui: { ...defaultConfig().ui, finishTool: true, finishAction: 'notify' } });
@@ -242,9 +289,13 @@ describe('session finish turn identity', () => {
   });
   it('releases durably, wakes a waiting call and does not release the next turn', async () => {
     hooks.hasInput = false;
-    const result = announceSessionFinish(sessionId, 'Waiting');
+    const released = vi.fn();
+    const result = announceSessionFinish(sessionId, 'Waiting').then(value => { released(); return value; });
     await vi.waitFor(() => expect(hooks.inputListeners.size).toBe(1));
     await releaseSessionFinish(sessionId, 'turn-one');
+    // A real recorder notification must wake this call; the 25-second transport
+    // deadline used to mask a leaked fake notification timer from an earlier test.
+    await vi.waitFor(() => expect(released).toHaveBeenCalledOnce(), { timeout: 2000 });
     expect(await result).toContain('RELEASED:');
     await flushSessions(); resetSessionStoreForTests(); initSessionStore(directory);
     expect(await sessionFinishHeld(sessionId, 'turn-one', hooks.caller.conversationId)).toBe(false);

--- a/test/session-input-attachments-audit.test.ts
+++ b/test/session-input-attachments-audit.test.ts
@@ -1,0 +1,38 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+const storage = vi.hoisted(() => ({ root: '' }));
+vi.mock('../src/main/session/store.js', () => ({ sessionsRoot: () => storage.root }));
+import { stageInputAttachment } from '../src/main/session/input-attachments.js';
+
+let directory: string;
+beforeEach(async () => {
+  directory = await fs.mkdtemp(path.join(os.tmpdir(), 'cos-attachment-audit-'));
+  storage.root = path.join(directory, 'sessions');
+});
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(directory, { recursive: true, force: true });
+});
+
+it('applies the staging quota atomically across concurrent picker/drop calls', async () => {
+  const staged = path.join(directory, 'input-attachments');
+  await fs.mkdir(staged);
+  const sentinel = path.join(staged, 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee');
+  await fs.writeFile(sentinel, 'quota fixture');
+  // Simulate a nearly full store without allocating gigabytes on the test host.
+  const stat = fs.stat.bind(fs);
+  vi.spyOn(fs, 'stat').mockImplementation((async (file: any, options?: any) => {
+    const result = await stat(file, options);
+    if (String(file) === sentinel) return Object.assign(result, { size: 2 * 1024 * 1024 * 1024 - 10 });
+    return result;
+  }) as typeof fs.stat);
+  const outcomes = await Promise.allSettled([
+    stageInputAttachment({ text: '0123456789' }, new Set()),
+    stageInputAttachment({ text: 'abcdefghij' }, new Set())
+  ]);
+  expect(outcomes.filter(row => row.status === 'fulfilled')).toHaveLength(1);
+  expect(outcomes.filter(row => row.status === 'rejected')).toHaveLength(1);
+});

--- a/test/session-input-attachments.test.ts
+++ b/test/session-input-attachments.test.ts
@@ -1,0 +1,47 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, expect, it } from 'vitest';
+import { makeTempDir, removeTempDir } from './helpers.js';
+import { initSessionStore } from '../src/main/session/store.js';
+import { stageInputAttachment, validateInputAttachments, readInputAttachmentChunk, ATTACHMENT_CHUNK_BYTES, MAX_ATTACHMENT_BYTES } from '../src/main/session/input-attachments.js';
+let directory: string;
+beforeEach(async () => { directory = await makeTempDir('cos-attachments-'); initSessionStore(directory); });
+afterEach(async () => { await removeTempDir(directory); });
+it('snapshots arbitrary file bytes across chunks without exposing the source path', async () => {
+  const original = Buffer.alloc(ATTACHMENT_CHUNK_BYTES + 19, 173);
+  const source = path.join(directory, 'notes.md'); await fs.writeFile(source, original);
+  const file = await stageInputAttachment(source, new Set());
+  await fs.writeFile(source, 'later user edit');
+  expect(file).toMatchObject({ name: 'notes.md', size: original.length, mimeType: 'text/markdown' });
+  expect(JSON.stringify(file)).not.toContain(directory);
+  await validateInputAttachments([file]);
+  const chunks = await Promise.all([0, ATTACHMENT_CHUNK_BYTES].map(offset => readInputAttachmentChunk(file, offset)));
+  expect(Buffer.concat(chunks.map(chunk => Buffer.from(chunk, 'base64')))).toEqual(original);
+  await expect(readInputAttachmentChunk(file, 1)).rejects.toThrow('offset');
+  await expect(validateInputAttachments([{ ...file, name: 'spoof.pdf' }])).rejects.toThrow('changed');
+});
+it('keeps dropped Unicode text exact and permits empty native files', async () => {
+  const text = 'Text\n中文 — ä 🎈';
+  const file = await stageInputAttachment({ text }, new Set());
+  expect(Buffer.from(await readInputAttachmentChunk(file, 0), 'base64').toString()).toBe(text);
+  const empty = await stageInputAttachment({ text: '' }, new Set());
+  expect(empty.size).toBe(0); await validateInputAttachments([empty]);
+});
+it('rejects folders, traversal IDs, oversized files and oversized messages', async () => {
+  await expect(stageInputAttachment(directory, new Set())).rejects.toThrow('folders');
+  const source = path.join(directory, 'big.bin');
+  const handle = await fs.open(source, 'w'); await handle.truncate(MAX_ATTACHMENT_BYTES + 1); await handle.close();
+  await expect(stageInputAttachment(source, new Set())).rejects.toThrow('512 MB');
+  const file = await stageInputAttachment({ text: 'x' }, new Set());
+  await expect(validateInputAttachments([{ ...file, id: '../config' }])).rejects.toThrow();
+  await expect(validateInputAttachments(Array(21).fill(file))).rejects.toThrow('20 files');
+});
+it('prunes only expired unreferenced staging while durable input members survive', async () => {
+  const keep = await stageInputAttachment({ text: 'keep' }, new Set());
+  const discard = await stageInputAttachment({ text: 'discard' }, new Set());
+  const old = new Date(Date.now() - 48 * 3600000);
+  for (const file of [keep, discard]) await fs.utimes(path.join(directory, 'input-attachments', file.id), old, old);
+  await stageInputAttachment({ text: 'new' }, new Set([keep.id]));
+  await validateInputAttachments([keep]);
+  await expect(validateInputAttachments([discard])).rejects.toThrow();
+});

--- a/test/session-input-images.test.ts
+++ b/test/session-input-images.test.ts
@@ -3,36 +3,39 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import sharp from 'sharp';
-import { prepareInputImage, validateInputImages } from '../src/main/session/input-images.js';
+import { validateInputImages } from '../src/main/session/input-images.js';
+import { stageInputAttachment, readInputAttachmentChunk } from '../src/main/session/input-attachments.js';
+import { initSessionStore } from '../src/main/session/store.js';
 
 let directory: string;
-beforeEach(async () => { directory = await fs.mkdtemp(path.join(os.tmpdir(), 'cos-input-images-')); });
+beforeEach(async () => { directory = await fs.mkdtemp(path.join(os.tmpdir(), 'cos-input-images-')); initSessionStore(directory); });
 afterEach(async () => { await fs.rm(directory, { recursive: true, force: true }); });
 const dataUrl = (buffer: Buffer) => `data:image/webp;base64,${buffer.toString('base64')}`;
 describe('input image byte and pixel validation', () => {
-  it('normalizes a real image to bounded WebP with a basename-only attachment name', async () => {
+  it('preserves original image bytes and creates a separate bounded thumbnail', async () => {
     const file = path.join(directory, 'example.png');
     await sharp({ create: { width: 2000, height: 1000, channels: 3, background: '#123456' } }).png().toFile(file);
-    const image = await prepareInputImage(file);
-    expect(image.name).toBe('example.webp');
-    expect(image.dataUrl).toMatch(/^data:image\/webp;base64,/);
-    const metadata = await sharp(Buffer.from(image.dataUrl.split(',')[1]!, 'base64')).metadata();
-    expect(metadata).toMatchObject({ format: 'webp', width: 1600, height: 800 });
-    await expect(validateInputImages([image])).resolves.toBeUndefined();
+    const image = await stageInputAttachment(file, new Set());
+    expect(image.name).toBe('example.png');
+    expect(image.preview).toMatch(/^data:image\/webp;base64,/);
+    const metadata = await sharp(Buffer.from(image.preview!.split(',')[1]!, 'base64')).metadata();
+    expect(metadata).toMatchObject({ format: 'webp', width: 160, height: 80 });
+    expect(Buffer.from(await readInputAttachmentChunk(image, 0), 'base64')).toEqual(await fs.readFile(file));
   });
 
-  it('rejects oversized source files and directories before decoding', async () => {
+  it('rejects oversized source files and directories before staging', async () => {
     const file = path.join(directory, 'too-big.webp');
     await fs.writeFile(file, '');
-    await fs.truncate(file, 12 * 1024 * 1024 + 1);
-    await expect(prepareInputImage(file)).rejects.toThrow(/12 MB/);
-    await expect(prepareInputImage(directory)).rejects.toThrow(/12 MB/);
+    await fs.truncate(file, 512 * 1024 * 1024 + 1);
+    await expect(stageInputAttachment(file, new Set())).rejects.toThrow(/512 MB/);
+    await expect(stageInputAttachment(directory, new Set())).rejects.toThrow(/folders/);
   });
 
   it('rejects invalid source bytes and forged WebP MIME labels', async () => {
     const file = path.join(directory, 'invalid.png');
     await fs.writeFile(file, 'not an image');
-    await expect(prepareInputImage(file)).rejects.toThrow();
+    const staged = await stageInputAttachment(file, new Set());
+    expect(staged.preview).toBeUndefined(); // ChatGPT, not a thumbnail decoder, decides file support.
     const png = await sharp({ create: { width: 2, height: 2, channels: 3, background: '#fff' } }).png().toBuffer();
     await expect(validateInputImages([{ name: 'forged.webp', dataUrl: dataUrl(png) }])).rejects.toThrow(/Invalid image/);
     await expect(validateInputImages([{ name: 'invalid.webp', dataUrl: dataUrl(Buffer.from('invalid')) }])).rejects.toThrow();

--- a/test/session-list-refresh.test.ts
+++ b/test/session-list-refresh.test.ts
@@ -134,7 +134,7 @@ const note = (seq: number, text: string): SessionEvent => ({
 });
 
 describe('visible Chat refresh', () => {
-  it('uses the detail cursor after the initial bounded tail instead of resending that tail', async () => {
+  it.each([false, true])('uses the detail cursor without starving slow refreshes under continuous events (%s)', async streaming => {
     const html = await fs.readFile(path.join(process.cwd(), 'src', 'renderer', 'index.html'), 'utf8');
     dom = new JSDOM(html, { url: 'https://local.test/', pretendToBeVisual: true });
     const w = dom.window;
@@ -156,17 +156,20 @@ describe('visible Chat refresh', () => {
     let changed: () => void = () => undefined;
     const detailCalls: Array<{ id: string; options: any }> = [];
     let detailRound = 0;
+    let listDelay = 0;
     const ok = (data: any) => Promise.resolve({ ok: true as const, data });
     const api: any = new Proxy(
       {
-        listSessions: () =>
-          ok({
+        listSessions: async () => {
+          if (listDelay) await new Promise(resolve => setTimeout(resolve, listDelay));
+          return ok({
             sessions: [selected],
             activeId: selected.id,
             pressure: [],
             total: 1,
             nextCursor: null
-          }),
+          });
+        },
         getSession: (id: string, options?: any) => {
           detailCalls.push({ id, options });
           detailRound += 1;
@@ -202,9 +205,12 @@ describe('visible Chat refresh', () => {
     await vi.waitFor(() => expect(detailCalls).toHaveLength(1));
     expect(detailCalls[0]).toEqual({ id: selected.id, options: { limit: 160 } });
 
-    changed();
-    await new Promise((resolve) => setTimeout(resolve, 450));
-    await vi.waitFor(() => expect(detailCalls).toHaveLength(2));
+    listDelay = streaming ? 600 : 0;
+    const stream = streaming ? setInterval(changed, 100) : undefined;
+    try {
+      changed();
+      await vi.waitFor(() => expect(detailCalls).toHaveLength(2), { timeout: 1600 });
+    } finally { clearInterval(stream); }
     expect(detailCalls[1]).toEqual({ id: selected.id, options: { from: 101, limit: 160 } });
     expect(w.document.getElementById('timeline')?.textContent).toContain('initial');
     expect(w.document.getElementById('timeline')?.textContent).toContain('delta');

--- a/test/session-usage.test.ts
+++ b/test/session-usage.test.ts
@@ -201,11 +201,24 @@ describe('model attribution and equivalent cost', () => {
     expect(usageEstimate(rows, { divisor: 4, multiplier: 1, rates: { a: 0, b: 1 } })).toEqual({ tokens: 2e6, cost: 1, unpricedTokens: 0.5e6 });
     expect(rows[0]!.tokens).toBe(1e6);
   });
+  it('prices the recorded Sol picker ID without changing its identity or overriding saved rates', async () => {
+    const { DEFAULT_USAGE_FORMULA, usageEstimate } = await import('../src/shared/usage.js');
+    const rows = [{ model: 'gpt-5-6-thinking', reasoningEffort: 'high', assumed: false, tokens: 427245 }];
+    expect(usageEstimate(rows, DEFAULT_USAGE_FORMULA)).toEqual({ tokens: 427245, cost: 0.2050776, unpricedTokens: 0 });
+    for (const rate of [null, 0, 0.8]) {
+      const estimate = usageEstimate(rows, { ...DEFAULT_USAGE_FORMULA, rates: { ...DEFAULT_USAGE_FORMULA.rates, 'gpt-5-6-thinking': rate } });
+      expect(estimate.unpricedTokens).toBe(rate === null ? 427245 : 0);
+      expect(estimate.cost).toBeCloseTo(rate === null ? 0 : 427245 / 1e6 * rate * 1.2);
+    }
+    expect(usageEstimate(rows, { ...DEFAULT_USAGE_FORMULA, rates: { 'gpt-5.6-sol': 0.8 } }).cost).toBeCloseTo(0.4101552);
+    expect(usageEstimate([{ ...rows[0]!, model: 'gpt-5-6-thinking-unknown' }], DEFAULT_USAGE_FORMULA).unpricedTokens).toBe(427245);
+    expect(rows[0]!.model).toBe('gpt-5-6-thinking');
+  });
   it('prices the verified ChatGPT GPT-6 Pro alias at the Astra cached-input comparison rate', async () => {
     const { DEFAULT_USAGE_FORMULA, usageEstimate } = await import('../src/shared/usage.js');
-    const rows = ['gpt-5.6', 'gpt-5.6-sol', 'gpt-6-astra', 'gpt-5.5', 'gpt-6-pro'].map(model => ({ model, reasoningEffort: 'high', assumed: false, tokens: 1e6 }));
+    const rows = ['gpt-5.6', 'gpt-5.6-sol', 'gpt-6-astra', 'gpt-5.5', 'gpt-6-pro', 'gpt-5.6-terra', 'gpt-5.6-luna'].map(model => ({ model, reasoningEffort: 'high', assumed: false, tokens: 1e6 }));
     const estimate = usageEstimate(rows, DEFAULT_USAGE_FORMULA);
-    expect(estimate).toMatchObject({ tokens: 5e6, unpricedTokens: 0 });
-    expect(estimate.cost).toBeCloseTo(3.96);
+    expect(estimate).toMatchObject({ tokens: 7e6, unpricedTokens: 0 });
+    expect(estimate.cost).toBeCloseTo(4.224);
   });
 });

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -1782,6 +1782,50 @@ describe('handoff storage', () => {
 // ---------------------------------------------------------------- recorder
 
 describe('canonical recorder 1.8', () => {
+  it('counts a full tool result after rebind while keeping its recorder preview bounded', async () => {
+    const config = defaultConfig();
+    await saveConfig({ ...config, compaction: { ...config.compaction, auto: true, autoTokens: 10000 } });
+    try {
+      const source = 'conv-fulltext-source';
+      const destination = 'conv-fulltext-destination';
+      const opened = await recordChatObservations(source, [{ kind: 'user_message', time: Date.now(),
+        messageId: 'old-large-context', text: 'x'.repeat(50000) }]);
+      const sessionId = opened.sessionId!;
+      expect(await rebindSession(sessionId, source, destination)).toBe(true);
+      rebindConversation(sessionId, source, destination);
+      const requestId = 'wfr-fulltext-result';
+      await recordChatObservations(destination, [
+        { kind: 'user_message', time: Date.now(), messageId: 'new-handoff', text: 'h'.repeat(13237) },
+        { kind: 'tool_evidence', time: Date.now(), calls: [{ messageId: 'fulltext-call', requestId,
+          tool: 'read', order: 0, answered: false }] }
+      ]);
+      const before = (await getSession(sessionId))!;
+      const args = { paths: ['a.ts', 'b.ts', 'c.ts'] };
+      const result = 'r'.repeat(60306);
+      const call = await recordToolCall({ tool: 'read', args, content: [{ type: 'text', text: result }],
+        outcome: 'ok', durationMs: 1, startedAt: Date.now(), requestId });
+      expect(call?.result).toMatchObject({ truncated: true, chars: result.length });
+      expect(call!.result.text.length).toBeLessThan(8200);
+      expect((await readAsset(sessionId, call!.result.assetId!))?.toString('utf8')).toBe(result);
+      const expected = estimateTokens(JSON.stringify(args)) + estimateTokens(result) + estimateTokens(call!.summary.title);
+      const after = (await getSession(sessionId))!;
+      expect(after.estimatedTokens - before.estimatedTokens).toBe(expected);
+      expect(after.contextTokens).toBe(estimateTokens('h'.repeat(13237)) + expected);
+      expect(autoCompactionReady(after)).toBe(true);
+    } finally { await enableRecording(); }
+  });
+
+  it('replaces a canonical truncated message contribution with its new full length once', async () => {
+    const opened = await createSession({ title: 'full message revisions' });
+    const revision = (chars: number) => ({ time: Date.now(), source: 'extension' as const, kind: 'assistant_message' as const,
+      messageId: 'full-answer', state: 'streaming' as const, final: false,
+      message: { text: 'same bounded head', truncated: true, chars, digest: String(chars) } });
+    await upsertMessageEvent(opened.id, revision(20000));
+    await upsertMessageEvent(opened.id, revision(60000));
+    await upsertMessageEvent(opened.id, revision(60000));
+    expect(await getSession(opened.id)).toMatchObject({ estimatedTokens: 15000, contextTokens: 15000 });
+  });
+
   it('lets the store deduplicate repeated recorder assets instead of shadow-counting the same bytes toward quota', async () => {
     const conversationId = `conv-dedup-shot-${Date.now()}`;
     const sessionId = await sessionForConversation(conversationId);
@@ -2361,6 +2405,24 @@ describe('naming the chats this app opened', () => {
     expect((await getSession(opened.sessionId!))?.title).toBe('My manual title');
   });
 
+  it('does not persist native file credentials in recorded artifact arguments', async () => {
+    const conversationId = 'conv-artifact-privacy';
+    const requestId = 'wfr_artifact_privacy';
+    const opened = await recordChatObservations(conversationId, [{
+      kind: 'tool_evidence', time: Date.now(), fiberConversationId: conversationId,
+      calls: [{ messageId: 'artifact-private', tool: 'download_artifact', order: 0, answered: false, requestId }]
+    }]);
+    await recordToolCall({ tool: 'download_artifact',
+      args: { file: { download_url: 'https://files.oaiusercontent.com/f?sig=PRIVATE_SIGNATURE', file_id: 'file-PRIVATE_ID' }, path: '/project/image.png' },
+      content: [{ type: 'text', text: 'Saved /project/image.png.' }], outcome: 'ok', durationMs: 1,
+      startedAt: Date.now(), requestId, agent: null });
+    const stored = JSON.stringify(await readEvents(opened.sessionId!, { kinds: ['tool_call'] }));
+    expect(stored).toContain('native file credentials not stored');
+    expect(stored).toContain('/project/image.png');
+    expect(stored).not.toContain('PRIVATE_SIGNATURE');
+    expect(stored).not.toContain('PRIVATE_ID');
+  });
+
   it('recovers a late worker call agent from the durable worker session origin after live broker state is gone', async () => {
     const conversationId = 'conv-late-worker-call';
     const requestId = 'wfr_late_worker_exact';
@@ -2846,6 +2908,27 @@ describe('token estimation', () => {
       }
     } as SessionEvent;
     expect(eventTokens(event)).toBe(100 + 200 + Math.ceil('Read a.ts'.length / 4));
+  });
+
+  it('counts full truncated tool text once, independently of its preview and asset reference', () => {
+    const event = { seq: 1, time: 1, source: 'mcp', kind: 'tool_call', call: {
+      callId: 'full-result', tool: 'read', attribution: 'turn',
+      args: { text: 'short preview with a recorder annotation', truncated: true, chars: 20001, assetId: 'args.txt' },
+      result: { text: 'x'.repeat(8000) + ' [52306 characters stored as result.txt]', truncated: true, chars: 60306, assetId: 'result.txt' },
+      outcome: 'ok', durationMs: 1, summary: { title: 'Read 3 paths', tone: 'neutral', kind: 'read' },
+      assets: [{ id: 'result.txt', mimeType: 'text/plain', bytes: 60306 }]
+    } } as SessionEvent;
+    expect(eventTokens(event)).toBe(Math.ceil(20001 / 4) + Math.ceil(60306 / 4) + estimateTokens('Read 3 paths'));
+    if (event.kind !== 'tool_call') throw new Error('fixture');
+    delete event.call.result.assetId;
+    event.call.result.text = 'Another bounded preview; overflow asset unavailable';
+    expect(eventTokens(event)).toBe(Math.ceil(20001 / 4) + Math.ceil(60306 / 4) + estimateTokens('Read 3 paths'));
+  });
+
+  it.each([undefined, -1, NaN, Infinity, 2.5])('keeps legacy or malformed original lengths bounded by actual inline text (%s)', chars => {
+    const event = { seq: 1, time: 1, source: 'extension', kind: 'user_message',
+      message: { text: 'abcdefgh', truncated: true, chars } } as SessionEvent;
+    expect(eventTokens(event)).toBe(2);
   });
 
   it('does not inflate the context advisory with transient progress captions', () => {

--- a/test/task-request.test.ts
+++ b/test/task-request.test.ts
@@ -1,7 +1,33 @@
 import { randomUUID } from 'node:crypto';
 import { afterEach, expect, it, vi } from 'vitest';
-import { cancelTaskRequest, runTaskRequest, TaskRequestError } from '../src/main/task-request.js';
+import { cancelTaskRequest, retryTaskRequest, runTaskRequest, TaskRequestError } from '../src/main/task-request.js';
 afterEach(() => vi.useRealTimers());
+
+it('keeps a caller-owned operation retrying every fifteen seconds until it succeeds', async () => {
+  vi.useFakeTimers();
+  const work = vi.fn().mockRejectedValueOnce(new TaskRequestError('rate_limited', true))
+    .mockRejectedValueOnce(new TaskRequestError('http_503', true))
+    .mockRejectedValueOnce(new TaskRequestError('rate_limited', true))
+    .mockRejectedValueOnce(new TaskRequestError('rate_limited', true)).mockResolvedValue('ready');
+  const result = retryTaskRequest(work, new AbortController().signal, vi.fn());
+  await vi.advanceTimersByTimeAsync(59999);
+  expect(work).toHaveBeenCalledTimes(4);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(await result).toBe('ready');
+  expect(work).toHaveBeenCalledTimes(5);
+});
+
+it('honors Retry-After beyond the native timer range without immediate retries', async () => {
+  vi.useFakeTimers();
+  const delay = 30 * 24 * 60 * 60 * 1000;
+  const work = vi.fn().mockRejectedValueOnce(new TaskRequestError('rate_limited', true, delay)).mockResolvedValue('ready');
+  const result = retryTaskRequest(work, new AbortController().signal, vi.fn());
+  await vi.advanceTimersByTimeAsync(delay - 1);
+  expect(work).toHaveBeenCalledTimes(1);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(await result).toBe('ready');
+  expect(work).toHaveBeenCalledTimes(2);
+});
 
 it('honors Retry-After, coalesces the same invocation and never retries a successful result', async () => {
   vi.useFakeTimers(); const id = randomUUID(), progress = vi.fn();

--- a/test/tools-desktop-permissions.test.ts
+++ b/test/tools-desktop-permissions.test.ts
@@ -44,6 +44,7 @@ function caps(over: Partial<Capabilities>): Capabilities {
     move: false,
     deleteFile: false,
     command: false,
+    saveArtifact: false,
     screen: false,
     control: false,
     clipboardRead: false,

--- a/test/tools-desktop-runtime.test.ts
+++ b/test/tools-desktop-runtime.test.ts
@@ -41,6 +41,7 @@ function caps(over: Partial<Capabilities>): Capabilities {
     move: false,
     deleteFile: false,
     command: false,
+    saveArtifact: false,
     screen: false,
     control: false,
     clipboardRead: false,

--- a/test/tunnel-lifecycle.test.ts
+++ b/test/tunnel-lifecycle.test.ts
@@ -104,6 +104,31 @@ beforeEach(() => {
 });
 
 describe('OpenAI tunnel process ownership', () => {
+  it('classifies structured control-plane context together with its network error', async () => {
+    vi.useFakeTimers();
+    const reports: any[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/readyz') return new Response('ok');
+      if (url.pathname === '/metrics') return new Response('commands_poll_last_successful_timestamp_seconds 0\ncommands_poll_errors_total 1\n');
+      if (url.pathname === '/api/status') return Response.json({ uptime_seconds: 50, channels: [] });
+      return new Response('missing', { status: 404 });
+    }));
+    const handle = await startTunnel({ localUrl: 'http://127.0.0.1:1234/secret', settings, apiKey: 'test', report: r => reports.push(r) });
+    await vi.advanceTimersByTimeAsync(10);
+    fixture.health.url = 'http://127.0.0.1:34567';
+    await vi.advanceTimersByTimeAsync(1_000);
+    const child = fixture.children[0];
+    child.stderr.emit('data', Buffer.from(JSON.stringify({ level: 'WARN', msg: 'MCP probe failed', error: 'dial tcp: i/o timeout' }) + '\n'));
+    await vi.advanceTimersByTimeAsync(45_000);
+    expect(reports.some(r => r.state === 'offline')).toBe(false);
+    child.stderr.emit('data', Buffer.from(JSON.stringify({ level: 'WARN', msg: 'poll failed; backing off', error: 'dial tcp: i/o timeout' }) + '\n'));
+    await vi.advanceTimersByTimeAsync(45_000);
+    expect(reports.at(-1).state).toBe('offline');
+    expect(fixture.children).toHaveLength(1);
+    await handle.stop();
+  });
+
   it('claims one restart and waits for the old process tree before launching its replacement', async () => {
     vi.useFakeTimers();
     const reports: any[] = [];
@@ -169,7 +194,7 @@ describe('OpenAI tunnel process ownership', () => {
     await handle.stop();
   });
 
-  it('starts a replacement with no inherited health address, handshake, or outage verdict', async () => {
+  it.each(['unavailable', 'missing timestamp'])('starts a replacement with no inherited health and %s metrics', async missing => {
     vi.useFakeTimers();
     vi.setSystemTime(1_800_000_000_000);
     const reports: any[] = [];
@@ -178,7 +203,10 @@ describe('OpenAI tunnel process ownership', () => {
       const url = new URL(String(input));
       if (url.pathname === '/readyz') return new Response('ok');
       if (url.pathname === '/metrics') {
-        if (!metricsAvailable) throw new Error('metrics unavailable');
+        if (!metricsAvailable) {
+          if (missing === 'missing timestamp') return new Response('commands_poll_errors_total 0\n');
+          throw new Error('metrics unavailable');
+        }
         return new Response(
           `commands_poll_last_successful_timestamp_seconds ${Date.now() / 1000}\ncommands_poll_errors_total 0\n`
         );

--- a/test/tunnel.test.ts
+++ b/test/tunnel.test.ts
@@ -60,13 +60,12 @@ describe('cross-platform tunnel executable discovery', () => {
 
 /** Verbatim lines seen in the field, with the tunnel up and the WLAN off. */
 const REAL_OUTAGE_LINES = [
-  'poll failed; backing off',
-  'poll timed out; backing off',
-  'Post "https://api.openai.com/v1/tunnels/poll": dial tcp: lookup api.openai.com: no such host',
-  'read tcp 192.168.0.24:51544->104.18.32.115:443: wsarecv: An established connection was aborted by the software in your host machine',
-  'dial tcp 104.18.32.115:443: i/o timeout',
-  'connection refused',
-  'network is unreachable'
+  'poll failed; backing off: Post "https://api.openai.com/v1/tunnels/poll": dial tcp: lookup api.openai.com: no such host',
+  'poll failed; backing off: read tcp: wsarecv: An established connection was aborted by the software in your host machine',
+  'poll failed; backing off: dial tcp: i/o timeout',
+  'poll failed; backing off: connection refused',
+  'poll failed; backing off: network is unreachable',
+  'poll timed out; backing off: context deadline exceeded'
 ];
 
 describe('network error classification', () => {
@@ -82,6 +81,9 @@ describe('network error classification', () => {
     expect(isUnreachableError('WARN config reload skipped')).toBe(false);
     expect(isUnreachableError('ERROR unauthorized: invalid api key')).toBe(false);
     expect(isUnreachableError('tunnel not found')).toBe(false);
+    expect(isUnreachableError('context deadline exceeded')).toBe(false);
+    expect(isUnreachableError('mcp probe failed: context deadline exceeded')).toBe(false);
+    expect(isUnreachableError('dial tcp: i/o timeout')).toBe(false);
     expect(isUnreachableError('context deadline exceeded while probing the local MCP server')).toBe(false);
   });
 
@@ -96,6 +98,9 @@ describe('network error classification', () => {
       'the connection was refused'
     );
     expect(describeNetworkError('dial tcp: i/o timeout')).toBe('the connection timed out');
+    expect(describeNetworkError('poll timed out; backing off: context deadline exceeded')).toBe(
+      'the connection timed out'
+    );
     expect(describeNetworkError('network is unreachable')).toBe('the network is unreachable');
     expect(describeNetworkError('something odd happened')).toBe('a network error');
   });

--- a/test/window-lifecycle.test.ts
+++ b/test/window-lifecycle.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import vm from 'node:vm';
 import {
+  applyLoginStartup,
+  isBackgroundLaunch,
+  supportsLoginStartup,
   createWindowActivationGate,
   ownsAppRuntime,
   registerNativeWindowActivation,
@@ -40,18 +43,22 @@ describe('native window activation', () => {
     ready(); expect(showWindow).toHaveBeenCalledTimes(1);
     launch.quitting = true; ready(); expect(showWindow).toHaveBeenCalledTimes(1);
   });
-  it('starts background catalog discovery on each actual show, including tray reopen, and never during quit', async () => {
+  it('requests only passive catalog observation on show with browser presence, never during quit or absence', async () => {
     const source = readFileSync(new URL('../src/main/index.ts', import.meta.url), 'utf8');
     const listener = source.slice(source.indexOf("  window.on('show'"), source.indexOf("  window.once('ready-to-show'"));
     let show!: () => void;
     const start = vi.fn(async () => ({}));
+    let present = false;
     const context = vm.createContext({ window: { on: (event: string, callback: () => void) => {
       expect(event).toBe('show'); show = callback;
-    } }, quitting: false, startChatModelDiscovery: start, logWarn: vi.fn() });
+    } }, quitting: false, bridgeStatus: async () => ({ present }), startChatModelDiscovery: start, logWarn: vi.fn() });
     vm.runInContext(listener, context);
+    show(); await Promise.resolve(); expect(start).not.toHaveBeenCalled();
+    present = true;
     show(); await Promise.resolve();
     show(); await Promise.resolve();
     expect(start).toHaveBeenCalledTimes(2);
+    expect(start).toHaveBeenCalledWith(false);
     context.quitting = true;
     show();
     expect(start).toHaveBeenCalledTimes(2);
@@ -120,5 +127,36 @@ describe('native window activation', () => {
   it.each(['win32', 'linux'] as const)('keeps close-to-tray semantics on %s', (platform) => {
     expect(shouldQuitOnWindowAllClosed(platform, true)).toBe(false);
     expect(shouldQuitOnWindowAllClosed(platform, false)).toBe(true);
+  });
+});
+
+describe('Windows login startup', () => {
+  it('writes only packaged Windows login settings and supports turning the same entry off', () => {
+    const app = { isPackaged: true, setLoginItemSettings: vi.fn() };
+    applyLoginStartup(app, true, 'win32', 'C:/Program Files/Chat On Steroids/app.exe');
+    applyLoginStartup(app, false, 'win32', 'C:/Program Files/Chat On Steroids/app.exe');
+    expect(app.setLoginItemSettings.mock.calls).toEqual([
+      [{ openAtLogin: true, path: 'C:/Program Files/Chat On Steroids/app.exe', args: ['--background'] }],
+      [{ openAtLogin: false, path: 'C:/Program Files/Chat On Steroids/app.exe', args: ['--background'] }]
+    ]);
+    for (const platform of ['darwin', 'linux'] as const) applyLoginStartup(app, true, platform);
+    app.isPackaged = false;
+    applyLoginStartup(app, true, 'win32');
+    expect(app.setLoginItemSettings).toHaveBeenCalledTimes(2);
+    expect(supportsLoginStartup('win32', false)).toBe(false);
+  });
+  it('ignores background second-instance launches while ordinary launches still focus', () => {
+    const source = readFileSync(new URL('../src/main/index.ts', import.meta.url), 'utf8');
+    const start = source.indexOf("app.on('second-instance'");
+    const handler = source.slice(start, source.indexOf('\n});', start) + 4);
+    let received!: (event: unknown, argv: string[]) => void;
+    const request = vi.fn();
+    vm.runInNewContext(handler, { app: { on: (_: string, listener: typeof received) => { received = listener; } }, windowActivation: { request }, isBackgroundLaunch });
+    received({}, ['app.exe', '--background']);
+    expect(request).not.toHaveBeenCalled();
+    received({}, ['app.exe']);
+    expect(request).toHaveBeenCalledOnce();
+    expect(isBackgroundLaunch(['app.exe', '--background=false'])).toBe(false);
+    expect(source).toContain('if (!isBackgroundLaunch(process.argv)) windowActivation.request();');
   });
 });


### PR DESCRIPTION
## Result
This single snapshot commit contains the final 2.0.7 file changes on top of main; intermediate development commits are excluded. It integrates the browser ownership and native input fixes. Browser handoffs keep one elected document across navigation and worker suspension; Goal/Loop and finish requests retain exact turn ownership, retry temporary API failures, and deliver generated follow-ups through the next tool response. Provider destination, model and reasoning remain consistent across settings changes.

Native file workflows include bounded opt-in artifact downloads and image handling. Connector refresh now handles validated native cards with no Refresh action, while the companion popup requires confirmed protocol compatibility. Usage accounting recognizes the observed Sol model alias and uses current configurable cached-input rates. macOS notification actions receive the required alert-style packaging declaration.

## Validation
- Complete local integration suite: 3155 passed, 23 skipped before the final focused fixes; isolated shutdown tests included.
- Final affected suites: 177 passed; canonical artifact fixture follow-up: 16 passed. Finish test timer isolation also has a failing-before/passing-after regression. TypeScript and staged-diff checks pass.
- Shared-tree finish/exec regression rerun: 163 passed, 3 skipped.
- Public snapshot privacy checks pass. Maintainer logs and local session evidence are excluded.
- Windows/macOS/Linux CI all pass against snapshot 7c38fcb (run 34140556583). Local Windows installation completed; installed main/preload/renderer bytes match a fresh build of the final runtime.

Live Windows testing confirms ordered, exactly-once queued-stage delivery and one active worker. Model compliance with completing every stage before calling finish remains distinct from transport correctness. Actual packaged macOS notification/focus behavior and native Linux behavior are not claimed as locally verified.

PR #93 startup/reopen behavior is covered. Its mandatory residency and Dock-removal proposal is deferred because it changes existing close preferences. Broader product proposals remain separately scoped.




