### PR TITLE
feat: add download_artifact MCP tool for saving ChatGPT files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -607,6 +607,7 @@ earn it today.
 | `find` | `search` **and not** `command` | `tools-core.ts` → `search.ts` |
 | `apply_patch` | any of `create`/`edit`/`move`/`deleteFile` | `codex/apply-patch/*` |
 | `exec_command`, `write_stdin` | `command` | `codex/unified-exec.ts` |
+| `download_artifact` | `saveArtifact` | `tools-core.ts` → `artifact-fetch.ts` + `artifact-target.ts` |
 | `session` | recording enabled | session subsystem |
 | `agents` | multi-agent enabled | `agents.ts` |
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Permission changes take effect locally immediately. Schema changes schedule a se
 
 | Connector | Tools | What they do |
 | --- | --- | --- |
-| **Core** (all platforms) | `read`, `view_image`, `find`, `apply_patch`, `exec_command`, `write_stdin`, `session`, `agents` | Bounded reads and search inside approved folders, preflighted multi-file patches, shell commands and interactive terminals, lookups into the recorded session, and worker chat control |
+| **Core** (all platforms) | `read`, `view_image`, `find`, `apply_patch`, `exec_command`, `write_stdin`, `download_artifact`, `session`, `agents` | Bounded reads and search inside approved folders, preflighted multi-file patches, shell commands and interactive terminals, saving ChatGPT-generated files, lookups into the recorded session, and worker chat control |
 | **Desktop** (Windows, and macOS when switched on) | `observe`, `computer` | Screenshots, window and control inspection, mouse, keyboard and clipboard |
 
 The live tool list follows your settings: `find` is the no-shell search fallback and steps aside when commands are enabled. Enabling Session finish adds the Astra-only `session_finish` tool. Revoking a permission takes effect immediately, even while ChatGPT still shows the old schema. The full contract lives in [`docs/tool-surface.md`](docs/tool-surface.md).

--- a/docs/tool-surface.md
+++ b/docs/tool-surface.md
@@ -12,7 +12,7 @@ separate secret tokenized local paths.
 
 | Connector | Purpose | Possible tools |
 | --- | --- | --- |
-| **Chat On Steroids Core** | Approved files, patches, terminal, recorded-session lookup, workers | `read`, `view_image`, `find`, `apply_patch`, `exec_command`, `write_stdin`, `session`, `agents` |
+| **Chat On Steroids Core** | Approved files, patches, terminal, ChatGPT file saving, recorded-session lookup, workers | `read`, `view_image`, `find`, `apply_patch`, `exec_command`, `write_stdin`, `download_artifact`, `session`, `agents` |
 | **Chat On Steroids Desktop** | **Windows/macOS:** screen, windows, mouse/keyboard and clipboard | `observe`, `computer` |
 
 The Desktop connector is optional on Windows/macOS. Core is the main connector everywhere.
@@ -23,8 +23,8 @@ Desktop permissions off at runtime while preserving stored choices for a config 
 Windows or macOS. Existing configs keep explicit choices during upgrades; missing legacy permissions are
 not silently widened.
 
-With the fresh all-on capability snapshot, Core advertises seven schemas:
-`read`, `view_image`, `apply_patch`, `exec_command`, `write_stdin`, `session`, and `agents`.
+With the fresh all-on capability snapshot, Core advertises eight schemas:
+`read`, `view_image`, `apply_patch`, `exec_command`, `write_stdin`, `download_artifact`, `session`, and `agents`.
 `find` is the search fallback for a snapshot where search is enabled and command execution is
 unavailable. Tool exposure is monotonic within a running connector instance, so a permission
 changed mid-conversation can leave a previously exposed name listed; its handler still enforces
@@ -78,6 +78,16 @@ budget. A blank `chars` value is a poll rather than a separate process-status to
 poll returns as soon as the process produces output rather than holding the full yield window;
 anything that arrives afterwards stays buffered for the next poll. A non-empty write keeps
 Codex's collection-window behaviour so one interactive response is gathered whole.
+
+### `download_artifact`
+
+Saves one file ChatGPT generated or attached into an approved folder. The file value is
+injected by ChatGPT (the schema carries `_meta` `openai/fileParams`); the model supplies
+only the destination path, never a URL or bytes. Gated by the save-artifact capability
+and bounded by a per-file byte limit (default 20 MiB). Missing parents are created, an
+existing destination is refused rather than overwritten, and symlinked parents are
+rejected. Binary files must go through this tool, never be recreated with
+`apply_patch` or `exec_command`.
 
 ### `session`
 

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -18,6 +18,7 @@ import {
   WRITE_CAPABILITIES,
   type Capabilities,
   DESKTOP_CAPABILITIES,
+  type ArtifactSettings,
   type CompactionSettings,
   type Config,
   type GoalSettings,
@@ -112,6 +113,17 @@ const DEFAULT_COMPACTION: CompactionSettings = {
   auto: true,
   autoTokens: DEFAULT_SESSIONS.advisoryTokens
 };
+/**
+ * Default bound for `download_artifact`.
+ *
+ * 20 MiB covers generated images, PDFs and small archives without letting one call
+ * fill the disk or blow the MCP result budget. Enforced before, during and after
+ * the stream (see artifact-fetch/artifact-target), so a lying Content-Length helps nothing.
+ */
+const DEFAULT_ARTIFACTS: ArtifactSettings = {
+  maxFileBytes: 20 * 1024 * 1024
+};
+
 /**
  * The goal loop's defaults.
  *
@@ -317,6 +329,18 @@ const configSchema = z.object({
     })
     .optional()
     .default({ ...DEFAULT_MULTI_AGENT }),
+  artifacts: z
+    .object({
+      maxFileBytes: z
+        .number()
+        .int()
+        .min(1)
+        .max(256 * 1024 * 1024)
+        .optional()
+        .default(DEFAULT_ARTIFACTS.maxFileBytes)
+    })
+    .optional()
+    .default({ ...DEFAULT_ARTIFACTS }),
   // An empty model id is repaired rather than rejected: the id is free text from a
   // provider listing that changes weekly, and a config that lost it must still load with
   // every root and permission in it intact.
@@ -408,6 +432,7 @@ export function defaultConfig(platform: NodeJS.Platform = process.platform, rele
     sessions: { ...DEFAULT_SESSIONS },
     compaction: { ...DEFAULT_COMPACTION },
     multiAgent: { ...FIRST_LAUNCH_MULTI_AGENT },
+    artifacts: { ...DEFAULT_ARTIFACTS },
     goal: { ...DEFAULT_GOAL }
   };
 }

--- a/src/main/connection.ts
+++ b/src/main/connection.ts
@@ -154,6 +154,7 @@ function toolsFor(id: SurfaceId): string[] {
   if (!caps.command && caps.search) tools.push('find');
   if (caps.create || caps.edit || caps.move || caps.deleteFile) tools.push('apply_patch');
   if (caps.command) tools.push('exec_command', 'write_stdin');
+  if (caps.saveArtifact) tools.push('download_artifact');
   if (config.sessions.record) tools.push('session');
   if (config.multiAgent.enabled) tools.push('agents');
   return tools;

--- a/src/main/mcp/artifact-download.ts
+++ b/src/main/mcp/artifact-download.ts
@@ -1,0 +1,106 @@
+/**
+ * Orchestration for `download_artifact`: resolve → fetch → write → publish.
+ *
+ * Mirrors devspace `downloadIncomingArtifact` (src/artifact-tools.ts:127-218) with two
+ * local adaptations: path resolution goes through `resolveIn` (approved roots +
+ * per-chat workspace, the sandbox remaining the single authority), and the secure
+ * target is the koffi-free `artifact-target.ts`.
+ */
+
+import { createHash } from 'node:crypto';
+import nodePath from 'node:path';
+import { rawPromises as fs } from '../rawfs.js';
+import { resolveIn } from './kernel.js';
+import type { Root } from '../../shared/types.js';
+import {
+  ArtifactFetchError,
+  openArtifactFile,
+  type OpenAIFileAdapterOptions
+} from './artifact-fetch.js';
+import { ArtifactTargetError, openArtifactTarget } from './artifact-target.js';
+
+export interface SavedArtifact {
+  /** Normalised virtual path, always "/root/..." with forward slashes. */
+  virtual: string;
+  size: number;
+  sha256: string;
+}
+
+export interface DownloadArtifactOptions extends OpenAIFileAdapterOptions {
+  maxFileBytes: number;
+}
+
+/**
+ * Stream one ChatGPT-injected file value to `requestedPath` inside an approved root.
+ * The destination must name a file that does not already exist; missing parents are
+ * created. Throws ArtifactFetchError / ArtifactTargetError / SandboxError on refusal;
+ * the caller maps those to model-facing failures without leaking real paths.
+ */
+export async function downloadArtifactFile(
+  roots: readonly Root[],
+  requestedPath: string,
+  file: unknown,
+  options: DownloadArtifactOptions
+): Promise<SavedArtifact> {
+  const { maxFileBytes } = options;
+  if (!Number.isSafeInteger(maxFileBytes) || maxFileBytes < 1) {
+    throw new ArtifactTargetError('Artifact file-size limit must be a positive integer.');
+  }
+  if (typeof requestedPath !== 'string' || requestedPath.trim() === '') {
+    throw new ArtifactTargetError('Artifact destination is invalid.');
+  }
+  if (/[/\\]$/.test(requestedPath.trim())) {
+    throw new ArtifactTargetError('Artifact destination must name a file, not a folder.');
+  }
+
+  const resolved = await resolveIn(roots as Parameters<typeof resolveIn>[0], requestedPath, {
+    allowMissing: true
+  });
+  const parentReal = nodePath.dirname(resolved.real);
+  const name = nodePath.basename(resolved.real);
+  let rootReal: string;
+  try {
+    rootReal = await fs.realpath(resolved.root.path);
+  } catch {
+    rootReal = resolved.root.path;
+  }
+
+  const opened = await openArtifactFile(file, options);
+  if (opened.size !== undefined && opened.size > maxFileBytes) {
+    opened.stream.destroy();
+    throw new ArtifactFetchError('ChatGPT file exceeds the configured per-file limit.');
+  }
+
+  try {
+    await fs.mkdir(parentReal, { recursive: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+  }
+
+  const target = await openArtifactTarget({ parentReal, rootReal, name, maxFileBytes });
+  const hash = createHash('sha256');
+  let size = 0;
+  try {
+    for await (const value of opened.stream) {
+      const chunk =
+        typeof value === 'string' ? Buffer.from(value) : Buffer.from(value as Uint8Array);
+      if (size + chunk.length > maxFileBytes) {
+        throw new ArtifactFetchError('ChatGPT file exceeds the configured per-file limit.');
+      }
+      await target.writeAll(chunk, size);
+      hash.update(chunk);
+      size += chunk.length;
+    }
+    if (opened.size !== undefined && opened.size !== size) {
+      throw new ArtifactFetchError('ChatGPT file metadata did not match the downloaded content.');
+    }
+    await target.syncAndVerify(size);
+    await target.publish();
+    return { virtual: resolved.virtual, size, sha256: `sha256:${hash.digest('hex')}` };
+  } catch (error) {
+    opened.stream.destroy();
+    throw error;
+  } finally {
+    await target.close().catch(() => undefined);
+  }
+}

--- a/src/main/mcp/artifact-fetch.ts
+++ b/src/main/mcp/artifact-fetch.ts
@@ -1,0 +1,301 @@
+/**
+ * Trusted gateway from a ChatGPT-injected file reference to a readable byte stream.
+ *
+ * Ported from devspace `src/incoming-artifacts.ts`: the model never supplies bytes or
+ * URLs directly. ChatGPT injects `{download_url, file_id, ...}` because the tool schema
+ * carries `_meta: {"openai/fileParams": ["file"]}`; this module validates that value and
+ * fetches it. Anything the model invents fails here, before any disk is touched.
+ */
+
+import { basename, isAbsolute } from 'node:path';
+import { Readable } from 'node:stream';
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
+
+const OPENAI_FILE_HOSTS = new Set(['files.oaiusercontent.com']);
+// ChatGPT-generated files are served from regional OpenAI-managed Azure storage
+// accounts. Accept that account family only, never arbitrary Azure Blob hosts.
+const OPENAI_REGIONAL_BLOB_HOST_PATTERN = /^oaisdmntpr[a-z0-9]+\.blob\.core\.windows\.net$/u;
+const OPENAI_FILENAME_SAFE_FILE_ID_PATTERN = /^file[-_][A-Za-z0-9][A-Za-z0-9._-]{0,255}$/u;
+const OPENAI_FILE_ID_MAX_LENGTH = 512;
+const OPENAI_FILE_ID_CONTROL_PATTERN = /[\u0000-\u001F\u007F]/u;
+const OPENAI_FILE_KEYS = new Set([
+  'download_url',
+  'file_id',
+  'mime_type',
+  'file_name',
+  'name',
+  'size'
+]);
+const OPENAI_FILE_REDIRECT_LIMIT = 3;
+const OPENAI_FILE_DOWNLOAD_TIMEOUT_MS = 30_000;
+
+export class ArtifactFetchError extends Error {}
+
+export interface ArtifactSource {
+  name: string;
+  mimeType?: string;
+  size?: number;
+  stream: Readable;
+}
+
+export interface OpenAIFileReference {
+  download_url: string;
+  file_id: string;
+  mime_type?: string;
+  file_name?: string;
+  size?: number;
+}
+
+export interface OpenAIFileAdapterOptions {
+  fetch?: typeof fetch;
+  timeoutMs?: number;
+}
+
+/**
+ * Shape-only summary for logs: type/length/URL-kind, never the URL or id itself.
+ * Mirrors devspace describeIncomingArtifactValue for the fields this tool accepts.
+ */
+export function describeArtifactFileValue(value: unknown): unknown {
+  if (value === null || value === undefined) return { type: value === null ? 'null' : 'undefined' };
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    return { type: Array.isArray(value) ? 'array' : typeof value };
+  }
+  const entries: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort().slice(0, 20)) {
+    const entry = (value as Record<string, unknown>)[key];
+    entries[key] =
+      typeof entry === 'string'
+        ? { type: 'string', kind: classifyValueString(entry), length: entry.length }
+        : { type: typeof entry };
+  }
+  return { type: 'object', entries };
+}
+
+/** Hostname only, for logs. Returns null when the reference has no usable URL. */
+export function artifactFileHostname(value: unknown): string | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const raw = (value as Record<string, unknown>)['download_url'];
+  if (typeof raw !== 'string') return null;
+  try {
+    return new URL(raw).hostname;
+  } catch {
+    return null;
+  }
+}
+
+export function isOpenAIFileReferenceCandidate(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  return (
+    keys.length >= 2 &&
+    keys.every((key) => OPENAI_FILE_KEYS.has(key)) &&
+    Object.hasOwn(value, 'download_url') &&
+    Object.hasOwn(value, 'file_id')
+  );
+}
+
+export function normalizeOpenAIFileReference(value: unknown): OpenAIFileReference {
+  if (!isOpenAIFileReferenceCandidate(value)) {
+    throw new ArtifactFetchError('ChatGPT file reference is malformed.');
+  }
+  const downloadUrl = value['download_url'];
+  const fileId = value['file_id'];
+  if (typeof downloadUrl !== 'string' || typeof fileId !== 'string' || !isValidOpenAIFileId(fileId)) {
+    throw new ArtifactFetchError('ChatGPT file reference is malformed.');
+  }
+  const mimeType = nullableString(value['mime_type']);
+  const fileName = nullableString(value['file_name']);
+  const nameAlias = nullableString(value['name']);
+  if (mimeType === null || fileName === null || nameAlias === null) {
+    throw new ArtifactFetchError('ChatGPT file reference is malformed.');
+  }
+  const normalizedFileName = normalizeSuppliedFileName(fileName);
+  const normalizedNameAlias = normalizeSuppliedFileName(nameAlias);
+  if (normalizedFileName && normalizedNameAlias && normalizedFileName !== normalizedNameAlias) {
+    throw new ArtifactFetchError('ChatGPT file reference contained conflicting filenames.');
+  }
+  let size: number | undefined;
+  const rawSize = value['size'];
+  if (rawSize !== undefined && rawSize !== null) {
+    if (typeof rawSize !== 'number' || !Number.isSafeInteger(rawSize) || rawSize < 0) {
+      throw new ArtifactFetchError('ChatGPT file reference is malformed.');
+    }
+    size = rawSize;
+  }
+  return {
+    download_url: downloadUrl,
+    file_id: fileId,
+    mime_type: mimeType,
+    file_name: normalizedFileName ?? normalizedNameAlias,
+    size
+  };
+}
+
+/** Fetch the trusted file URL and return its stream. Every redirect is re-validated. */
+export async function openArtifactFile(
+  value: unknown,
+  options: OpenAIFileAdapterOptions = {}
+): Promise<ArtifactSource> {
+  const fetchFile = options.fetch ?? globalThis.fetch;
+  const timeoutMs = options.timeoutMs ?? OPENAI_FILE_DOWNLOAD_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new ArtifactFetchError('Artifact download timeout must be a positive integer.');
+  }
+  const reference = normalizeOpenAIFileReference(value);
+
+  let downloadUrl = validateOpenAIFileUrl(reference.download_url);
+  let response: Response | undefined;
+  for (let redirect = 0; redirect <= OPENAI_FILE_REDIRECT_LIMIT; redirect += 1) {
+    try {
+      response = await fetchFile(downloadUrl, {
+        redirect: 'manual',
+        signal: AbortSignal.timeout(timeoutMs)
+      });
+    } catch {
+      throw new ArtifactFetchError('ChatGPT file could not be downloaded.');
+    }
+    if (!isRedirectStatus(response.status)) break;
+    const location = response.headers.get('location');
+    await response.body?.cancel().catch(() => undefined);
+    if (!location || redirect === OPENAI_FILE_REDIRECT_LIMIT) {
+      throw new ArtifactFetchError('ChatGPT file download returned an invalid redirect.');
+    }
+    downloadUrl = validateOpenAIFileUrl(new URL(location, downloadUrl).toString());
+  }
+
+  if (!response?.ok || !response.body) {
+    await response?.body?.cancel().catch(() => undefined);
+    throw new ArtifactFetchError('ChatGPT file download did not return file content.');
+  }
+  const responseSize = responseContentLength(response);
+  if (reference.size !== undefined && responseSize !== undefined && reference.size !== responseSize) {
+    await response.body.cancel().catch(() => undefined);
+    throw new ArtifactFetchError('ChatGPT file metadata did not match the downloaded content.');
+  }
+  const mimeType = reference.mime_type ?? responseMimeType(response);
+  const source: ArtifactSource = {
+    name: normalizeOpenAIFileName(reference.file_name, reference.file_id, mimeType),
+    mimeType,
+    size: responseSize ?? reference.size,
+    stream: Readable.fromWeb(response.body as unknown as NodeReadableStream)
+  };
+  validateArtifactSource(source);
+  return source;
+}
+
+function validateArtifactSource(source: ArtifactSource): void {
+  if (typeof source.name !== 'string' || source.name.length === 0) {
+    throw new ArtifactFetchError('ChatGPT file adapter must provide a filename.');
+  }
+  if (source.size !== undefined && (!Number.isSafeInteger(source.size) || source.size < 0)) {
+    throw new ArtifactFetchError('ChatGPT file adapter returned an invalid byte size.');
+  }
+  const stream = source.stream as Partial<Readable> | undefined;
+  if (!stream || typeof stream[Symbol.asyncIterator] !== 'function') {
+    source.stream?.destroy?.();
+    throw new ArtifactFetchError('ChatGPT file adapter must provide an async-readable stream.');
+  }
+}
+
+function nullableString(value: unknown): string | undefined | null {
+  if (value === undefined || value === null) return undefined;
+  return typeof value === 'string' ? value : null;
+}
+
+function normalizeOpenAIFileName(
+  suppliedName: string | undefined,
+  fileId: string,
+  mimeType: string | undefined
+): string {
+  if (suppliedName) return suppliedName;
+  const safeBaseName = OPENAI_FILENAME_SAFE_FILE_ID_PATTERN.test(fileId) ? fileId : 'chatgpt-file';
+  return `${safeBaseName}${extensionForMimeType(mimeType) ?? '.bin'}`;
+}
+
+function isValidOpenAIFileId(value: string): boolean {
+  return (
+    value.length > 0 && value.length <= OPENAI_FILE_ID_MAX_LENGTH && !OPENAI_FILE_ID_CONTROL_PATTERN.test(value)
+  );
+}
+
+function normalizeSuppliedFileName(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const candidate = basename(value.replaceAll('\\', '/')).trim();
+  if (!candidate || candidate === '.' || candidate === '..' || candidate.startsWith('.')) return undefined;
+  return candidate;
+}
+
+function extensionForMimeType(mimeType: string | undefined): string | undefined {
+  switch (mimeType?.toLowerCase()) {
+    case 'image/png':
+      return '.png';
+    case 'image/jpeg':
+      return '.jpg';
+    case 'image/webp':
+      return '.webp';
+    case 'image/gif':
+      return '.gif';
+    case 'application/pdf':
+      return '.pdf';
+    case 'text/plain':
+      return '.txt';
+    case 'application/zip':
+      return '.zip';
+    case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+      return '.docx';
+    default:
+      return undefined;
+  }
+}
+
+export function validateOpenAIFileUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new ArtifactFetchError('ChatGPT file download URL is invalid.');
+  }
+  if (
+    url.protocol !== 'https:' ||
+    !isTrustedOpenAIFileHost(url.hostname) ||
+    (url.port !== '' && url.port !== '443') ||
+    url.username !== '' ||
+    url.password !== '' ||
+    url.hash !== ''
+  ) {
+    throw new ArtifactFetchError('ChatGPT file download URL is outside the trusted file host.');
+  }
+  return url.toString();
+}
+
+function isTrustedOpenAIFileHost(hostname: string): boolean {
+  return OPENAI_FILE_HOSTS.has(hostname) || OPENAI_REGIONAL_BLOB_HOST_PATTERN.test(hostname);
+}
+
+function isRedirectStatus(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+function responseMimeType(response: Response): string | undefined {
+  const value = response.headers.get('content-type')?.split(';', 1)[0]?.trim();
+  return value || undefined;
+}
+
+function responseContentLength(response: Response): number | undefined {
+  const value = response.headers.get('content-length');
+  if (!value || !/^\d+$/u.test(value)) return undefined;
+  const size = Number(value);
+  return Number.isSafeInteger(size) ? size : undefined;
+}
+
+function classifyValueString(value: string): 'absolute-path' | 'url' | 'data-url' | 'text' {
+  if (value.startsWith('data:')) return 'data-url';
+  if (isAbsolute(value)) return 'absolute-path';
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') return 'url';
+  } catch {
+    // Non-URL strings are summarized only by type and length.
+  }
+  return 'text';
+}

--- a/src/main/mcp/artifact-target.ts
+++ b/src/main/mcp/artifact-target.ts
@@ -1,0 +1,232 @@
+/**
+ * Secure local target for one `download_artifact` call.
+ *
+ * Simplified port of devspace `src/artifact-secure-filesystem-{common,linux}.ts`
+ * without koffi: containment is owned by `sandbox.resolvePath` (checked by the caller
+ * before this module is entered), and this module owns the publication semantics —
+ * exclusive partial beside the destination, fsync, fstat-vs-lstat verification and an
+ * atomic link publish that never overwrites. The check-to-use window is narrowed by
+ * re-verifying the parent with lstat immediately before and after the publish; a fully
+ * fd-pinned backend (openat/linkat) remains a possible phase two with this same interface.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { constants as fsConstants } from 'node:fs';
+import type { FileHandle } from 'node:fs/promises';
+import path from 'node:path';
+import { rawPromises as fs } from '../rawfs.js';
+
+export const ARTIFACT_PARTIAL_PREFIX = '.steroids-download-';
+export const ARTIFACT_PARTIAL_SUFFIX = '.partial';
+
+export class ArtifactTargetError extends Error {}
+
+export interface ArtifactTargetOptions {
+  /** Canonical real path of the already-validated parent directory. */
+  parentReal: string;
+  /** Canonical real path of the approved root, for the pre-write containment re-check. */
+  rootReal: string;
+  /** Final file name (one validated segment, never a path). */
+  name: string;
+  /** Per-file byte ceiling. */
+  maxFileBytes: number;
+}
+
+export interface ArtifactTarget {
+  writeAll(buffer: Buffer, position: number): Promise<void>;
+  syncAndVerify(expectedSize: number): Promise<void>;
+  publish(): Promise<void>;
+  close(): Promise<void>;
+  /** Bytes written so far (for the streaming limit check in the caller). */
+  readonly size: number;
+}
+
+/**
+ * Remove stale crash leftovers in one directory. Bounded and conservative: at most 32
+ * entries are scanned, only this module's prefix+suffix, only regular files older than
+ * 24h. Never throws.
+ */
+export async function cleanupStalePartials(dirReal: string): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dirReal);
+  } catch {
+    return;
+  }
+  let scanned = 0;
+  for (const entry of entries) {
+    if (scanned >= 32) return;
+    scanned += 1;
+    if (!entry.startsWith(ARTIFACT_PARTIAL_PREFIX) || !entry.endsWith(ARTIFACT_PARTIAL_SUFFIX)) continue;
+    const candidate = path.join(dirReal, entry);
+    try {
+      const stat = await fs.lstat(candidate);
+      if (!stat.isFile() || stat.isSymbolicLink()) continue;
+      if (Date.now() - stat.mtimeMs < 24 * 60 * 60 * 1000) continue;
+      await fs.unlink(candidate).catch(() => undefined);
+    } catch {
+      // A concurrent writer owns it now; leave it alone.
+    }
+  }
+}
+
+function isContainedPath(parentReal: string, childReal: string): boolean {
+  const a = path.resolve(parentReal);
+  const b = path.resolve(childReal);
+  const norm = (s: string): string => (process.platform === 'win32' ? s.toLowerCase() : s);
+  if (norm(a) === norm(b)) return true;
+  const prefix = a.endsWith(path.sep) ? a : a + path.sep;
+  return norm(b).startsWith(norm(prefix));
+}
+
+/** A name the sandbox already validated, re-checked defensively at the I/O boundary. */
+export function assertSafeFileName(name: string): void {
+  if (typeof name !== 'string' || name === '' || name === '.' || name === '..') {
+    throw new ArtifactTargetError('Artifact destination is invalid.');
+  }
+  if (name.includes('/') || name.includes('\\') || name.includes('\0')) {
+    throw new ArtifactTargetError('Artifact destination is invalid.');
+  }
+}
+
+/**
+ * Open the exclusive partial for one download. The parent must already exist and be a
+ * real directory inside the approved root; missing intermediate folders are created by
+ * the caller through validated sandbox paths, never here from raw strings.
+ */
+export async function openArtifactTarget(options: ArtifactTargetOptions): Promise<ArtifactTarget> {
+  const { parentReal, rootReal, name, maxFileBytes } = options;
+  assertSafeFileName(name);
+  if (!Number.isSafeInteger(maxFileBytes) || maxFileBytes < 1) {
+    throw new ArtifactTargetError('Artifact file-size limit must be a positive integer.');
+  }
+
+  let parentStat: Awaited<ReturnType<typeof fs.lstat>>;
+  try {
+    parentStat = await fs.lstat(parentReal);
+  } catch {
+    throw new ArtifactTargetError('Artifact destination parent is not available.');
+  }
+  if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) {
+    throw new ArtifactTargetError('Artifact destination parent must be a real directory inside an approved folder.');
+  }
+  if (!isContainedPath(rootReal, parentReal)) {
+    throw new ArtifactTargetError('Artifact destination escapes its approved folder.');
+  }
+
+  await cleanupStalePartials(parentReal).catch(() => undefined);
+
+  const partialPath = path.join(parentReal, `${ARTIFACT_PARTIAL_PREFIX}${randomUUID()}${ARTIFACT_PARTIAL_SUFFIX}`);
+  const candidatePath = path.join(parentReal, name);
+  // Refuse to overwrite: the existence check and the exclusive link below are both
+  // enforced, so a file created between them still fails at publish time.
+  try {
+    await fs.lstat(candidatePath);
+    throw new ArtifactTargetError('Artifact destination already exists.');
+  } catch (error) {
+    if (error instanceof ArtifactTargetError) throw error;
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+
+  let fileHandle: FileHandle | undefined;
+  try {
+    fileHandle = await fs.open(
+      partialPath,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | (fsConstants.O_NOFOLLOW ?? 0),
+      0o600
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      throw new ArtifactTargetError('Artifact partial collision; retry the download.');
+    }
+    throw error;
+  }
+
+  let writtenBytes = 0;
+  let writtenDev: number | undefined;
+  let writtenIno: number | undefined;
+  let verified = false;
+  let published = false;
+  let closed = false;
+
+  async function close(): Promise<void> {
+    if (closed) return;
+    closed = true;
+    await fileHandle?.close().catch(() => undefined);
+    fileHandle = undefined;
+    if (!published) await fs.unlink(partialPath).catch(() => undefined);
+  }
+
+  return {
+    get size() {
+      return writtenBytes;
+    },
+    async writeAll(buffer: Buffer, position: number): Promise<void> {
+      if (!fileHandle || closed || verified) {
+        throw new ArtifactTargetError('Artifact target is not writable.');
+      }
+      if (position !== writtenBytes) {
+        throw new ArtifactTargetError('Artifact write is not sequential.');
+      }
+      if (writtenBytes + buffer.length > maxFileBytes) {
+        throw new ArtifactTargetError('Artifact file exceeds the configured per-file limit.');
+      }
+      let offset = 0;
+      while (offset < buffer.length) {
+        const written = await fileHandle.write(buffer, offset, buffer.length - offset, position + offset);
+        if (written.bytesWritten === 0) throw new ArtifactTargetError('Artifact write was interrupted.');
+        offset += written.bytesWritten;
+      }
+      writtenBytes += buffer.length;
+    },
+    async syncAndVerify(expectedSize: number): Promise<void> {
+      if (!fileHandle || closed) throw new ArtifactTargetError('Artifact target is not open.');
+      if (writtenBytes !== expectedSize) {
+        throw new ArtifactTargetError('Artifact size did not match the downloaded content.');
+      }
+      await fileHandle.sync();
+      const fdStat = await fileHandle.stat();
+      if (!fdStat.isFile() || fdStat.size !== expectedSize) {
+        throw new ArtifactTargetError('Artifact partial is not a complete file.');
+      }
+      const pathStat = await fs.lstat(partialPath);
+      if (pathStat.isSymbolicLink() || !pathStat.isFile() || pathStat.size !== expectedSize) {
+        throw new ArtifactTargetError('Artifact partial changed before publication.');
+      }
+      // dev/ino bind the open description to the pathname: a swap between fsync and
+      // publish changes one of them and fails the publish re-check below.
+      writtenDev = fdStat.dev;
+      writtenIno = fdStat.ino;
+      verified = true;
+    },
+    async publish(): Promise<void> {
+      if (!verified || writtenDev === undefined || writtenIno === undefined) {
+        throw new Error('Artifact must be verified before publication.');
+      }
+      if (published) return;
+      try {
+        await fs.link(partialPath, candidatePath);
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === 'EEXIST') throw new ArtifactTargetError('Artifact destination already exists.');
+        if (code === 'EXDEV') {
+          throw new ArtifactTargetError('Artifact partial and destination are on different filesystems.');
+        }
+        throw error;
+      }
+      const publishedStat = await fs.lstat(candidatePath);
+      if (
+        publishedStat.isSymbolicLink() ||
+        !publishedStat.isFile() ||
+        publishedStat.size !== writtenBytes ||
+        publishedStat.dev !== writtenDev ||
+        publishedStat.ino !== writtenIno
+      ) {
+        throw new ArtifactTargetError('Artifact could not be published at the requested destination.');
+      }
+      await fs.unlink(partialPath).catch(() => undefined);
+      published = true;
+    },
+    close
+  };
+}

--- a/src/main/mcp/instructions.ts
+++ b/src/main/mcp/instructions.ts
@@ -99,7 +99,12 @@ function coreInstructions(ctx: ToolContext, platform: NodeJS.Platform): string {
     // The one exception to the virtual-path rule above, and the model has to be told: cmd
     // is a program, not a path, so it reaches the shell exactly as written.
     'exec_command’s workdir is virtual, but its cmd is not translated — set workdir and write paths inside the command relative to it.',
-    'Output is capped. When a result says it was truncated, narrow the request instead of repeating it.'
+    'Output is capped. When a result says it was truncated, narrow the request instead of repeating it.',
+    ...(ctx.caps.saveArtifact
+      ? [
+          'When the user supplies or ChatGPT generates a file that is not on this computer, save it with download_artifact using its native file value and a destination path inside an approved folder. The tool refuses to overwrite and returns the saved path. Never recreate such files with apply_patch or exec_command, and never place signed URLs, file objects or base64 content in shell commands or logs.'
+        ]
+      : [])
   ];
 
   if (desktop && (ctx.caps.screen || ctx.caps.control || ctx.caps.clipboardRead || ctx.caps.clipboardWrite)) {

--- a/src/main/mcp/kernel.ts
+++ b/src/main/mcp/kernel.ts
@@ -980,6 +980,12 @@ export interface SurfaceRegistrar {
       inputSchema: Schema;
       outputSchema?: z.ZodType;
       annotations?: ToolAnnotations;
+      /**
+       * Opaque host metadata advertised verbatim in tools/list.
+       * Used once by download_artifact for {"openai/fileParams": ["file"]},
+       * which tells ChatGPT to inject the native file value. Never interpreted here.
+       */
+      _meta?: Record<string, unknown>;
     },
     handler: (args: z.output<Schema>) => Promise<ToolResult>
   ): void;

--- a/src/main/mcp/surfaces.ts
+++ b/src/main/mcp/surfaces.ts
@@ -91,9 +91,9 @@ export interface SurfaceDefinition {
  *    it here. A dedicated connector for one conditional schema is pure setup overhead with
  *    no discovery benefit.
  *
- * Core declares 8 possible tool names below, but at most 7 schemas are live at once. `find`
- * and the exec pair are mutually exclusive — `find` exists only when command execution is
- * off — so no runtime tools/list reaches all 8 declarations.
+ * Core declares 10 possible tool names below, but at most 9 schemas are live at once.
+ * `find` and the exec pair are mutually exclusive — `find` exists only when command
+ * execution is off — so no runtime tools/list reaches all 10 declarations.
  */
 const CORE: SurfaceDefinition = {
   id: 'core',
@@ -102,12 +102,13 @@ const CORE: SurfaceDefinition = {
   description:
     'Read and edit code and text files on this computer, and run commands in a real terminal. ' +
     'Use for: opening and reading files, searching a repository, applying patches, creating, renaming and deleting files, ' +
-    'running builds, tests, linters, git, npm and shell commands, and continuing long-running or interactive terminal sessions. ' +
+    'running builds, tests, linters, git, npm and shell commands, continuing long-running or interactive terminal sessions, ' +
+    'and saving images and files ChatGPT generates onto this computer. ' +
     'Also searches and reads local recordings of previous or concurrently running ChatGPT work, and — when the user has ' +
     'enabled it — spawns and coordinates worker agents, subagents or a parallel swarm across several ChatGPT conversations.',
   cardSummary: 'Files, patches and the terminal. Required — this is the coding connector.',
   required: true,
-  tools: ['read', 'view_image', 'find', 'apply_patch', 'exec_command', 'write_stdin', 'session', 'agents', 'session_finish']
+  tools: ['read', 'view_image', 'find', 'apply_patch', 'exec_command', 'write_stdin', 'download_artifact', 'session', 'agents', 'session_finish']
 };
 
 /**

--- a/src/main/mcp/tools-core.ts
+++ b/src/main/mcp/tools-core.ts
@@ -4,13 +4,13 @@ import { getConfig } from '../config.js';
 /**
  * The Core connector: reading, changing and running code on this PC.
  *
- * Seven tools at the absolute maximum, and usually five. That number is the design (see
+ * Nine tools at the absolute maximum, and usually seven. That number is the design (see
  * `docs/tool-surface.md` §3): a no-query discovery pull against this connector returns
  * every schema here at once, so the surface is sized for the worst case rather than for
  * the case where the harness happens to ask a narrow question.
  *
- * What used to be forty-five tools did not become seven by dropping capability. It became
- * seven by separating *primitives* from *procedures*: `exec_command` can run git, so `git`
+ * What used to be forty-five tools did not become nine by dropping capability. It became
+ * eight by separating *primitives* from *procedures*: `exec_command` can run git, so `git`
  * is a skill rather than a tool; `read` can open a directory, a text file or an image,
  * because those are three shapes of one question. Anything that reads as "and also, for
  * this special case…" belongs in a skill over these primitives, not in a schema every
@@ -125,6 +125,7 @@ import { repairPrimeFromResumeShadow } from '../session/continuation.js';
 import {
   currentCall,
   currentCaller,
+  noteChange,
   noteChanges,
   noteCount,
   noteDetail,
@@ -153,6 +154,9 @@ import {
   type ToolResult
 } from './kernel.js';
 import { registerSessionTool as registerSessionSearchReadTool } from './session-tool.js';
+import { ArtifactFetchError } from './artifact-fetch.js';
+import { ArtifactTargetError } from './artifact-target.js';
+import { downloadArtifactFile } from './artifact-download.js';
 
 /** Entries one `read` of a directory returns before it says it stopped. */
 const MAX_DIR_ENTRIES = 200;
@@ -967,6 +971,80 @@ export function registerCoreTools(reg: SurfaceRegistrar): void {
                 ? ` Retry this same session_id (${input.session_id}); do not replace it with a new command.`
                 : '';
             return fail(`write_stdin failed: ${message}${retry}`);
+          }
+        })
+    );
+  }
+
+  // ------------------------------------------------------- download_artifact
+
+  // Saves one ChatGPT-provided native file (generated image, PDF, ...) into an
+  // approved folder. The file value is injected by ChatGPT because the schema
+  // carries _meta openai/fileParams; anything the model invents fails the fetch
+  // gateway before any disk is touched. Binary files are never recreated through
+  // apply_patch or exec_command.
+  if (exposedCaps.saveArtifact) {
+    reg.register(
+      'download_artifact',
+      {
+        title: 'Save ChatGPT file',
+        description:
+          'Save one file ChatGPT generated or attached to a path inside an approved folder. ' +
+          'The file value is supplied by ChatGPT itself — never invent download_url or file_id values. ' +
+          'The destination must not already exist; missing parent folders are created. ' +
+          'Use for images, PDFs, archives and other files ChatGPT produces; never recreate such files with apply_patch or exec_command.',
+        inputSchema: z
+          .object({
+            file: z
+              .strictObject({
+                download_url: z.string(),
+                file_id: z.string(),
+                mime_type: z.string().nullable().optional(),
+                file_name: z.string().nullable().optional(),
+                name: z.string().nullable().optional(),
+                size: z.number().int().nonnegative().nullable().optional()
+              })
+              .describe('Native file value injected by ChatGPT.'),
+            path: pathArg.describe(
+              'Destination inside an approved folder: a virtual /<root>/... path or an absolute native path. ' +
+                'Relative paths resolve against this chat\'s folder. The destination must name a file that does not already exist.'
+            )
+          })
+          .strict(),
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+        _meta: { 'openai/fileParams': ['file'] }
+      },
+      async ({ file, path: requestedPath }) =>
+        guard('download_artifact', async () => {
+          if (!caps.saveArtifact) {
+            return fail(
+              'TOOL_DISABLED: download_artifact is disabled by the current Chat On Steroids permissions. Ask the user to enable saving ChatGPT files in the app.'
+            );
+          }
+          try {
+            const saved = await downloadArtifactFile(ctx.roots, requestedPath, file, {
+              maxFileBytes: getConfig().artifacts.maxFileBytes
+            });
+            noteChange({ path: saved.virtual, added: 0, removed: 0, approximate: true });
+            logInfo(`tool download_artifact ${saved.virtual} (${formatBytes(saved.size)}, ${saved.sha256})`);
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Saved ${saved.virtual} (${formatBytes(saved.size)}, ${saved.sha256}).`
+                }
+              ],
+              structuredContent: { path: saved.virtual, size: saved.size, sha256: saved.sha256 }
+            };
+          } catch (error) {
+            if (
+              error instanceof ArtifactFetchError ||
+              error instanceof ArtifactTargetError ||
+              error instanceof SandboxError
+            ) {
+              return fail(`download_artifact failed: ${error.message}`);
+            }
+            throw error;
           }
         })
     );

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -63,8 +63,8 @@ const GROUPS: Group[] = [
     id: 'write',
     title: 'Change files',
     icon: 'i-pencil',
-    blurb: 'Create, edit, move and delete, inside those folders only.',
-    caps: ['create', 'edit', 'move', 'deleteFile']
+    blurb: 'Create, edit, move, delete and save ChatGPT files, inside those folders only.',
+    caps: ['create', 'edit', 'move', 'deleteFile', 'saveArtifact']
   },
   {
     id: 'desktop',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -31,6 +31,7 @@ export const CAPABILITIES = [
   'move',
   'deleteFile',
   'command',
+  'saveArtifact',
   'screen',
   'control',
   'clipboardRead',
@@ -60,6 +61,7 @@ export const WRITE_CAPABILITIES: readonly Capability[] = [
   'move',
   'deleteFile',
   'command',
+  'saveArtifact',
   'control',
   'clipboardWrite'
 ];
@@ -267,12 +269,22 @@ export interface MultiAgentSettings {
   recoverAgentTabs: boolean;
 }
 
+/**
+ * Bounds for saving ChatGPT-provided files with `download_artifact`.
+ * Kept beside the capability it gates so the limit and the switch cannot drift apart.
+ */
+export interface ArtifactSettings {
+  /** Per-file byte ceiling enforced before, during and after the download stream. */
+  maxFileBytes: number;
+}
+
 export interface Config {
   roots: Root[];
   capabilities: Capabilities;
   readOnly: boolean;
   tunnel: TunnelSettings;
   ui: UiPrefs;
+  artifacts: ArtifactSettings;
   sessions: SessionSettings;
   compaction: CompactionSettings;
   multiAgent: MultiAgentSettings;
@@ -529,6 +541,7 @@ export const DEFAULT_CAPABILITIES: Capabilities = {
   move: false,
   deleteFile: false,
   command: false,
+  saveArtifact: false,
   screen: false,
   control: false,
   clipboardRead: false,
@@ -545,6 +558,7 @@ export const CAPABILITY_LABELS: Record<Capability, string> = {
   move: 'Move / rename',
   deleteFile: 'Delete files',
   command: 'Run commands',
+  saveArtifact: 'Save ChatGPT files',
   screen: 'See the screen',
   control: 'Control mouse and keyboard',
   clipboardRead: 'Read clipboard',
@@ -569,6 +583,7 @@ export const CAPABILITY_DETAILS: Record<Capability, string> = {
   move: 'Move or rename, both ends inside approved folders.',
   deleteFile: 'Permanent — there is no Recycle Bin.',
   command: 'Run anything as you. NOT limited to approved folders.',
+  saveArtifact: 'Save images and files ChatGPT generates into an approved folder.',
   screen: 'Screenshots, open windows, and the controls on them.',
   control: 'Moves the pointer, clicks, types and presses keys, as you.',
   clipboardRead: 'Read the current clipboard text.',
@@ -593,6 +608,7 @@ export const CAPABILITY_TOOLS: Record<Capability, readonly string[]> = {
   move: ['apply_patch'],
   deleteFile: ['apply_patch'],
   command: ['exec_command', 'write_stdin'],
+  saveArtifact: ['download_artifact'],
   screen: ['observe'],
   control: ['computer'],
   clipboardRead: ['computer'],

--- a/test/artifact-download.test.ts
+++ b/test/artifact-download.test.ts
@@ -1,0 +1,381 @@
+/**
+ * download_artifact: ChatGPT-provided files land inside approved roots, and only there.
+ *
+ * Three layers, tested bottom-up like the implementation is built:
+ * artifact-fetch (trusted-URL gateway) → artifact-target (exclusive publish) →
+ * downloadArtifactFile (sandbox resolution + orchestration) → MCP surface
+ * (registration, _meta fileParams, TOOL_DISABLED gating).
+ */
+
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  artifactFileHostname,
+  describeArtifactFileValue,
+  normalizeOpenAIFileReference,
+  openArtifactFile,
+  validateOpenAIFileUrl
+} from '../src/main/mcp/artifact-fetch.js';
+import { downloadArtifactFile } from '../src/main/mcp/artifact-download.js';
+import {
+  ARTIFACT_PARTIAL_PREFIX,
+  ARTIFACT_PARTIAL_SUFFIX,
+  cleanupStalePartials,
+  openArtifactTarget
+} from '../src/main/mcp/artifact-target.js';
+import { startMcpServer, type McpEndpoint } from '../src/main/mcp/server.js';
+import type { ToolContext } from '../src/main/mcp/tools.js';
+import { resetWorkspaces } from '../src/main/workspace.js';
+import { DEFAULT_CAPABILITIES, type Capabilities, type Root } from '../src/shared/types.js';
+import { makeTempDir, removeTempDir } from './helpers.js';
+
+const FILE_ID = 'file-abc123';
+const GOOD_URL = 'https://files.oaiusercontent.com/file-abc123?se=2030&sig=test';
+
+function fileRef(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return { download_url: GOOD_URL, file_id: FILE_ID, ...over };
+}
+
+/** Minimal fetch stub: route URL → canned Response. */
+function stubFetch(handler: (url: string) => Response): typeof fetch {
+  return (async (input: unknown) => handler(String(input))) as unknown as typeof fetch;
+}
+
+function okResponse(body: string, headers: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'application/octet-stream', ...headers }
+  });
+}
+
+async function streamText(stream: AsyncIterable<unknown>): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const value of stream) {
+    chunks.push(typeof value === 'string' ? Buffer.from(value) : Buffer.from(value as Uint8Array));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+// ------------------------------------------------------------------ fetch gateway
+
+describe('artifact file gateway', () => {
+  it('accepts only the trusted ChatGPT file hosts over https', () => {
+    expect(validateOpenAIFileUrl(GOOD_URL)).toBe(GOOD_URL);
+    expect(() =>
+      validateOpenAIFileUrl('https://oaisdmntpr01.blob.core.windows.net/c/f?sig=x')
+    ).not.toThrow();
+    for (const bad of [
+      'http://files.oaiusercontent.com/file-abc123',
+      'https://evil.example.com/file-abc123',
+      'https://files.oaiusercontent.com.evil.example.com/x',
+      'https://myaccount.blob.core.windows.net/c/f',
+      'https://files.oaiusercontent.com:8080/x',
+      'https://user:pass@files.oaiusercontent.com/x',
+      'https://files.oaiusercontent.com/x#frag',
+      'not-a-url'
+    ]) {
+      expect(() => validateOpenAIFileUrl(bad), bad).toThrow();
+    }
+  });
+
+  it('rejects malformed or smuggled file references', () => {
+    expect(() => normalizeOpenAIFileReference({})).toThrow();
+    expect(() => normalizeOpenAIFileReference(fileRef({ file_id: 42 }))).toThrow();
+    // strictObject behaviour lives in the tool schema; the gateway additionally refuses
+    // unknown keys so a hand-built call cannot widen the reference shape.
+    expect(() => normalizeOpenAIFileReference(fileRef({ authorization: 'Bearer x' }))).toThrow();
+    expect(() => normalizeOpenAIFileReference(fileRef({ file_id: 'x'.repeat(600) }))).toThrow();
+    expect(() => normalizeOpenAIFileReference(fileRef({ file_id: 'bad\x01id' }))).toThrow();
+    expect(() =>
+      normalizeOpenAIFileReference(fileRef({ file_name: 'a.png', name: 'b.png' }))
+    ).toThrow();
+  });
+
+  it('derives a safe name and never trusts a supplied path', async () => {
+    const fetch = stubFetch(() => okResponse('bytes'));
+    const opened = await openArtifactFile(fileRef({ file_name: '../../etc/passwd' }), { fetch });
+    expect(opened.name).toBe('passwd');
+    await opened.stream.destroy();
+    const fallback = await openArtifactFile(
+      { download_url: GOOD_URL, file_id: FILE_ID, mime_type: 'image/png' },
+      { fetch }
+    );
+    expect(fallback.name).toBe(`${FILE_ID}.png`);
+    await fallback.stream.destroy();
+  });
+
+  it('re-validates every redirect hop and rejects escapes', async () => {
+    const fetch = stubFetch((url) => {
+      if (url === GOOD_URL) return new Response(null, { status: 302, headers: { location: 'https://evil.example.com/f' } });
+      return okResponse('nope');
+    });
+    await expect(openArtifactFile(fileRef(), { fetch })).rejects.toThrow(/outside the trusted file host/);
+  });
+
+  it('follows an allowlisted redirect and checks size agreement', async () => {
+    const target = 'https://oaisdmntpr02.blob.core.windows.net/c/f?sig=y';
+    const fetch = stubFetch((url) => {
+      if (url === GOOD_URL) return new Response(null, { status: 302, headers: { location: target } });
+      return okResponse('hello', { 'content-length': '5' });
+    });
+    const opened = await openArtifactFile(fileRef({ size: 5, file_name: 'hi.txt' }), { fetch });
+    expect(await streamText(opened.stream)).toBe('hello');
+    const mismatch = stubFetch(() => okResponse('hello', { 'content-length': '5' }));
+    await expect(openArtifactFile(fileRef({ size: 6 }), { fetch: mismatch })).rejects.toThrow(/did not match/);
+  });
+
+  it('logs shapes and hostnames, never the URL or id', () => {
+    const shape = JSON.stringify(describeArtifactFileValue(fileRef()));
+    expect(shape).not.toContain(GOOD_URL);
+    expect(shape).not.toContain(FILE_ID);
+    expect(artifactFileHostname(fileRef())).toBe('files.oaiusercontent.com');
+    expect(artifactFileHostname({})).toBeNull();
+  });
+});
+
+// ------------------------------------------------------------------ secure target
+
+describe('artifact secure target', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'clf-artifact-target-'));
+  });
+
+  it('writes an exclusive partial and publishes it atomically', async () => {
+    const target = await openArtifactTarget({ parentReal: dir, rootReal: dir, name: 'a.png', maxFileBytes: 1024 });
+    await target.writeAll(Buffer.from('PNGDATA'), 0);
+    await target.syncAndVerify(7);
+    // Not visible before publish.
+    await expect(fs.stat(path.join(dir, 'a.png'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await target.publish();
+    await target.close();
+    expect(await fs.readFile(path.join(dir, 'a.png'), 'utf8')).toBe('PNGDATA');
+    const leftovers = (await fs.readdir(dir)).filter((f) => f.startsWith(ARTIFACT_PARTIAL_PREFIX));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('refuses to overwrite and leaves the existing file alone', async () => {
+    await fs.writeFile(path.join(dir, 'taken.txt'), 'original');
+    await expect(
+      openArtifactTarget({ parentReal: dir, rootReal: dir, name: 'taken.txt', maxFileBytes: 1024 })
+    ).rejects.toThrow(/already exists/);
+    expect(await fs.readFile(path.join(dir, 'taken.txt'), 'utf8')).toBe('original');
+  });
+
+  it('rejects symlinked parents and unsafe names', async () => {
+    const real = path.join(dir, 'real');
+    await fs.mkdir(real);
+    const linkPath = path.join(dir, 'linkparent');
+    try {
+      await fs.symlink(real, linkPath, 'dir');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EPERM') return;
+      throw error;
+    }
+    await expect(
+      openArtifactTarget({ parentReal: linkPath, rootReal: dir, name: 'x.bin', maxFileBytes: 1024 })
+    ).rejects.toThrow(/real directory/);
+    for (const bad of ['..', '', 'a/b', 'a\\b']) {
+      await expect(
+        openArtifactTarget({ parentReal: dir, rootReal: dir, name: bad, maxFileBytes: 1024 })
+      ).rejects.toThrow(/invalid/);
+    }
+  });
+
+  it('cleans only its own stale partials', async () => {
+    const stale = path.join(dir, `${ARTIFACT_PARTIAL_PREFIX}old${ARTIFACT_PARTIAL_SUFFIX}`);
+    const fresh = path.join(dir, `${ARTIFACT_PARTIAL_PREFIX}new${ARTIFACT_PARTIAL_SUFFIX}`);
+    const keep = path.join(dir, 'notes.txt');
+    await fs.writeFile(stale, 'x');
+    await fs.writeFile(fresh, 'y');
+    await fs.writeFile(keep, 'z');
+    const old = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    await fs.utimes(stale, old, old);
+    await cleanupStalePartials(dir);
+    await expect(fs.stat(stale)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(await fs.readFile(fresh, 'utf8')).toBe('y');
+    expect(await fs.readFile(keep, 'utf8')).toBe('z');
+  });
+});
+
+// ------------------------------------------------------------------ orchestration
+
+describe('downloadArtifactFile', () => {
+  let base: string;
+  let approved: string;
+  let roots: Root[];
+
+  beforeAll(async () => {
+    base = await makeTempDir('clf-artifact-');
+    approved = path.join(base, 'workspace');
+    await fs.mkdir(approved, { recursive: true });
+    roots = [{ name: 'workspace', path: approved }];
+  });
+
+  afterAll(async () => {
+    await removeTempDir(base);
+  });
+
+  beforeEach(() => {
+    resetWorkspaces();
+  });
+
+  function fetchBytes(body: string): typeof fetch {
+    return stubFetch(() => okResponse(body, { 'content-length': String(Buffer.byteLength(body)) }));
+  }
+
+  it('saves nested paths, creates parents and reports size+sha256', async () => {
+    const saved = await downloadArtifactFile(roots, '/workspace/reports/icon.png', fileRef(), {
+      maxFileBytes: 1024 * 1024,
+      fetch: fetchBytes('IMAGEDATA!')
+    });
+    expect(saved.virtual).toBe('/workspace/reports/icon.png');
+    expect(saved.size).toBe(10);
+    expect(saved.sha256).toBe(`sha256:${createHash('sha256').update('IMAGEDATA!').digest('hex')}`);
+    expect(await fs.readFile(path.join(approved, 'reports', 'icon.png'), 'utf8')).toBe('IMAGEDATA!');
+  });
+
+  it('refuses traversal, folders, existing files and oversized streams', async () => {
+    await expect(
+      downloadArtifactFile(roots, '/workspace/../../evil.bin', fileRef(), {
+        maxFileBytes: 1024,
+        fetch: fetchBytes('x')
+      })
+    ).rejects.toThrow();
+    await expect(
+      downloadArtifactFile(roots, '/workspace/folder/', fileRef(), {
+        maxFileBytes: 1024,
+        fetch: fetchBytes('x')
+      })
+    ).rejects.toThrow(/folder/);
+    await fs.writeFile(path.join(approved, 'kept.bin'), 'keep');
+    await expect(
+      downloadArtifactFile(roots, '/workspace/kept.bin', fileRef(), {
+        maxFileBytes: 1024,
+        fetch: fetchBytes('new')
+      })
+    ).rejects.toThrow(/already exists/);
+    expect(await fs.readFile(path.join(approved, 'kept.bin'), 'utf8')).toBe('keep');
+    await expect(
+      downloadArtifactFile(roots, '/workspace/big.bin', fileRef(), {
+        maxFileBytes: 4,
+        fetch: fetchBytes('way too long')
+      })
+    ).rejects.toThrow(/limit/);
+    await expect(
+      downloadArtifactFile(roots, '/workspace/x.bin', { nope: true }, {
+        maxFileBytes: 1024,
+        fetch: fetchBytes('x')
+      })
+    ).rejects.toThrow(/malformed/);
+  });
+});
+
+// ------------------------------------------------------------------ MCP surface
+
+describe('download_artifact MCP surface', () => {
+  let base: string;
+  let approved: string;
+  let endpoint: McpEndpoint;
+  let ctx: ToolContext;
+  let nextId = 1;
+
+  const withCaps = (overrides: Partial<Capabilities>): Capabilities => ({ ...DEFAULT_CAPABILITIES, ...overrides });
+
+  function rawCall(body: string): Promise<{ status: number; parsed: any }> {
+    const url = new URL(endpoint.urls.core);
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: url.pathname + url.search,
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream',
+            'content-length': Buffer.byteLength(body)
+          }
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (chunk: Buffer) => chunks.push(chunk));
+          res.on('end', () => {
+            const text = Buffer.concat(chunks).toString('utf8').trim();
+            let parsed: any = text;
+            try {
+              parsed = JSON.parse(text);
+            } catch {
+              const last = [...text.matchAll(/^data:\s*(.*)$/gm)].map((m) => m[1]).at(-1);
+              if (last !== undefined) parsed = JSON.parse(last);
+            }
+            resolve({ status: res.statusCode ?? 0, parsed });
+          });
+        }
+      );
+      req.on('error', reject);
+      req.end(body);
+    });
+  }
+
+  const list = async (): Promise<Array<Record<string, any>>> => {
+    const { parsed } = await rawCall(JSON.stringify({ jsonrpc: '2.0', id: nextId++, method: 'tools/list', params: {} }));
+    return (parsed?.result?.tools ?? []) as Array<Record<string, any>>;
+  };
+
+  beforeAll(async () => {
+    base = await makeTempDir('clf-artifact-mcp-');
+    approved = path.join(base, 'workspace');
+    await fs.mkdir(approved, { recursive: true });
+  });
+
+  afterAll(async () => {
+    if (endpoint) await endpoint.stop();
+    await removeTempDir(base);
+  });
+
+  beforeEach(async () => {
+    if (endpoint) await endpoint.stop();
+    resetWorkspaces();
+    ctx = {
+      roots: [{ name: 'workspace', path: approved }],
+      caps: withCaps({}),
+      readOnly: true,
+      sessionTools: false,
+      agentTools: false
+    };
+    endpoint = await startMcpServer(() => ctx);
+  });
+
+  it('is absent without the capability and advertised with fileParams once enabled', async () => {
+    expect((await list()).map((t) => t.name)).not.toContain('download_artifact');
+    ctx.caps = withCaps({ saveArtifact: true });
+    const tools = await list();
+    const tool = tools.find((t) => t.name === 'download_artifact');
+    expect(tool).toBeDefined();
+    // The one field ChatGPT needs to inject the native file value (the spike question).
+    expect(tool?.['_meta']).toMatchObject({ 'openai/fileParams': ['file'] });
+  });
+
+  it('keeps the schema but refuses the call after the permission is switched off', async () => {
+    ctx.caps = withCaps({ saveArtifact: true });
+    expect((await list()).map((t) => t.name)).toContain('download_artifact');
+    ctx.caps = withCaps({});
+    ctx.readOnly = false;
+    const { parsed } = await rawCall(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: nextId++,
+        method: 'tools/call',
+        params: { name: 'download_artifact', arguments: { file: fileRef(), path: '/workspace/x.bin' } }
+      })
+    );
+    expect(parsed?.result?.isError).toBe(true);
+    expect(JSON.stringify(parsed?.result?.content)).toContain('TOOL_DISABLED');
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -84,6 +84,10 @@ describe('settings migration', () => {
     expect(loaded.capabilities.create).toBe(true);
     expect(loaded.capabilities.clipboardRead).toBe(false);
     expect(loaded.capabilities.clipboardWrite).toBe(false);
+    // A config written before download_artifact existed gains the new switch off and a
+    // bounded default limit: an upgrade never widens what the user approved.
+    expect(loaded.capabilities.saveArtifact).toBe(false);
+    expect(loaded.artifacts.maxFileBytes).toBe(defaultConfig().artifacts.maxFileBytes);
     expect(loaded.ui.autoConnect).toBe(true);
     expect(loaded.ui.privacyScreenshots).toBe(false);
     // The one tunnel id a pre-split config had is Core's, because Core is the connector

--- a/test/feature-parity.test.ts
+++ b/test/feature-parity.test.ts
@@ -64,6 +64,7 @@ describe('portable browser-backed feature parity', () => {
       'apply_patch',
       'exec_command',
       'write_stdin',
+      'download_artifact',
       'session',
       'agents',
       'session_finish'

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -592,7 +592,7 @@ describe('surface boundaries', () => {
     everything();
     const names = toolNames(await core('tools/list'));
     // find is absent because exec_command is present — they are mutually exclusive.
-    expect(names).toEqual(['agents', 'apply_patch', 'exec_command', 'read', 'session', 'view_image', 'write_stdin']);
+    expect(names).toEqual(['agents', 'apply_patch', 'download_artifact', 'exec_command', 'read', 'session', 'view_image', 'write_stdin']);
     for (const name of surfaceDefinition('desktop').tools) expect(names, name).not.toContain(name);
   });
 
@@ -769,9 +769,9 @@ describe('surface boundaries', () => {
     const coreTools = toolList(await core('tools/list'));
     const desktopTools = toolList(await desktop('tools/list'));
 
-    // Counts are the design: Core is capped at seven live schemas because find and the exec
+    // Counts are the design: Core is capped at eight live schemas because find and the exec
     // pair cannot both exist, and Desktop is two.
-    expect(coreTools).toHaveLength(7);
+    expect(coreTools).toHaveLength(8);
     expect(desktopTools).toHaveLength(2);
 
     // And the size, which is what a discovery pull actually costs the model on every

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -21,6 +21,7 @@ const allCapabilities = (): Capabilities => ({
   move: true,
   deleteFile: true,
   command: true,
+  saveArtifact: true,
   screen: true,
   control: true,
   clipboardRead: true,

--- a/test/tools-desktop-permissions.test.ts
+++ b/test/tools-desktop-permissions.test.ts
@@ -44,6 +44,7 @@ function caps(over: Partial<Capabilities>): Capabilities {
     move: false,
     deleteFile: false,
     command: false,
+    saveArtifact: false,
     screen: false,
     control: false,
     clipboardRead: false,

--- a/test/tools-desktop-runtime.test.ts
+++ b/test/tools-desktop-runtime.test.ts
@@ -41,6 +41,7 @@ function caps(over: Partial<Capabilities>): Capabilities {
     move: false,
     deleteFile: false,
     command: false,
+    saveArtifact: false,
     screen: false,
     control: false,
     clipboardRead: false,


### PR DESCRIPTION
Adds one Core tool that streams a ChatGPT-injected native file (generated images, PDFs, archives) into an approved folder.

The file value is injected by ChatGPT via _meta openai/fileParams; the model supplies only the destination path. Anything invented fails the trusted-host gateway (https allowlist, manual 3-hop redirect re-validation, 30s timeout, triple size checks) before any disk is touched. Locally the write goes to an exclusive partial beside the destination with fsync plus fstat-vs-lstat verification, then publishes with an atomic link that never overwrites; symlinked parents are rejected. Containment stays with sandbox.resolvePath, so no new native dependencies.

Gated by a new saveArtifact capability (in WRITE_CAPABILITIES, off for existing configs) with a per-file byte limit defaulting to 20 MiB. Core grows to 10 declared tools with at most 9 live.

Verification: new test/artifact-download.test.ts (14 tests: gateway refusals, exclusive publish, symlink parents, stale partials, _meta wire passthrough, TOOL_DISABLED gating); typecheck, privacy gate and the full suite pass except two environment-only failures (homebrew rg shadowing the bundled binary, and a resources/tunnel dev mirror present in the working tree).