### PR TITLE
Fix macOS tray app window lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,7 +491,7 @@ single-instance lock
   → if feature is off: pause live execution, preserve history, persist the safe projection
   → restore continuations AFTER swarm, because recovery may need to repair prime ownership
   → install renderer CSP + deny browser permissions
-  → register fixed IPC → enable the native window activation gate → create/show window + tray
+  → register fixed IPC → enable native activation → macOS accessory policy → create tray + show control panel
   → queue legacy attribution repair asynchronously
   → start bridge if recording OR multi-agent
   → start session-retention maintenance independently of recording admission

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ ChatGPT is a good engineer trapped in a text box. Developer mode lets it call MC
 - **Plans, Goal and Loop.** Split a request into editable tasks or generate follow-ups through a separate ChatGPT helper or the API. Astra can receive the next task through `session_finish` in the same turn, without opening another model turn.
 - **You stay the permission boundary.** Only the folders you approve are visible. Each capability is a switch. Read-only mode is a single kill switch. Nothing runs on this machine that you did not turn on.
 
-It runs in the tray, hosts no model of its own, and works with the ChatGPT you already use in the browser.
+It runs in the tray, hosts no model of its own, and works with the ChatGPT you already use in the browser. On macOS it lives in the menu bar without occupying the Dock or App Switcher.
 
 ## Download
 
@@ -86,7 +86,7 @@ Use a normal ChatGPT conversation with the custom app enabled. OpenAI's built-in
 
 ## Quick start
 
-1. Install the build for your CPU and open Chat On Steroids. It lives in the tray or menu bar.
+1. Install the build for your CPU and open Chat On Steroids. The control panel opens on every launch; closing it leaves the app running in the tray or menu bar, where you can reopen it.
 2. Open **Settings → Workspace**, review permissions and approve a project folder. Press **Add**, or drop the folder onto the Folders card.
 3. Create an OpenAI Secure MCP Tunnel and a restricted API key, then press **Connect**. Details below.
 4. In ChatGPT on the web, enable Developer mode and create the **Core** app from the tunnel. On Windows, create the **Desktop** app too if you left screen and input control on; on macOS, if you switched them on.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -90,6 +90,9 @@ mac:
   category: public.app-category.developer-tools
   minimumSystemVersion: "13.0"
   extendInfo:
+    # This is a menu-bar utility, not a Dock/App Switcher application. The control
+    # panel remains a normal focusable BrowserWindow opened on launch or from the tray.
+    LSUIElement: true
     NSScreenCaptureUsageDescription: Chat On Steroids captures a display or window only when the enabled Desktop connector asks to observe it.
   # v2.0.2 intentionally ships unsigned/unnotarized macOS artifacts. Make that policy
   # deterministic instead of depending on whatever identities or Apple env vars happen to be

--- a/scripts/smoke-macos-bundle.mjs
+++ b/scripts/smoke-macos-bundle.mjs
@@ -50,6 +50,7 @@ const expectedPlist = {
   CFBundleVersion: packageVersion,
   LSApplicationCategoryType: 'public.app-category.developer-tools',
   LSMinimumSystemVersion: '13.0',
+  LSUIElement: 'true',
   NSScreenCaptureUsageDescription:
     'Chat On Steroids captures a display or window only when the enabled Desktop connector asks to observe it.'
 };

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -265,7 +265,6 @@ const configSchema = z.object({
     finishLeadMinutes: z.number().int().min(3).max(5).optional(),
     backgroundChats: z.boolean().optional().default(false),
     tabsToKeepOpen: z.number().int().min(1).max(50).optional(),
-    minimizeToTray: z.boolean(),
     autoConnect: z.boolean(),
     privacyScreenshots: z.boolean().optional().default(false),
     // Dark is the design the app is drawn for, and a config written before the theme
@@ -404,7 +403,7 @@ export function defaultConfig(platform: NodeJS.Platform = process.platform, rele
     capabilities: firstLaunchCapabilities(platform, release),
     readOnly: false,
     tunnel: { kind: 'openai', tunnelId: '', desktopTunnelId: '', binaryPath: '' },
-    ui: { minimizeToTray: true, autoConnect: false, privacyScreenshots: false, theme: 'dark' },
+    ui: { autoConnect: false, privacyScreenshots: false, theme: 'dark' },
     sessions: { ...DEFAULT_SESSIONS },
     compaction: { ...DEFAULT_COMPACTION },
     multiAgent: { ...FIRST_LAUNCH_MULTI_AGENT },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -386,7 +386,7 @@ void app.whenReady().then(async () => {
   // From here on a second launch may safely focus/recreate the window: renderer security policy
   // is installed and the renderer's fixed IPC methods already have handlers before it can load.
   // The same quit the tray's Quit performs. It has to go through `quitting` for the window's
-  // close-to-tray handler to let go: without it, quitting to install would hide the window and
+  // close handler to let go: without it, quitting to install would hide the window and
   // leave the app running, which is exactly the trap the Install button exists to end.
   registerIpc(
     () => window,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -66,8 +66,7 @@ import {
   createWindowActivationGate,
   ownsAppRuntime,
   registerNativeWindowActivation,
-  shouldBeginAppBootstrap,
-  shouldQuitOnWindowAllClosed
+  shouldBeginAppBootstrap
 } from './window-lifecycle.js';
 import { trayGuidArgsForPlatform, trayImageSpec } from './tray-image.js';
 import { browserWindowIconPath } from './window-icon.js';
@@ -122,11 +121,9 @@ function createWindow(): void {
   window.on('show', () => {
     if (!quitting) void startChatModelDiscovery().catch(error => logWarn(`model discovery on window open: ${error.message}`));
   });
-  window.once('ready-to-show', () => {
-    // A renderer can finish loading after Cmd+Q has already entered bounded teardown. Never let
-    // that late native event make the app visible again while `will-quit` is draining.
-    if (!quitting) showWindow();
-  });
+  // The desktop window is a control panel for the tray app, not the app's lifetime owner.
+  // Every process launch presents it once. Closing it hides it to the tray/menu bar, and a later
+  // tray click, native activation, or second-instance launch presents the same control panel again.
 
   // A renderer that fails to load leaves a blank window with no other clue, so
   // record it where the diagnostics panel can show it.
@@ -152,7 +149,7 @@ function createWindow(): void {
   window.webContents.on('will-attach-webview', (event) => event.preventDefault());
 
   window.on('close', (event) => {
-    if (!quitting && getConfig().ui.minimizeToTray) {
+    if (!quitting) {
       event.preventDefault();
       window?.hide();
     }
@@ -178,10 +175,8 @@ function showWindow(): void {
   // below additionally protects the long pre-window startup interval, while this invariant makes
   // a direct caller harmless once `before-quit` has started.
   if (quitting) return;
-  if (!window) {
-    createWindow();
-    return;
-  }
+  if (!window) createWindow();
+  if (!window) return;
   if (window.isMinimized()) window.restore();
   window.show();
   // Launch, tray reopen and native activation share the same work-area presentation.
@@ -271,6 +266,10 @@ void app.whenReady().then(async () => {
   // This guard is intentionally before even app.getPath/init* calls. A secondary instance, or a
   // primary that was told to quit before ready, must never touch the primary's shared userData.
   if (!shouldBeginAppBootstrap(hasSingleInstanceLock, quitting)) return;
+  // Keep macOS presence menu-bar-only even in development builds, where there is no packaged
+  // Info.plist to supply LSUIElement. `accessory` still allows ordinary focusable windows while
+  // removing the app from the Dock and App Switcher.
+  if (process.platform === 'darwin') app.setActivationPolicy('accessory');
   const userData = app.getPath('userData');
   initLogFile(path.join(userData, 'app.log'));
   initConfigPath(userData);
@@ -397,16 +396,19 @@ void app.whenReady().then(async () => {
     }
   );
   windowActivation.enable();
-  windowActivation.request();
-  // macOS `activate` can fire on first launch, so do not wire it at module load where it could
-  // create a BrowserWindow before Electron is ready. Once the initial window path is established,
-  // Dock activation/re-launch can safely recreate or focus it.
+  // macOS `activate` can fire on first launch or re-launch, so do not wire it at module load where
+  // it could create a BrowserWindow before Electron is ready. Once the initial window path is
+  // established, native re-launch activation can safely recreate or focus it.
   registerNativeWindowActivation(app, windowActivation.request);
 
   tray = new Tray(trayIcon(false), ...trayGuidArgsForPlatform());
   tray.on('click', windowActivation.request);
   refreshTray();
   onStatusChange(refreshTray);
+  // Present the control panel on every primary process launch. Closing it still hides to the
+  // tray/menu bar because the close handler above owns window lifetime independently of process lifetime.
+  createWindow();
+  windowActivation.request();
 
   logInfo('app started');
 
@@ -443,17 +445,9 @@ void app.whenReady().then(async () => {
 app.on('before-quit', () => {
   if (!ownsAppRuntime(hasSingleInstanceLock)) return;
   quitting = true;
-  // From this point `will-quit` owns a bounded teardown. A Dock click/relaunch arriving while
+  // From this point `will-quit` owns a bounded teardown. A native relaunch arriving while
   // that sequence drains must not recreate or reveal a window after the tray has disappeared.
   windowActivation.disable();
-});
-
-app.on('window-all-closed', () => {
-  if (!ownsAppRuntime(hasSingleInstanceLock)) return;
-  // macOS convention: closing the last window is not quitting the application. The Dock/menu
-  // bar stay alive and `activate` recreates it. Windows/Linux retain the explicit close-to-tray
-  // preference; Cmd+Q / app.quit bypasses this event and still enters the shutdown sequence.
-  if (shouldQuitOnWindowAllClosed(process.platform, getConfig().ui.minimizeToTray)) app.quit();
 });
 
 app.on('will-quit', (event) => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -146,7 +146,6 @@ const settingsPatch = z.object({
     finishLeadMinutes: z.number().int().min(3).max(5).optional(),
     backgroundChats: z.boolean().optional(),
     tabsToKeepOpen: z.number().int().min(1).max(50).optional(),
-    minimizeToTray: z.boolean(),
     autoConnect: z.boolean(),
     privacyScreenshots: z.boolean(),
     theme: z.enum(['light', 'dark'])
@@ -244,7 +243,6 @@ function mergeSettings(current: Config, base: SettingsSnapshot, wanted: Settings
       finishLeadMinutes: pick(current.ui.finishLeadMinutes, base.ui.finishLeadMinutes, wanted.ui.finishLeadMinutes),
       backgroundChats: pick(current.ui.backgroundChats, base.ui.backgroundChats, wanted.ui.backgroundChats),
       tabsToKeepOpen: pick(current.ui.tabsToKeepOpen, base.ui.tabsToKeepOpen, wanted.ui.tabsToKeepOpen),
-      minimizeToTray: pick(current.ui.minimizeToTray, base.ui.minimizeToTray, wanted.ui.minimizeToTray),
       autoConnect: pick(current.ui.autoConnect, base.ui.autoConnect, wanted.ui.autoConnect),
       privacyScreenshots: pick(
         current.ui.privacyScreenshots,

--- a/src/main/window-lifecycle.ts
+++ b/src/main/window-lifecycle.ts
@@ -55,20 +55,7 @@ export function createWindowActivationGate(showWindow: () => void): {
 }
 
 /**
- * Closing the last ordinary window is not an application quit on macOS. The app stays in the
- * Dock/menu bar until the user explicitly quits (Cmd+Q / application menu / tray menu), and a
- * later `activate` recreates the window. Windows/Linux retain the existing preference semantics:
- * when close-to-tray is off, closing the last window exits the app.
- */
-export function shouldQuitOnWindowAllClosed(
-  platform: NodeJS.Platform,
-  minimizeToTray: boolean
-): boolean {
-  return platform !== 'darwin' && !minimizeToTray;
-}
-
-/**
- * macOS users return to a hidden app through the Dock, which Electron reports as `activate`.
+ * macOS can report Finder/re-launch activation through `activate` even for a menu-bar accessory.
  * Windows/Linux use the tray/second-instance paths and should not gain a synthetic handler.
  */
 export function registerNativeWindowActivation(

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -516,7 +516,7 @@
 
               <div class="field">
                 <label class="inline"><input type="checkbox" id="autoConnect" /> Connect automatically at startup</label>
-                <label class="inline"><input type="checkbox" id="minimizeToTray" /> <span id="minimizeToTrayCopy">Keep running when closed</span></label>
+                <label class="inline"><input type="checkbox" id="minimizeToTray" checked disabled /> <span id="minimizeToTrayCopy">Runs in the tray when closed</span></label>
                 <label class="inline" id="privacyScreenshotsSetting"><input type="checkbox" id="privacyScreenshots" /> Privacy screenshots: default to the active window instead of the whole monitor</label>
                 <label class="inline"><input type="checkbox" id="developerMode" /> Developer mode: show turn boundaries and recovery events</label>
               </div>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -516,7 +516,6 @@
 
               <div class="field">
                 <label class="inline"><input type="checkbox" id="autoConnect" /> Connect automatically at startup</label>
-                <label class="inline"><input type="checkbox" id="minimizeToTray" checked disabled /> <span id="minimizeToTrayCopy">Runs in the tray when closed</span></label>
                 <label class="inline" id="privacyScreenshotsSetting"><input type="checkbox" id="privacyScreenshots" /> Privacy screenshots: default to the active window instead of the whole monitor</label>
                 <label class="inline"><input type="checkbox" id="developerMode" /> Developer mode: show turn boundaries and recovery events</label>
               </div>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -448,7 +448,6 @@ function save(over: { readOnly?: boolean; theme?: 'light' | 'dark' } = {}): Prom
       finishLeadMinutes: Number($<HTMLSelectElement>('finishLeadMinutes').value),
       backgroundChats: $<HTMLInputElement>('backgroundChats').checked,
       autoConnect: $<HTMLInputElement>('autoConnect').checked,
-      minimizeToTray: $<HTMLInputElement>('minimizeToTray').checked,
       developerMode: $<HTMLInputElement>('developerMode').checked,
       privacyScreenshots: $<HTMLInputElement>('privacyScreenshots').checked,
       theme: over.theme ?? previous.ui.theme
@@ -929,9 +928,6 @@ function apply(next: AppState): void {
   applyChecked($<HTMLInputElement>('backgroundChats'), config.ui.backgroundChats === true, previousState?.config.ui.backgroundChats);
   applyChecked($<HTMLInputElement>('autoConnect'), config.ui.autoConnect, previousState?.config.ui.autoConnect);
   applyChecked($<HTMLInputElement>('developerMode'), config.ui.developerMode === true, previousState?.config.ui.developerMode);
-  // Tray residence is now an app invariant rather than an optional close behavior. Keep the
-  // legacy persisted field pinned true so older configs converge on the current contract.
-  $<HTMLInputElement>('minimizeToTray').checked = true;
   applyChecked(
     $<HTMLInputElement>('privacyScreenshots'),
     config.ui.privacyScreenshots,
@@ -941,11 +937,9 @@ function apply(next: AppState): void {
   if (next.platform?.family === 'macos') {
     $('backgroundRunningCopy').textContent =
       'Leave it running while you use the connector. It stays available from the menu bar without occupying the Dock when you close the window.';
-    $('minimizeToTrayCopy').textContent = 'Runs in the menu bar when the window is closed';
   } else {
     $('backgroundRunningCopy').textContent =
       'Leave it running while you use the connector. It stays in the tray when you close the window.';
-    $('minimizeToTrayCopy').textContent = 'Runs in the tray when the window is closed';
   }
 
   const openai = config.tunnel.kind === 'openai';
@@ -1626,7 +1620,6 @@ $('removeApiKey').addEventListener('click', async () => {
 
 for (const id of [
   'autoConnect',
-  'minimizeToTray',
   'developerMode',
   'privacyScreenshots',
   'tunnelKind',

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -929,11 +929,9 @@ function apply(next: AppState): void {
   applyChecked($<HTMLInputElement>('backgroundChats'), config.ui.backgroundChats === true, previousState?.config.ui.backgroundChats);
   applyChecked($<HTMLInputElement>('autoConnect'), config.ui.autoConnect, previousState?.config.ui.autoConnect);
   applyChecked($<HTMLInputElement>('developerMode'), config.ui.developerMode === true, previousState?.config.ui.developerMode);
-  applyChecked(
-    $<HTMLInputElement>('minimizeToTray'),
-    config.ui.minimizeToTray,
-    previousState?.config.ui.minimizeToTray
-  );
+  // Tray residence is now an app invariant rather than an optional close behavior. Keep the
+  // legacy persisted field pinned true so older configs converge on the current contract.
+  $<HTMLInputElement>('minimizeToTray').checked = true;
   applyChecked(
     $<HTMLInputElement>('privacyScreenshots'),
     config.ui.privacyScreenshots,
@@ -942,12 +940,12 @@ function apply(next: AppState): void {
   $('privacyScreenshotsSetting').hidden = !(next.platform?.desktopAutomation ?? true);
   if (next.platform?.family === 'macos') {
     $('backgroundRunningCopy').textContent =
-      'Leave it running while you use the connector. It stays available from the menu bar and Dock when you close the window.';
-    $('minimizeToTrayCopy').textContent = 'Hide the window to the menu bar when closed';
+      'Leave it running while you use the connector. It stays available from the menu bar without occupying the Dock when you close the window.';
+    $('minimizeToTrayCopy').textContent = 'Runs in the menu bar when the window is closed';
   } else {
     $('backgroundRunningCopy').textContent =
       'Leave it running while you use the connector. It stays in the tray when you close the window.';
-    $('minimizeToTrayCopy').textContent = 'Keep running in the tray when closed';
+    $('minimizeToTrayCopy').textContent = 'Runs in the tray when the window is closed';
   }
 
   const openai = config.tunnel.kind === 'openai';

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -125,7 +125,6 @@ export interface UiPrefs {
   finishAction?: 'notify' | 'goal';
   finishLeadMinutes?: number;
   developerMode?: boolean;
-  minimizeToTray: boolean;
   autoConnect: boolean;
   /** Default screenshots to the active window instead of the whole primary monitor. */
   privacyScreenshots: boolean;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -75,7 +75,9 @@ describe('settings migration', () => {
         tunnelId: 'tunnel_0123456789abcdef0123456789abcdef',
         binaryPath: ''
       },
-      ui: { minimizeToTray: true, autoConnect: true }
+      // The retired close-to-tray preference may be false in an older config. It must be
+      // discarded at the config boundary now that tray residence is an application invariant.
+      ui: { minimizeToTray: false, autoConnect: true }
     };
     await fs.writeFile(path.join(dir, 'config.json'), JSON.stringify(oldConfig), 'utf8');
 
@@ -85,6 +87,7 @@ describe('settings migration', () => {
     expect(loaded.capabilities.clipboardRead).toBe(false);
     expect(loaded.capabilities.clipboardWrite).toBe(false);
     expect(loaded.ui.autoConnect).toBe(true);
+    expect(loaded.ui).not.toHaveProperty('minimizeToTray');
     expect(loaded.ui.privacyScreenshots).toBe(false);
     // The one tunnel id a pre-split config had is Core's, because Core is the connector
     // the app cannot work without. Desktop is a second, optional tunnel that starts empty
@@ -355,7 +358,7 @@ describe('shipped defaults', () => {
       capabilities: { browse: true, search: true, read: true, metadata: true },
       readOnly: true,
       tunnel: { kind: 'openai', tunnelId: '', binaryPath: '' },
-      ui: { minimizeToTray: true, autoConnect: false }
+      ui: { autoConnect: false }
     };
     await fs.writeFile(path.join(dir, 'config.json'), JSON.stringify(legacy), 'utf8');
     const loaded = await loadConfig();

--- a/test/ipc.test.ts
+++ b/test/ipc.test.ts
@@ -501,9 +501,9 @@ describe('settings writes from more than one UI', () => {
     expect(selected.ok, selected.error).toBe(true);
     expect(getConfig().ui.planBackend).toBe('api');
     expect(JSON.parse(await fs.readFile(path.join(dir, 'config.json'), 'utf8')).ui.planBackend).toBe('api');
-    const stale = await save({ ...base, ui: { ...base.ui, minimizeToTray: !base.ui.minimizeToTray } }, base);
+    const stale = await save({ ...base, ui: { ...base.ui, autoConnect: !base.ui.autoConnect } }, base);
     expect(stale.ok, stale.error).toBe(true);
-    expect(getConfig().ui).toMatchObject({ planBackend: 'api', minimizeToTray: !base.ui.minimizeToTray });
+    expect(getConfig().ui).toMatchObject({ planBackend: 'api', autoConnect: !base.ui.autoConnect });
     const current = getConfig();
     expect((await save({ ...current, ui: { ...current.ui, planBackend: 'chatgpt' } }, current)).ok).toBe(true);
     expect(getConfig().ui.planBackend).toBe('chatgpt');
@@ -545,11 +545,11 @@ describe('settings writes from more than one UI', () => {
       multiAgent: { ...base.multiAgent, allowUnattributedCalls: true }
     });
 
-    const wanted = { ...base, ui: { ...base.ui, minimizeToTray: !base.ui.minimizeToTray } };
+    const wanted = { ...base, ui: { ...base.ui, autoConnect: !base.ui.autoConnect } };
     const reply = await save(wanted, base);
 
     expect(reply.ok, reply.error).toBe(true);
-    expect(getConfig().ui.minimizeToTray).toBe(!base.ui.minimizeToTray);
+    expect(getConfig().ui.autoConnect).toBe(!base.ui.autoConnect);
     expect(getConfig().multiAgent.allowUnattributedCalls).toBe(true);
   });
 
@@ -561,11 +561,11 @@ describe('settings writes from more than one UI', () => {
       multiAgent: { ...base.multiAgent, recoverAgentTabs: false }
     });
 
-    const wanted = { ...base, ui: { ...base.ui, minimizeToTray: !base.ui.minimizeToTray } };
+    const wanted = { ...base, ui: { ...base.ui, autoConnect: !base.ui.autoConnect } };
     const reply = await save(wanted, base);
 
     expect(reply.ok, reply.error).toBe(true);
-    expect(getConfig().ui.minimizeToTray).toBe(!base.ui.minimizeToTray);
+    expect(getConfig().ui.autoConnect).toBe(!base.ui.autoConnect);
     expect(getConfig().multiAgent.recoverAgentTabs).toBe(false);
   });
 });

--- a/test/packaging.test.ts
+++ b/test/packaging.test.ts
@@ -306,17 +306,12 @@ describe('cross-platform packaging targets', () => {
     const beforeQuit = main.indexOf("app.on('before-quit', () => {");
     const beforeQuitOwner = main.indexOf('if (!ownsAppRuntime(hasSingleInstanceLock)) return;', beforeQuit);
     const beforeQuitMutation = main.indexOf('quitting = true;', beforeQuit);
-    const windowAllClosed = main.indexOf("app.on('window-all-closed', () => {");
-    const windowAllOwner = main.indexOf('if (!ownsAppRuntime(hasSingleInstanceLock)) return;', windowAllClosed);
-    const windowAllConfig = main.indexOf('getConfig().ui.minimizeToTray', windowAllClosed);
     const willQuit = main.indexOf("app.on('will-quit', (event) => {");
     const willQuitOwner = main.indexOf('if (!ownsAppRuntime(hasSingleInstanceLock)) return;', willQuit);
     const preventDefault = main.indexOf('event.preventDefault();', willQuit);
 
     expect(beforeQuitOwner).toBeGreaterThan(beforeQuit);
     expect(beforeQuitOwner).toBeLessThan(beforeQuitMutation);
-    expect(windowAllOwner).toBeGreaterThan(windowAllClosed);
-    expect(windowAllOwner).toBeLessThan(windowAllConfig);
     expect(willQuitOwner).toBeGreaterThan(willQuit);
     expect(willQuitOwner).toBeLessThan(preventDefault);
   });
@@ -327,13 +322,17 @@ describe('cross-platform packaging targets', () => {
     const loadConfig = main.indexOf('await loadConfig();', ready);
     const theme = main.indexOf('nativeTheme.themeSource = getConfig().ui.theme;', loadConfig);
     const enableActivation = main.indexOf('windowActivation.enable();', theme);
-    const firstWindowRequest = main.indexOf('windowActivation.request();', enableActivation);
+    const trayCreation = main.indexOf('tray = new Tray(', enableActivation);
+    const startupCreate = main.indexOf('  createWindow();', trayCreation);
+    const startupShow = main.indexOf('  windowActivation.request();', startupCreate);
 
     expect(ready).toBeGreaterThan(-1);
     expect(loadConfig).toBeGreaterThan(ready);
     expect(theme).toBeGreaterThan(loadConfig);
     expect(enableActivation).toBeGreaterThan(theme);
-    expect(firstWindowRequest).toBeGreaterThan(enableActivation);
+    expect(trayCreation).toBeGreaterThan(enableActivation);
+    expect(startupCreate).toBeGreaterThan(trayCreation);
+    expect(startupShow).toBeGreaterThan(startupCreate);
 
     const ipc = readFileSync(path.join(root, 'src', 'main', 'ipc.ts'), 'utf8');
     const save = ipc.indexOf("handle('settings:save', async (payload) => {");
@@ -342,6 +341,16 @@ describe('cross-platform packaging targets', () => {
     expect(save).toBeGreaterThan(-1);
     expect(liveTheme).toBeGreaterThan(save);
     expect(background).toBeGreaterThan(liveTheme);
+  });
+
+  it('keeps macOS menu-bar-only while still allowing the control-panel window', () => {
+    const builder = yamlFile('electron-builder.yml');
+    const main = readFileSync(path.join(root, 'src', 'main', 'index.ts'), 'utf8');
+    const macSmoke = readFileSync(path.join(root, 'scripts', 'smoke-macos-bundle.mjs'), 'utf8');
+
+    expect(builder.mac.extendInfo.LSUIElement).toBe(true);
+    expect(main).toContain("if (process.platform === 'darwin') app.setActivationPolicy('accessory');");
+    expect(macSmoke).toContain("LSUIElement: 'true'");
   });
 
   it('uses Noble-compatible Linux packages and a FUSE-independent AppImage runtime', () => {
@@ -432,6 +441,7 @@ describe('cross-platform packaging targets', () => {
       'CFBundleVersion: packageVersion',
       "LSApplicationCategoryType: 'public.app-category.developer-tools'",
       "LSMinimumSystemVersion: '13.0'",
+      "LSUIElement: 'true'",
       'NSScreenCaptureUsageDescription:',
       "path.join(resources, 'desktop', 'macos-desktop-addon.node')",
       "path.join(resources, 'desktop', 'libcos-desktop.dylib')",

--- a/test/renderer-state.test.ts
+++ b/test/renderer-state.test.ts
@@ -444,15 +444,15 @@ it('preserves native Desktop permissions when saving unrelated settings on Linux
   });
 });
 
-it('uses native menu-bar/Dock wording on macOS instead of Windows tray copy', async () => {
+it('uses menu-bar-only wording on macOS instead of Windows tray copy', async () => {
   const mounted = await mountChat({
     platform: { family: 'macos', name: 'macOS', desktopAutomation: true }
   });
   const doc = mounted.window.document;
 
-  expect(doc.getElementById('backgroundRunningCopy')!.textContent).toContain('menu bar and Dock');
+  expect(doc.getElementById('backgroundRunningCopy')!.textContent).toContain('menu bar without occupying the Dock');
   expect(doc.getElementById('backgroundRunningCopy')!.textContent).not.toContain('tray');
-  expect(doc.getElementById('minimizeToTrayCopy')!.textContent).toBe('Hide the window to the menu bar when closed');
+  expect(doc.getElementById('minimizeToTrayCopy')!.textContent).toBe('Runs in the menu bar when the window is closed');
 });
 
 it('surfaces the existing root rename API in the folder row', async () => {

--- a/test/renderer-state.test.ts
+++ b/test/renderer-state.test.ts
@@ -39,7 +39,7 @@ it('does not overwrite a focused dirty settings field on an unsolicited state pu
       screen: false, control: false, clipboardRead: false, clipboardWrite: false
     },
     tunnel: { kind: 'openai', tunnelId: 'tunnel_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', desktopTunnelId: '', binaryPath: '' },
-    ui: { minimizeToTray: true, autoConnect: false, privacyScreenshots: false, theme: 'light' },
+    ui: { autoConnect: false, privacyScreenshots: false, theme: 'light' },
     sessions: { record: true, retainDays: 30, advisoryTokens: 300000, limitTokens: 400000 },
     compaction: { auto: true, autoTokens: 300000 },
     multiAgent: { enabled: false, maxWorkers: 2, allowUnattributedCalls: false, recoverAgentTabs: true },
@@ -194,7 +194,7 @@ it('serializes settings intent so rapid toggles and later UI changes cannot undo
       screen: true, control: true, clipboardRead: true, clipboardWrite: true
     },
     tunnel: { kind: 'openai', tunnelId: 'tunnel_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', desktopTunnelId: '', binaryPath: '' },
-    ui: { minimizeToTray: true, autoConnect: false, privacyScreenshots: false, theme: 'light' as 'light' | 'dark' },
+    ui: { autoConnect: false, privacyScreenshots: false, theme: 'light' as 'light' | 'dark' },
     sessions: { record: true, retainDays: 30, advisoryTokens: 300000, limitTokens: 400000 },
     compaction: { auto: true, autoTokens: 300000 },
     multiAgent: { enabled: false, maxWorkers: 2, allowUnattributedCalls: false, recoverAgentTabs: true },
@@ -342,7 +342,7 @@ async function mountChat(
       screen: true, control: true, clipboardRead: true, clipboardWrite: true
     },
     tunnel: { kind: 'openai', tunnelId: 'tunnel_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', desktopTunnelId: '', binaryPath: '' },
-    ui: { minimizeToTray: true, autoConnect: false, privacyScreenshots: false, theme: 'light' as const },
+    ui: { autoConnect: false, privacyScreenshots: false, theme: 'light' as const },
     sessions: { record: true, retainDays: 30, advisoryTokens: 300000, limitTokens: 400000 },
     compaction: { auto: true, autoTokens: 300000 },
     multiAgent: { enabled: false, maxWorkers: 2, allowUnattributedCalls: false, recoverAgentTabs: true },
@@ -452,7 +452,7 @@ it('uses menu-bar-only wording on macOS instead of Windows tray copy', async () 
 
   expect(doc.getElementById('backgroundRunningCopy')!.textContent).toContain('menu bar without occupying the Dock');
   expect(doc.getElementById('backgroundRunningCopy')!.textContent).not.toContain('tray');
-  expect(doc.getElementById('minimizeToTrayCopy')!.textContent).toBe('Runs in the menu bar when the window is closed');
+  expect(doc.getElementById('minimizeToTray')).toBeNull();
 });
 
 it('surfaces the existing root rename API in the folder row', async () => {

--- a/test/renderer-timeline.test.ts
+++ b/test/renderer-timeline.test.ts
@@ -161,7 +161,7 @@ async function boot(events: SessionEvent[], selectExisting = true, pausedHelpers
       screen: false, control: false, clipboardRead: false, clipboardWrite: false
     },
     tunnel: { kind: 'openai', tunnelId: 'tunnel_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', desktopTunnelId: '', binaryPath: '' },
-    ui: { minimizeToTray: true, autoConnect: false, privacyScreenshots: false, theme: 'light', developerMode: options.developerMode ?? false },
+    ui: { autoConnect: false, privacyScreenshots: false, theme: 'light', developerMode: options.developerMode ?? false },
     sessions: { record: true, retainDays: 30, advisoryTokens: 300000, limitTokens: 400000 },
     compaction: { auto: true, autoTokens: 300000 },
     multiAgent: { enabled: false, maxWorkers: 2, allowUnattributedCalls: false, recoverAgentTabs: true },

--- a/test/window-lifecycle.test.ts
+++ b/test/window-lifecycle.test.ts
@@ -5,8 +5,7 @@ import {
   createWindowActivationGate,
   ownsAppRuntime,
   registerNativeWindowActivation,
-  shouldBeginAppBootstrap,
-  shouldQuitOnWindowAllClosed
+  shouldBeginAppBootstrap
 } from '../src/main/window-lifecycle.js';
 
 describe('native window activation', () => {
@@ -22,6 +21,11 @@ describe('native window activation', () => {
     const context = vm.createContext({ window: native, quitting: false, createWindow });
     vm.runInContext(present + '\nshowWindow();', context);
     expect(operations.splice(0)).toEqual(['show', 'maximize', 'focus']);
+    context.window = null;
+    context.createWindow = vi.fn(() => { context.window = native; });
+    vm.runInContext('showWindow()', context);
+    expect(context.createWindow).toHaveBeenCalledTimes(1);
+    expect(operations.splice(0)).toEqual(['show', 'maximize', 'focus']);
     state.minimized = true;
     vm.runInContext('showWindow()', context);
     expect(operations.splice(0)).toEqual(['restore', 'show', 'maximize', 'focus']);
@@ -32,17 +36,25 @@ describe('native window activation', () => {
     vm.runInContext('showWindow()', context);
     expect(operations).toEqual([]);
 
-    let ready!: () => void;
-    const startup = source.slice(source.indexOf("  window.once('ready-to-show'"), source.indexOf('  // A renderer that fails', source.indexOf("  window.once('ready-to-show'")));
-    const showWindow = vi.fn();
-    const launch = vm.createContext({ window: { once: (_event: string, listener: () => void) => { ready = listener; } }, quitting: false, showWindow });
-    vm.runInContext(startup, launch);
-    ready(); expect(showWindow).toHaveBeenCalledTimes(1);
-    launch.quitting = true; ready(); expect(showWindow).toHaveBeenCalledTimes(1);
+    // BrowserWindow itself starts hidden so renderer readiness cannot race presentation. Once
+    // startup owns the tray and activation gate, every primary process launch explicitly opens it.
+    expect(source).toContain('show: false');
+    expect(source).not.toContain("window.once('ready-to-show'");
+    expect(source).toContain("tray.on('click', windowActivation.request)");
+    const startupCreate = source.indexOf('  createWindow();', source.indexOf('tray = new Tray('));
+    const startupShow = source.indexOf('  windowActivation.request();', startupCreate);
+    expect(startupCreate).toBeGreaterThan(-1);
+    expect(startupShow).toBeGreaterThan(startupCreate);
+
+    // Closing the control panel is never process quit: it is always intercepted and hidden.
+    const close = source.slice(source.indexOf("  window.on('close'"), source.indexOf("  window.on('closed'"));
+    expect(close).toContain('if (!quitting)');
+    expect(close).toContain('event.preventDefault();');
+    expect(close).toContain('window?.hide();');
   });
   it('starts background catalog discovery on each actual show, including tray reopen, and never during quit', async () => {
     const source = readFileSync(new URL('../src/main/index.ts', import.meta.url), 'utf8');
-    const listener = source.slice(source.indexOf("  window.on('show'"), source.indexOf("  window.once('ready-to-show'"));
+    const listener = source.slice(source.indexOf("  window.on('show'"), source.indexOf('  // The desktop window is a control panel'));
     let show!: () => void;
     const start = vi.fn(async () => ({}));
     const context = vm.createContext({ window: { on: (event: string, callback: () => void) => {
@@ -70,8 +82,8 @@ describe('native window activation', () => {
     const gate = createWindowActivationGate(show);
 
     // Electron can emit second-instance after its `ready` event while our async startup is still
-    // restoring state. The initial startup path will show a window itself, so this early request
-    // must not create one before CSP/permission/IPC setup is complete.
+    // restoring state. Startup itself opens the control panel only after bootstrap, so an early
+    // second-instance request must not create or reveal one before security/IPC is ready.
     gate.request();
     expect(show).not.toHaveBeenCalled();
 
@@ -88,14 +100,14 @@ describe('native window activation', () => {
 
     // Startup is async. A continuation that resumes after `before-quit` can still execute its
     // old enable() call; shutdown must be a one-way boundary so that stale continuation cannot
-    // reactivate Dock/second-instance/tray presentation.
+    // reactivate native/second-instance/tray presentation.
     expect(gate.isDisabled()).toBe(true);
     gate.enable();
     gate.request();
     expect(show).toHaveBeenCalledTimes(1);
   });
 
-  it('reopens the app from the macOS Dock activation event', () => {
+  it('reopens the app from the macOS native activation event', () => {
     const listeners = new Map<string, () => void>();
     const source = { on: vi.fn((event: 'activate', listener: () => void) => listeners.set(event, listener)) };
     const show = vi.fn();
@@ -112,13 +124,4 @@ describe('native window activation', () => {
     expect(source.on).not.toHaveBeenCalled();
   });
 
-  it('keeps a macOS app alive after its last window closes, regardless of close-to-tray preference', () => {
-    expect(shouldQuitOnWindowAllClosed('darwin', true)).toBe(false);
-    expect(shouldQuitOnWindowAllClosed('darwin', false)).toBe(false);
-  });
-
-  it.each(['win32', 'linux'] as const)('keeps close-to-tray semantics on %s', (platform) => {
-    expect(shouldQuitOnWindowAllClosed(platform, true)).toBe(false);
-    expect(shouldQuitOnWindowAllClosed(platform, false)).toBe(true);
-  });
 });


### PR DESCRIPTION
## Summary

- keep macOS running as a true menu-bar accessory with no Dock/App Switcher presence
- open the control panel on every primary app launch and reopen it from tray/native activation
- hide the control panel to the tray/menu bar on close instead of quitting
- pin the legacy close-to-tray setting to the new always-resident behavior
- verify `LSUIElement` in macOS package smoke checks and update lifecycle/docs coverage

## Validation

- `npm run typecheck`
- `npx vitest run test/window-lifecycle.test.ts test/packaging.test.ts test/renderer-state.test.ts` — 54 passed
- `npm test` — 2,844 passed, 100 skipped
- `node scripts/smoke-macos-bundle.mjs arm64`
- packaged `Info.plist` verified with `LSUIElement=true`
