### PR TITLE
Fix plugin refresh loop when Refresh control is unavailable

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -2264,12 +2264,12 @@ const HANDLERS = {
     if (!ownsDocument(source) || !/^[a-f0-9-]{36}$/i.test(String(message.id || ''))) return { ok: false };
     const tab = await chrome.tabs.get(source.tab);
     if (!ownsDocument(source) || pluginRefreshMarker(tab) !== message.id) return { ok: false };
-    if (!['claim', 'current', 'complete', 'fail'].includes(message.action)) return { ok: false };
+    if (!['claim', 'current', 'manual', 'complete', 'fail'].includes(message.action)) return { ok: false };
     const body = JSON.stringify({ action: message.action, id: message.id, appId: message.appId, connectorName: message.connectorName, tools: message.tools, versionId: message.versionId, error: message.error });
     if (body.length > 310000) return { ok: false };
     const result = await call('/plugin-refresh', { method: 'POST', body });
     if (!ownsDocument(source) || pluginRefreshMarker(await chrome.tabs.get(source.tab)) !== message.id) return { ok: false };
-    if (['current', 'complete', 'fail'].includes(message.action) && result.ok && result.data?.ok) void maintain();
+    if (['current', 'manual', 'complete', 'fail'].includes(message.action) && result.ok && result.data?.ok) void maintain();
     return result;
   },
   async model_catalog(message, _sender, source) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -9918,13 +9918,14 @@
       }, current, 8000);
       if (!view) return false;
       if (!current()) return false;
-      if (!view || (request.appId && view.appId !== request.appId) || !view.refresh || view.refresh.disabled) { await fail('Exact connector settings or Refresh control could not be verified'); return false; }
+      if (request.appId && view.appId !== request.appId) { await fail('Exact connector settings could not be verified'); return false; }
       const ownedEpoch = epoch, appId = view.appId;
       const stillCurrent = () => current() && epoch === ownedEpoch && CLF_DOM.pluginRefreshView(request.connectorName, request.tools, appId)?.appId === appId;
       const before = schemaKey(view.tools), expected = schemaKey(request.tools);
       if (before === expected) {
         return (await ask({ type: 'plugin_refresh', action: 'current', id: request.id, appId, connectorName: request.connectorName, tools: view.tools }))?.data?.ok === true && stillCurrent();
       }
+      if (!view.refresh || view.refresh.disabled) { await fail('Connector schema differs, but a Refresh control is unavailable'); return false; }
       const claimed = await ask({ type: 'plugin_refresh', action: 'claim', id: request.id, appId, connectorName: request.connectorName, tools: view.tools });
       if (!claimed?.data?.ok || !stillCurrent()) { await fail('Connector refresh claim or page ownership was not confirmed'); return false; }
       view.refresh.click(); // the durable main-process attempt owns this one click

--- a/extension/content.js
+++ b/extension/content.js
@@ -9925,7 +9925,10 @@
       if (before === expected) {
         return (await ask({ type: 'plugin_refresh', action: 'current', id: request.id, appId, connectorName: request.connectorName, tools: view.tools }))?.data?.ok === true && stillCurrent();
       }
-      if (!view.refresh || view.refresh.disabled) { await fail('Connector schema differs, but a Refresh control is unavailable'); return false; }
+      if (!view.refresh || view.refresh.disabled) {
+        const error = 'Connector schema differs, but ChatGPT exposes no Refresh control. Recreate or republish this custom app to load the current tool schema.';
+        return (await ask({ type: 'plugin_refresh', action: 'manual', id: request.id, appId, connectorName: request.connectorName, tools: view.tools, error }))?.data?.ok === true && stillCurrent();
+      }
       const claimed = await ask({ type: 'plugin_refresh', action: 'claim', id: request.id, appId, connectorName: request.connectorName, tools: view.tools });
       if (!claimed?.data?.ok || !stillCurrent()) { await fail('Connector refresh claim or page ownership was not confirmed'); return false; }
       view.refresh.click(); // the durable main-process attempt owns this one click

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -2,7 +2,7 @@ import { pendingChatModelRequest, observeChatModels } from './chat-models.js';
 import { isProModel } from '../shared/chat-models.js';
 import type { SessionSummary } from '../shared/session.js';
 import { publishBrowserDecision, authorizeBrowserInput, sessionInputPolicy } from './session/input.js';
-import { pluginRefreshPublications, pendingPluginRefreshes, claimPluginRefresh, completePluginRefresh, failPluginRefresh } from './plugin-refresh.js';
+import { pluginRefreshPublications, pendingPluginRefreshes, claimPluginRefresh, requireManualPluginRefresh, completePluginRefresh, failPluginRefresh } from './plugin-refresh.js';
 import { attachBrowserWake, wakeBrowserWork } from './browser-wake.js';
 let browserWake: ReturnType<typeof attachBrowserWake> | null = null;
 let browserWorkArea: (() => { x: number; y: number; width: number; height: number }) | null = null;
@@ -1394,6 +1394,7 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
     if (body.action === 'fail' && typeof body.error === 'string') ok = await failPluginRefresh({ id: body.id, error: body.error.slice(0, 200) });
     else if (typeof body.appId === 'string' && /^asdk_app_[a-zA-Z0-9_-]{1,160}$/.test(body.appId)) {
       if ((body.action === 'claim' || body.action === 'current') && typeof body.connectorName === 'string') ok = await claimPluginRefresh({ id: body.id, appId: body.appId, connectorName: body.connectorName, tools: body.tools, alreadyCurrent: body.action === 'current' });
+      if (body.action === 'manual' && typeof body.connectorName === 'string' && typeof body.error === 'string') ok = await requireManualPluginRefresh({ id: body.id, appId: body.appId, connectorName: body.connectorName, tools: body.tools, error: body.error.slice(0, 200) });
       if (body.action === 'complete') ok = await completePluginRefresh({ id: body.id, appId: body.appId, tools: body.tools, versionId: typeof body.versionId === 'string' ? body.versionId.slice(0, 200) : undefined });
     }
     if (ok) changed();

--- a/src/main/plugin-refresh.ts
+++ b/src/main/plugin-refresh.ts
@@ -2,12 +2,12 @@ import { createHash, randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import { readDurable, writeDurableNow } from './durable.js';
 import { wakeBrowserWork } from './browser-wake.js';
-import { logInfo } from './logger.js';
+import { logInfo, logWarn } from './logger.js';
 import { surfaceDefinition } from './mcp/surfaces.js';
 import type { PluginPublication, PluginRefreshRequest, PluginSurface, PluginToolSchema } from '../shared/plugin-refresh.js';
 
 const app = z.string().regex(/^asdk_app_[a-zA-Z0-9_-]{1,160}$/);
-const rowSchema = z.object({ surface: z.enum(['core', 'desktop']), schemaId: z.string(), id: z.string().uuid(), appId: app.nullable(), completedSchemaId: z.string().nullable(), attempted: z.boolean(), error: z.string().max(200).optional(), versionId: z.string().max(200).optional() });
+const rowSchema = z.object({ surface: z.enum(['core', 'desktop']), schemaId: z.string(), id: z.string().uuid(), appId: app.nullable(), completedSchemaId: z.string().nullable(), attempted: z.boolean(), manual: z.boolean().optional().default(false), error: z.string().max(200).optional(), versionId: z.string().max(200).optional() });
 type Row = z.infer<typeof rowSchema>;
 const publications = new Map<PluginSurface, PluginPublication>();
 const settling = new Map<PluginSurface, { schemaId: string; readyAt: number; timer?: ReturnType<typeof setTimeout> }>();
@@ -89,17 +89,17 @@ export function pendingPluginRefreshes(): Promise<PluginRefreshRequest[]> {
     for (const publication of publications.values()) {
       const found = current.find(row => row.surface === publication.surface);
       if (found?.schemaId === publication.schemaId) continue;
-      const next: Row = { surface: publication.surface, schemaId: publication.schemaId, id: randomUUID(), appId: found?.appId ?? null, completedSchemaId: found?.completedSchemaId ?? null, attempted: false };
+      const next: Row = { surface: publication.surface, schemaId: publication.schemaId, id: randomUUID(), appId: found?.appId ?? null, completedSchemaId: found?.completedSchemaId ?? null, attempted: false, manual: false };
       if (found) current[current.indexOf(found)] = next; else current.push(next);
       changed = true;
     }
     if (changed) {
       await writeDurableNow('plugin-refresh', current);
-      logInfo(`plugin refresh pending observed ${current.filter(row => row.completedSchemaId !== row.schemaId).map(row => `surface=${row.surface} schema=${row.schemaId.slice(0, 12)} dueInMs=${Math.max(0, (settling.get(row.surface)?.readyAt ?? 0) - Date.now())}`).join(' ')}`);
+      logInfo(`plugin refresh pending observed ${current.filter(row => !row.manual && row.completedSchemaId !== row.schemaId).map(row => `surface=${row.surface} schema=${row.schemaId.slice(0, 12)} dueInMs=${Math.max(0, (settling.get(row.surface)?.readyAt ?? 0) - Date.now())}`).join(' ')}`);
     }
     return current.flatMap(row => {
       const publication = publications.get(row.surface);
-      return publication && (settling.get(row.surface)?.readyAt ?? 0) <= Date.now() && publication.schemaId === row.schemaId && !row.attempted && row.completedSchemaId !== row.schemaId
+      return publication && (settling.get(row.surface)?.readyAt ?? 0) <= Date.now() && publication.schemaId === row.schemaId && !row.attempted && !row.manual && row.completedSchemaId !== row.schemaId
         ? [{ ...structuredClone(publication), id: row.id, appId: row.appId }] : [];
     });
   });
@@ -113,7 +113,7 @@ function exact(current: Row[], identity: Identity): Row | undefined {
 export function claimPluginRefresh(input: Identity & { connectorName: string; tools: unknown; alreadyCurrent?: boolean }): Promise<boolean> {
   return serial(async () => {
     const current = await rows(); const row = exact(current, input);
-    if (!row || row.attempted || row.completedSchemaId === row.schemaId || !recognizable(input.tools)) return false;
+    if (!row || row.attempted || row.manual || row.completedSchemaId === row.schemaId || !recognizable(input.tools)) return false;
     const publication = publications.get(row.surface)!;
     // Unique-name discovery is initial enrollment only. Stale definitions can still
     // identify the surface; the complete post-refresh declarations must match below.
@@ -129,10 +129,33 @@ export function claimPluginRefresh(input: Identity & { connectorName: string; to
     await writeDurableNow('plugin-refresh', current); return true;
   });
 }
+/**
+ * Records a changed provider snapshot that this ChatGPT workspace cannot refresh in place.
+ *
+ * This is intentionally neither a completed refresh nor an attempted click. The same schema stays
+ * visible as requiring manual recreation/republishing, but automatic browser maintenance stops
+ * reopening its settings page. A later local schema change creates a fresh row and may be tried
+ * again normally.
+ */
+export function requireManualPluginRefresh(input: Identity & { connectorName: string; tools: unknown; error: string }): Promise<boolean> {
+  return serial(async () => {
+    const current = await rows(); const row = exact(current, input);
+    if (!row || row.attempted || row.manual || row.completedSchemaId === row.schemaId || !recognizable(input.tools)) return false;
+    const publication = publications.get(row.surface)!;
+    if (row.appId ? row.appId !== input.appId : input.connectorName !== publication.connectorName || !enrollable(input.tools, publication)) return false;
+    if (current.some(other => other !== row && other.appId === input.appId) || matches(input.tools, publication.tools)) return false;
+    row.appId = input.appId;
+    row.manual = true;
+    row.error = input.error.slice(0, 200);
+    await writeDurableNow('plugin-refresh', current);
+    logWarn(`plugin refresh requires manual action surface=${row.surface}: ${row.error}`);
+    return true;
+  });
+}
 export function completePluginRefresh(input: Identity & { tools: unknown; versionId?: string }): Promise<boolean> {
   return serial(async () => {
     const current = await rows(); const row = exact(current, input);
-    if (!row || !row.attempted || row.appId !== input.appId || !matches(input.tools, publications.get(row.surface)!.tools)) return false;
+    if (!row || row.manual || !row.attempted || row.appId !== input.appId || !matches(input.tools, publications.get(row.surface)!.tools)) return false;
     row.completedSchemaId = row.schemaId; delete row.error;
     if (input.versionId) row.versionId = input.versionId.slice(0, 200);
     await writeDurableNow('plugin-refresh', current); return true;

--- a/test/input-delivery-integration.test.ts
+++ b/test/input-delivery-integration.test.ts
@@ -148,6 +148,18 @@ describe('IPC input delivery and Goal control integration', () => {
     expect((await post('/plugin-refresh', { ...identity, action: 'complete', tools, versionId: 'asdk_app_v_synthetic' })).body.ok).toBe(true);
     resetPluginRefreshForTests();
   });
+  it('accepts a manual plugin-refresh terminal state and removes it from browser pickup', async () => {
+    const { publishPluginSurface, resetPluginRefreshForTests } = await import('../src/main/plugin-refresh.js');
+    resetPluginRefreshForTests();
+    const tools = [{ name: 'read', description: 'Read current', inputSchema: { type: 'object', properties: {} } }];
+    const installed = [{ ...tools[0], description: 'Read old' }];
+    publishPluginSurface('core', 'Chat On Steroids Core', 'test', 'Synthetic instructions', tools);
+    const request = (await post('/plugin-refresh', { action: 'pending' })).body.requests[0];
+    const manual = await post('/plugin-refresh', { ...request, appId: 'asdk_app_synthetic', action: 'manual', connectorName: 'Chat On Steroids Core', tools: installed, error: 'Recreate or republish this custom app.' });
+    expect(manual.body.ok).toBe(true);
+    expect((await post('/plugin-refresh', { action: 'pending' })).body.requests).toEqual([]);
+    resetPluginRefreshForTests();
+  });
   it.each(['browser', 'tool'] as const)('records %s receipt text and pixels through the real IPC hook', async (transport) => {
     const { default: sharp } = await import('sharp');
     const { readEvents } = await import('../src/main/session/store.js');

--- a/test/plugin-refresh-workflow.test.ts
+++ b/test/plugin-refresh-workflow.test.ts
@@ -83,6 +83,17 @@ it('records an already current schema when the workspace exposes no Refresh cont
   expect(h.click).not.toHaveBeenCalled();
   expect(h.ask.mock.calls.map(([message]) => message.action)).toEqual(['current']);
 });
+it('stops automatic retry when a changed schema has no Refresh control', async () => {
+  const h = workflow({ refreshAvailable: false });
+  expect(await h.run()).toBe(true);
+  expect(h.click).not.toHaveBeenCalled();
+  expect(h.ask.mock.calls.map(([message]) => message.action)).toEqual(['manual']);
+  expect(h.ask.mock.calls[0]?.[0]).toMatchObject({
+    appId: 'asdk_app_synthetic',
+    connectorName: 'Chat On Steroids Core',
+    tools: [{ name: 'read', description: 'Old description.' }]
+  });
+});
 it('opens an enrolled exact App Id directly in marked settings without name discovery', async () => {
   const background = readFileSync(new URL('../extension/background.js', import.meta.url), 'utf8');
   const code = background.slice(background.indexOf('let pluginRefreshFlight = null;'), background.indexOf('async function catalogProbe('));

--- a/test/plugin-refresh-workflow.test.ts
+++ b/test/plugin-refresh-workflow.test.ts
@@ -7,13 +7,13 @@ const source = readFileSync(new URL('../extension/content.js', import.meta.url),
 const section = source.slice(source.indexOf('  let pluginRefreshBusy = false;'), source.indexOf('  function catalogPageReady('));
 const id = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
 const tools = [{ name: 'read', description: 'Read current.', inputSchema: { type: 'object' } }];
-function workflow(options: { unchanged?: boolean; deny?: boolean; navigateDuringClaim?: boolean } = {}) {
+function workflow(options: { unchanged?: boolean; deny?: boolean; navigateDuringClaim?: boolean; refreshAvailable?: boolean } = {}) {
   let refreshed = false;
   const click = vi.fn(() => { refreshed = true; });
   const context = vm.createContext({ URL, alive: true, generating: false, epoch: 1,
     location: { pathname: '/', href: `https://chatgpt.com/?cos-plugin-refresh=${id}#settings/Plugins/plugin_asdk_app_synthetic` },
     CLF_DOM: { generating: () => false, pluginManagementIdle: () => true,
-      pluginRefreshView: () => ({ appId: 'asdk_app_synthetic', refresh: { click }, tools: options.unchanged || refreshed ? tools : [{ ...tools[0], description: 'Old description.' }] }) }
+      pluginRefreshView: () => ({ appId: 'asdk_app_synthetic', refresh: options.refreshAvailable === false ? null : { click }, tools: options.unchanged || refreshed ? tools : [{ ...tools[0], description: 'Old description.' }] }) }
   });
   const ask = vi.fn(async (message: { action: string }) => {
     if (message.action === 'claim' && options.navigateDuringClaim) context.epoch = 2;
@@ -73,6 +73,12 @@ it('keeps a loading settings index pending and restores custody after its instal
 });
 it('records an already current schema without clicking Refresh and invalidating old chats', async () => {
   const h = workflow({ unchanged: true });
+  expect(await h.run()).toBe(true);
+  expect(h.click).not.toHaveBeenCalled();
+  expect(h.ask.mock.calls.map(([message]) => message.action)).toEqual(['current']);
+});
+it('records an already current schema when the workspace exposes no Refresh control', async () => {
+  const h = workflow({ unchanged: true, refreshAvailable: false });
   expect(await h.run()).toBe(true);
   expect(h.click).not.toHaveBeenCalled();
   expect(h.ask.mock.calls.map(([message]) => message.action)).toEqual(['current']);

--- a/test/plugin-refresh.test.ts
+++ b/test/plugin-refresh.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 const wake = vi.hoisted(() => vi.fn());
 vi.mock('../src/main/browser-wake.js', () => ({ wakeBrowserWork: wake }));
 import { initDurableStore, resetDurableForTests, readDurable, writeDurableNow } from '../src/main/durable.js';
-import { claimPluginRefresh, completePluginRefresh, failPluginRefresh, pendingPluginRefreshes, pluginRefreshPublications, publishPluginSurface, resetPluginRefreshForTests, unpublishPluginSurface } from '../src/main/plugin-refresh.js';
+import { claimPluginRefresh, requireManualPluginRefresh, completePluginRefresh, failPluginRefresh, pendingPluginRefreshes, pluginRefreshPublications, publishPluginSurface, resetPluginRefreshForTests, unpublishPluginSurface } from '../src/main/plugin-refresh.js';
 import { makeTempDir, removeTempDir } from './helpers.js';
 import { buildServer } from '../src/main/mcp/tools.js';
 import { defaultConfig } from '../src/main/config.js';
@@ -88,6 +88,19 @@ it('does not settle a changed contract as already current', async () => {
   publish(); const request = (await pendingPluginRefreshes())[0]!;
   expect(await claimPluginRefresh({ ...request, appId, connectorName: 'Chat On Steroids Core', tools: [{ ...tools[0]!, description: 'Old' }], alreadyCurrent: true })).toBe(false);
   expect(await claim(request)).toBe(true);
+});
+it('durably suppresses automatic retries when the provider requires manual recreation', async () => {
+  publish(); const request = (await pendingPluginRefreshes())[0]!;
+  const installed = [{ ...tools[0]!, description: 'Older installed declaration' }];
+  expect(await requireManualPluginRefresh({ ...request, appId, connectorName: 'Chat On Steroids Core', tools: installed, error: 'Recreate the custom app manually.' })).toBe(true);
+  expect(await pendingPluginRefreshes()).toEqual([]);
+  const stored = (await readDurable('plugin-refresh') as any[])[0];
+  expect(stored).toMatchObject({ appId, attempted: false, manual: true, error: 'Recreate the custom app manually.' });
+  expect(stored.completedSchemaId).not.toBe(stored.schemaId);
+  resetPluginRefreshForTests(); publish();
+  expect(await pendingPluginRefreshes()).toEqual([]);
+  publish('2', [{ ...tools[0]!, description: 'Another local schema' }]);
+  expect((await pendingPluginRefreshes())[0]).toMatchObject({ appId });
 });
 it('keeps an exact app mapping and refuses another installed same-name plugin', async () => {
   publish(); const a = (await pendingPluginRefreshes())[0]!;


### PR DESCRIPTION
## Summary

Fix the ChatGPT Business plugin-refresh loop reported in #90 when the workspace either already has the current schema or cannot refresh a stale schema in place because the settings UI exposes no `Refresh` button.

## Root cause

`refreshManagedPlugin()` previously required a visible/enabled `Refresh` control before comparing the installed tool schema with the expected schema. On ChatGPT Business, the plugin details page can expose the current action schemas without exposing `Refresh`, so an already-current connector failed before it could be acknowledged as current.

A second live-repro case showed that when the schemas genuinely differ and Business exposes no `Refresh` control, the request stayed retryable (`attempted: false`). Extension maintenance then reopened the same plugin settings page on every retry.

## Change

- Compare the installed schema with the expected schema before requiring `Refresh`.
- If the schemas already match, acknowledge the publication as current without clicking anything.
- Only require `Refresh` when the schemas actually differ.
- If the schemas differ and no `Refresh` control exists, record a durable manual-action state instead of leaving the request retryable.
- Exclude that manual-action state from automatic browser pickup so the settings page is not reopened indefinitely.
- A later local schema change creates a fresh refresh obligation, so the manual state does not permanently suppress future updates.
- Add regression coverage for both no-Refresh cases and the bridge protocol path.

## Validation

- `npm test -- --run test/plugin-refresh-workflow.test.ts` — 11/11 passing.
- `npm test -- --run test/plugin-refresh.test.ts` — 18/18 passing.
- `npm test -- --run test/input-delivery-integration.test.ts` — 24/24 passing.
- `npm run typecheck` — passing.
- `git diff --check` — passing.
- Earlier full `npm run verify` reached 2921 passing tests but hit one unrelated Windows/PowerShell locale-sensitive failure in `test/mcp.test.ts` (`scopes parser recovery to its failed batch command after an earlier mutation`); the plugin-refresh tests passed in that run.
- Live ChatGPT Business validation for the second (stale schema + no Refresh) case is pending before marking this PR ready for review.

Addresses #90.