### PR TITLE
feat: support custom OpenAI-compatible provider for Goal/Loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,7 +338,7 @@ src/shared/types.ts           config/app/IPC types and Capabilities
 
 ── browser ────────────────────────────────────────────────────────────────
 src/main/bridge.ts            extension HTTP bridge + compaction/worker orchestration
-src/main/goal.ts              Goal/Loop OpenRouter driver, durable obligations, one draft per turn
+src/main/goal.ts              Goal/Loop LLM driver (OpenRouter default, custom endpoint optional), durable obligations, one draft per turn
 src/main/agents.ts            the one global star-topology multi-agent broker
 extension/manifest.json       MV3 composition root: service worker, isolated scripts/CSS, MAIN-world Fiber, popup, host/extension permissions
 extension/chatgpt-dom.js      EVERY ChatGPT selector and DOM-shape assumption
@@ -2234,8 +2234,9 @@ auto-compaction setting. The composer context meter shows estimated current-chat
 provider-reported count; Pro has a static ring, while other models show configured utilization.
 
 
-**Goal + Loop.** `goal.ts` is one OpenRouter engine with two standing modes and one optional
-per-chat objective. It sends only authored user messages and final assistant answers to the
+**Goal + Loop.** `goal.ts` is one LLM engine with two standing modes and one optional
+per-chat objective: OpenRouter by default, or a custom OpenAI-compatible endpoint
+(`goal.provider`). It sends only authored user messages and final assistant answers to the
 provider; tool rows, native progress and hidden reasoning stay out of that transcript. That provider
 view comes from the **local canonical recording**, not the live page. `goal.ts::
 conversationMessages()` keeps final assistant revisions only, coalesces duplicate legacy final
@@ -2304,12 +2305,13 @@ project. Keep both properties if you rewrite these; a loop that drifts off the b
 whole night it was left running for.
 
 The Goal **model picker** has its own narrow secret/network boundary. Renderer code never receives
-the OpenRouter key and never fetches the catalogue directly: IPC `goal:models` accepts only a bounded
+the provider key and never fetches the catalogue directly: IPC `goal:models` accepts only a bounded
 offset, fixes the page size at 20, and calls `goal.ts::listGoalModels()`. The main-process catalogue
 loader uses a 30-second request ceiling, 8 MiB response bound and 5,000-model parse cap, sorts newest
 releases first, and caches for five minutes **scoped to a SHA-256 fingerprint of the current API
-key** (or the public/no-key bucket). A key change therefore cannot reuse a restricted catalogue from
-the previous credential. `renderer/chat.ts::loadGoalModels()` / `paintGoalModels()` /
+key** (or the public/no-key bucket) **plus the endpoint URL**. A key or endpoint change therefore cannot reuse a restricted catalogue from
+the previous credential. A custom endpoint that answers no usable catalogue yields an empty
+list and the model stays a hand-typed field. `renderer/chat.ts::loadGoalModels()` / `paintGoalModels()` /
 `maybePageGoalModels()` own scroll-paged presentation only; load failure leaves the user's current
 model selection untouched.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ sha256sum Chat-On-Steroids-Linux-x64.AppImage     # Linux
 - **Chrome 116 or newer** for the companion extension. Without it you still get the MCP tools, but not session attribution, Compact & Resume, worker chats or the Goal loop.
 - **Linux:** a Secret Service keyring such as GNOME Keyring or KWallet. The app refuses Electron's unencrypted `basic_text` fallback for stored keys.
 - A ChatGPT workspace with **Developer mode** and custom MCP apps. OpenAI currently documents full MCP support, including write actions, as a beta for Business, Enterprise and Edu, with Pro limited to read and fetch. Business needs an admin to enable it. Check OpenAI's [Developer mode and MCP apps](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt) page if your workspace looks different.
-- An **OpenRouter API key** only if you select the API source for plans, Goal or Loop. The default ChatGPT helper source uses your connected browser session.
+- An **OpenRouter API key** (or your own OpenAI-compatible endpoint) only if you select the API source for plans, Goal or Loop. The default ChatGPT helper source uses your connected browser session.
 
 Use a normal ChatGPT conversation with the custom app enabled. OpenAI's built-in Agent mode does not use custom apps.
 
@@ -147,6 +147,8 @@ For ordinary models, **Goal** checks a completed answer and either drafts a foll
 **Astra behaves differently.** With Session finish enabled, Goal and Loop both use Loop instructions and deliver through tool injection. Queued user instructions and plan stages take priority. When Astra calls `session_finish` with nothing waiting, your setting chooses a finish notification or automatic follow-up generation. A per-chat Goal/Loop switch also selects automatic generation. The generated instruction arrives on a later tool call; it never automatically starts a new turn after Astra has really finished. Silence alone does not queue a Pro goal, and Pro silence recovery waits ten minutes.
 
 Finish reminders are added by the delivery layer, separate from the visible plan. Desktop notifications depend on OS support and notification settings; the app also offers **Generate Goal** while waiting at a finish point. Native notification actions and cold background browser focus are not yet verified across every supported desktop environment.
+
+It needs a key for the configured API provider — OpenRouter by default, or none at all for a keyless local endpoint — stored encrypted and used only by the app. Provider, model and reasoning level live under **Settings → Agents & automation**. This spends credit on every finished turn and sends messages without asking each time. Switch it off when you are not watching.
 
 ### Multi-agent mode
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -7383,10 +7383,11 @@
   }
 
   /**
-   * The short name of an OpenRouter model id, for a caption a person reads at a glance.
+   * The short name of a model id, for a caption a person reads at a glance.
    *
    * `deepseek/deepseek-v4-flash` is the id the API wants and not what anybody calls it. The
-   * vendor prefix and the `:free`/`:nitro` variant suffix are both routing detail.
+   * vendor prefix and the `:free`/`:nitro` variant suffix are both routing detail. A custom
+   * endpoint id without a slash passes through untouched.
    */
   function modelLabel(id) {
     const name = String(id || '').trim();
@@ -7431,8 +7432,11 @@
     if (!goal) return null;
     const draft = goal.draft || null;
     const who = modelLabel(goal.model);
+    // The key prompt elsewhere needs no such switch: a custom endpoint is often keyless,
+    // so a missing key only ever means OpenRouter. Progress copy names the endpoint.
+    const dest = goal.provider === 'custom' ? 'custom endpoint' : 'OpenRouter';
     const bar = (at, done = false) => ({ steps: GOAL_STEPS, at, done });
-    const failure = goal.error || (draft && draft.stage === 'failed' ? draft.error || 'OpenRouter did not answer' : '');
+    const failure = goal.error || (draft && draft.stage === 'failed' ? draft.error || `${dest} did not answer` : '');
     if (failure) {
       const at = draft && draft.stage === 'failed' ? 2 : (GOAL_STEP_AT[goal.phase] ?? 1);
       if (goal.phase === 'retrying') {
@@ -7462,14 +7466,14 @@
       return { stage: 'Sending it to ChatGPT', detail: '', body: draft.reply, kind: 'goal', ...bar(3) };
     }
     if (goal.phase === 'requesting' && !draft) {
-      return { stage: 'Sending the answer to OpenRouter', detail: who, body: '', kind: 'goal', ...bar(1) };
+      return { stage: `Sending the answer to ${dest}`, detail: who, body: '', kind: 'goal', ...bar(1) };
     }
     if (!draft) return null;
     if (draft.stage === 'no-reply') {
       return { stage: 'Goal reached', detail: 'nothing was sent', body: '', kind: 'goal-done', ...bar(2, true) };
     }
     if (draft.stage === 'sending') {
-      return { stage: 'Sending the answer to OpenRouter', detail: who, body: '', kind: 'goal', ...bar(1) };
+      return { stage: `Sending the answer to ${dest}`, detail: who, body: '', kind: 'goal', ...bar(1) };
     }
     if (draft.stage === 'answering') {
       // Streamed, so the wait has something in it. The text is the message being written for
@@ -8681,7 +8685,7 @@
     }
     if (draft.stage === 'failed') {
       goalDraft = null;
-      const why = draft.error || 'OpenRouter did not answer';
+      const why = draft.error || `${goalConfig && goalConfig.provider === 'custom' ? 'custom endpoint' : 'OpenRouter'} did not answer`;
       const pending = goalConfig && goalConfig.pending;
       let retrying = draft.retryable === true && goalTurnId === draft.turnId;
       // A reload loses the document-local claim while the app keeps both the failed attempt

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -1807,6 +1807,10 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
       backend: goalBackendFor(goalModeFor(id)),
       hasKey: await goalKeyPresent(goalModeFor(id)),
       model: getConfig().goal.model,
+      // Which endpoint the draft runs on, so the page names the right one in progress
+      // copy instead of always saying OpenRouter. The key prompt needs no such field:
+      // a custom endpoint is often keyless, so a missing key only ever means OpenRouter.
+      provider: getConfig().goal.provider.kind,
       // This chat's own goal, and never a worker's: the loop is off there whatever is
       // stored, and reporting one would let the page offer to drive a chat the prime owns.
       objective: superseded || finishOnly || goalWorkerChat(id) ? '' : goalObjectiveFor(id),

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -14,6 +14,7 @@ import {
   CAPABILITIES,
   DEFAULT_CAPABILITIES,
   GOAL_MODES,
+  GOAL_PROVIDERS,
   GOAL_REASONING_LEVELS,
   WRITE_CAPABILITIES,
   type Capabilities,
@@ -139,6 +140,9 @@ const DEFAULT_GOAL: GoalSettings = {
   // the one that can end by itself: a loop that never stops is a deliberate choice, not a
   // default anybody should discover by turning something on.
   mode: 'goal',
+  // OpenRouter stays the default provider so an upgrade changes nothing for anyone who
+  // never touches the switch; a hand-written config predating the field parses the same way.
+  provider: { kind: 'openrouter', baseUrl: '' },
   model: DEFAULT_GOAL_MODEL,
   reasoning: 'default',
   prompt: DEFAULT_GOAL_SYSTEM_PROMPT,
@@ -333,6 +337,18 @@ const configSchema = z.object({
       // written by a version that knows one more mode than this one must not send every root
       // and permission in the file through conservative recovery over a single word.
       mode: z.enum(GOAL_MODES).optional().default(DEFAULT_GOAL.mode).catch(DEFAULT_GOAL.mode),
+      provider: z
+        .object({
+          // Repaired rather than rejected like `mode` above: a config written by a version
+          // that knows one more provider than this one must not invalidate every root and
+          // permission in the file over a single word.
+          kind: z.enum(GOAL_PROVIDERS).optional().default('openrouter').catch('openrouter'),
+          // Stored verbatim and validated at draft time: a URL cannot be repaired the way an
+          // enum can, and silently rewriting it would point a key at a host nobody chose.
+          baseUrl: z.string().max(2048).optional().default('')
+        })
+        .optional()
+        .default({ ...DEFAULT_GOAL.provider }),
       model: z
         .string()
         .max(160)

--- a/src/main/goal.ts
+++ b/src/main/goal.ts
@@ -71,7 +71,7 @@ import {
   GOAL_SYSTEM_TRAILER,
   goalObjectiveMessage
 } from '../shared/goal.js';
-import type { GoalMode } from '../shared/types.js';
+import type { GoalMode, GoalProviderKind } from '../shared/types.js';
 
 /** Where OpenRouter lives. One host, both routes. */
 const OPENROUTER_BASE = 'https://openrouter.ai/api/v1';
@@ -84,6 +84,49 @@ const ATTRIBUTION_HEADERS: Record<string, string> = {
   'HTTP-Referer': 'https://github.com/chat-on-steroids',
   'X-Title': 'Chat On Steroids'
 };
+
+/** Which LLM endpoint the Goal/Loop second model runs on, resolved per call from config. */
+export interface GoalEndpoint {
+  kind: GoalProviderKind;
+  /** Raw configured base URL for custom; OPENROUTER_BASE for openrouter. */
+  baseUrl: string;
+}
+
+export function goalEndpoint(): GoalEndpoint {
+  const provider = getConfig().goal.provider;
+  if (provider?.kind === 'custom') return { kind: 'custom', baseUrl: provider.baseUrl };
+  return { kind: 'openrouter', baseUrl: OPENROUTER_BASE };
+}
+
+/**
+ * Base URL checked at use time, not at save time.
+ *
+ * A URL cannot be repaired the way an enum can, so settings keep the user's text verbatim
+ * and a typo fails loudly here as settled `invalid_provider` instead of pointing a key at
+ * a host nobody chose. Loopback http is allowed for local servers (Ollama's default is
+ * `http://localhost:11434/v1`); anything else must be https, never with credentials in it.
+ */
+export function resolveGoalBaseUrl(endpoint: GoalEndpoint): string {
+  if (endpoint.kind === 'openrouter') return OPENROUTER_BASE;
+  const raw = endpoint.baseUrl.trim().replace(/\/+$/, '');
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error('invalid_provider: custom provider URL is invalid');
+  }
+  const host = url.hostname.toLowerCase();
+  const loopback = host === 'localhost' || host === '127.0.0.1' || host === '::1';
+  if ((url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) || url.username !== '' || url.password !== '') {
+    throw new Error('invalid_provider: custom provider URL must be https, or http on localhost');
+  }
+  return url.toString().replace(/\/+$/, '');
+}
+
+/** The credential for one provider kind. Custom endpoints are often keyless local servers. */
+export function goalProviderKey(kind: GoalProviderKind): Promise<string | null> {
+  return getSecret(kind === 'custom' ? 'customProviderApiKey' : 'openRouterApiKey');
+}
 
 /** How many messages of history the goal model is given, newest kept. */
 const MAX_CONTEXT_MESSAGES = 120;
@@ -106,7 +149,7 @@ const REQUEST_TIMEOUT_MS = 180_000;
  * belongs to the page's Goal loop, which is the only place that can tell whether the turn is
  * still the one being answered. This is what that loop reads, published as `retryable`.
  */
-const SETTLED_FAILURE = /^(?:auth_rejected|out_of_credit|unknown_model|no_api_key|no_conversation|no_objective|goal_marker_missing|goal_browser_cancelled|goal_browser_send_unconfirmed|goal_browser_send_failed)(?:$|:)/;
+const SETTLED_FAILURE = /^(?:auth_rejected|out_of_credit|unknown_model|no_api_key|no_conversation|no_objective|invalid_provider|goal_marker_missing|goal_browser_cancelled|goal_browser_send_unconfirmed|goal_browser_send_failed)(?:$|:)/;
 
 /** One failure classification shared by ordinary drafts and the conversation-less opening request. */
 function retryableGoalFailure(error: string): boolean {
@@ -914,7 +957,11 @@ export function goalBackendFor(mode: GoalMode): GoalBackend {
 }
 export async function goalKeyPresent(mode: GoalMode = goalDrivingMode()): Promise<boolean> {
   if (goalBackendFor(mode) !== 'api') return true;
-  return (await getSecret('openRouterApiKey')) !== null;
+  const endpoint = goalEndpoint();
+  // A custom endpoint is often a keyless local server, so there is nothing to require:
+  // reachability and auth are proven by the first call, not by the presence of a secret.
+  if (endpoint.kind === 'custom') return true;
+  return (await goalProviderKey('openrouter')) !== null;
 }
 
 function view(draft: GoalDraft): GoalDraftView {
@@ -1335,6 +1382,14 @@ async function requestGoalDecision(request: GoalRequest): Promise<GoalDecision |
     }
     return decision;
   }
+  const endpoint = goalEndpoint();
+  let baseUrl: string;
+  try {
+    baseUrl = resolveGoalBaseUrl(endpoint);
+  } catch (error) {
+    return { action: 'http', error: (error as Error).message };
+  }
+  const custom = endpoint.kind === 'custom';
   const body: Record<string, unknown> = {
     model: request.model,
     // Stream only to a real progress consumer. Partial text remains presentation;
@@ -1347,24 +1402,33 @@ async function requestGoalDecision(request: GoalRequest): Promise<GoalDecision |
       { role: 'system', content: request.trailer }
     ],
     response_format: request.mode === 'loop' ? LOOP_RESPONSE_FORMAT : GOAL_RESPONSE_FORMAT,
-    ...(!request.publish ? { plugins: [{ id: 'response-healing' }] } : {}),
+    ...(!request.publish && !custom ? { plugins: [{ id: 'response-healing' }] } : {}),
     // OpenRouter otherwise may route to a provider that silently ignores response_format.
-    provider: { require_parameters: true }
+    // A custom endpoint speaks plain OpenAI-compatible chat completions and must not
+    // receive vendor fields it never defined.
+    ...(custom ? {} : { provider: { require_parameters: true } })
   };
   // Reasoning may still be used, but it is never part of the response body this app parses.
   // OpenRouter documents `exclude` as supported across models even when effort selection is
   // not. `default` therefore means "provider-selected effort", not "return its scratchpad".
-  body['reasoning'] = {
-    ...(request.reasoning ? { effort: request.reasoning } : settings.reasoning === 'default' ? {} : { effort: settings.reasoning }),
-    exclude: true
-  };
+  // A custom endpoint gets the effort alone: `exclude` is OpenRouter vocabulary, and an
+  // endpoint that rejects unknown fields should run with reasoning `default`, which omits
+  // the block entirely.
+  if (!custom) {
+    body['reasoning'] = {
+      ...(request.reasoning ? { effort: request.reasoning } : settings.reasoning === 'default' ? {} : { effort: settings.reasoning }),
+      exclude: true
+    };
+  } else if (settings.reasoning !== 'default') {
+    body['reasoning'] = { effort: settings.reasoning };
+  }
 
-  const response = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
+  const response = await fetch(`${baseUrl}/chat/completions`, {
     method: 'POST',
     headers: {
-      authorization: `Bearer ${request.key}`,
+      ...(request.key ? { authorization: `Bearer ${request.key}` } : {}),
       'content-type': 'application/json',
-      ...ATTRIBUTION_HEADERS
+      ...(custom ? {} : ATTRIBUTION_HEADERS)
     },
     body: JSON.stringify(body),
     signal: request.signal
@@ -1408,9 +1472,14 @@ async function requestDrivingDecision(
 
 async function run(draft: GoalDraft): Promise<void> {
   if (await astraFinishOnly(draft.sessionId, draft.conversationId)) return settle(draft, 'no-reply');
-  const key = await getSecret('openRouterApiKey');
+  const endpoint = goalEndpoint();
+  const key = await goalProviderKey(endpoint.kind);
   if (draft.acknowledged || drafts.get(draft.conversationId) !== draft) return;
-  if (draft.backend === 'api' && !key) return settle(draft, 'failed', 'no_api_key');
+  // Only the OpenRouter api backend fails here without a key. A custom endpoint may be a
+  // keyless local server (key arrives as '' and no Authorization header is sent), and the
+  // other backends never needed one. A provider switch retires in-flight drafts at the
+  // settings boundary, so reading the endpoint live here cannot mix two configurations.
+  if (draft.backend === 'api' && !key && endpoint.kind === 'openrouter') return settle(draft, 'failed', 'no_api_key');
   const messages = await conversationMessages(draft.sessionId);
   if (draft.acknowledged || drafts.get(draft.conversationId) !== draft) return;
   // Goal Mode is supposed to continue *the user's objective*. A partially recovered recorder
@@ -1528,8 +1597,10 @@ async function run(draft: GoalDraft): Promise<void> {
 /** Finish asks the existing Loop driver for the next instruction; its caller owns delivery. */
 export async function draftFastFollowup(sessionId: string, signal: AbortSignal = AbortSignal.timeout(180000), preparedMessages?: ChatMessage[], publish?: GoalRequest['publish'], mode: GoalMode = 'loop'): Promise<string | null> {
   const backend = goalBackendFor(mode);
-  const key = await getSecret('openRouterApiKey');
-  if (backend === 'api' && !key) throw new Error('Configure the Goal API key for automatic finish follow-ups, or choose Notify me');
+  const endpoint = goalEndpoint();
+  const key = await goalProviderKey(endpoint.kind);
+  // Custom endpoints may be keyless; only OpenRouter fails here without one.
+  if (backend === 'api' && !key && endpoint.kind === 'openrouter') throw new Error('Configure the Goal API key for automatic finish follow-ups, or choose Notify me');
   const session = await getSession(sessionId);
   if (!session?.conversationId) throw new Error('This session has no current conversation');
   const objective = goalObjectiveFor(session.conversationId);
@@ -1559,8 +1630,10 @@ export async function draftFastFollowup(sessionId: string, signal: AbortSignal =
 export async function draftTaskPlan(prompt: string, backend: 'api' | 'chatgpt', onProgress?: (progress: TaskProgressUpdate) => void, signal?: AbortSignal): Promise<string[]> {
   onProgress?.({ phase: 'preparing', text: '' });
   if (!prompt.trim() || prompt.length > 16000) throw new Error('Enter a task of at most 16000 characters');
-  const key = backend === 'api' ? await getSecret('openRouterApiKey') : null;
-  if (backend === 'api' && !key) throw new Error('Configure a Goal API key or choose ChatGPT');
+  const endpoint = goalEndpoint();
+  const key = backend === 'api' ? await goalProviderKey(endpoint.kind) : null;
+  // Custom endpoints may be keyless; only OpenRouter fails here without one.
+  if (backend === 'api' && !key && endpoint.kind === 'openrouter') throw new Error('Configure a Goal API key or choose ChatGPT');
   onProgress?.({ phase: 'generating', text: '' });
   const result = await requestGoalDecision({ backend, lifetime: 'temporary-planner', key: key ?? '', model: getConfig().goal.model, mode: 'goal', publish: text => onProgress?.({ phase: 'generating', text: planProgressText(text) }),
     system: ['You are a task planner, not the executor. Divide the user request into 2 to 12 sequential, self-contained stages. Preserve all requirements and constraints. Include implementation and meaningful verification phases, with a final full acceptance check. Do not invent unrelated work. Return action continue; its reply must be a JSON string encoding {"stages":["first task", "next task"]}. Keep the entire plan below 12000 characters. Each stage is sent to the same working conversation only after it finishes the previous stage.'],
@@ -1586,10 +1659,12 @@ export async function draftOpeningMessage(
   signal?.throwIfAborted();
   onProgress?.({ phase: 'preparing', text: '' });
   if (!goal) return { error: 'no_objective' };
-  const key = await getSecret('openRouterApiKey');
+  const endpoint = goalEndpoint();
+  const key = await goalProviderKey(endpoint.kind);
   const backend = goalBackendFor(named ?? goalDrivingMode());
   if (backend === 'templates') return { reply: goal + GOAL_MARKER_INSTRUCTION, model: 'Offline Goal' };
-  if (backend === 'api' && !key) return { error: 'no_api_key' };
+  // Custom endpoints may be keyless; only OpenRouter fails here without one.
+  if (backend === 'api' && !key && endpoint.kind === 'openrouter') return { error: 'no_api_key' };
   const model = backend === 'chatgpt' ? getConfig().goal.helperModel ?? 'gpt-5.6-sol' : getConfig().goal.model;
   const abort = new AbortController();
   const timer = setTimeout(() => abort.abort(), REQUEST_TIMEOUT_MS);
@@ -2347,12 +2422,19 @@ export async function listGoalModels(offset = 0, limit = MODEL_PAGE_SIZE): Promi
 }
 
 async function allGoalModels(): Promise<GoalModel[]> {
-  const key = await getSecret('openRouterApiKey');
+  const endpoint = goalEndpoint();
+  const custom = endpoint.kind === 'custom';
+  const key = await goalProviderKey(endpoint.kind);
   // OpenRouter may return a key-restricted catalogue. A cache filled under key A is therefore
   // not valid under key B. Keep only a one-way fingerprint beside the models rather than the
   // credential itself; replacing a key immediately changes the cache scope without retaining
-  // either secret for the five-minute listing TTL.
-  const keyScope = key ? createHash('sha256').update(key).digest('hex') : 'public';
+  // either secret for the five-minute listing TTL. A custom endpoint joins the scope by URL,
+  // so switching servers never serves the previous server's catalogue.
+  const keyScope = custom
+    ? `custom:${endpoint.baseUrl.trim()}:${key ? createHash('sha256').update(key).digest('hex') : 'public'}`
+    : key
+      ? createHash('sha256').update(key).digest('hex')
+      : 'public';
   if (modelCache && modelCache.keyScope === keyScope && Date.now() - modelCache.at < MODEL_CACHE_MS) {
     return modelCache.models;
   }
@@ -2360,24 +2442,34 @@ async function allGoalModels(): Promise<GoalModel[]> {
   const timer = setTimeout(() => abort.abort(), MODEL_LIST_TIMEOUT_MS);
   let response: Response;
   let parsed: unknown;
+  // A custom catalogue is best-effort UI data: most local servers answer `/models` in the
+  // vanilla OpenAI shape, some answer nothing at all, and either way the model stays a
+  // hand-typed field. A failure here returns an empty list rather than an error, while the
+  // OpenRouter catalogue keeps its throwing behaviour so a broken default stays visible.
+  const label = custom ? 'custom provider' : 'OpenRouter';
   try {
-    response = await fetch(`${OPENROUTER_BASE}/models`, {
+    const baseUrl = resolveGoalBaseUrl(endpoint);
+    response = await fetch(`${baseUrl}/models`, {
       headers: {
         // The listing is public; the key is sent when there is one so a key with a restricted
         // model set sees its own set rather than the catalogue.
         ...(key ? { authorization: `Bearer ${key}` } : {}),
-        ...ATTRIBUTION_HEADERS
+        ...(custom ? {} : ATTRIBUTION_HEADERS)
       },
       signal: abort.signal
     });
-    if (!response.ok) throw new Error(`OpenRouter would not list its models (HTTP ${response.status})`);
+    if (!response.ok) throw new Error(`${label} would not list its models (HTTP ${response.status})`);
     const raw = await boundedResponseText(response, MAX_MODEL_LIST_BODY_BYTES);
     try {
       parsed = raw ? JSON.parse(raw) : null;
     } catch {
-      throw new Error('OpenRouter returned a model list this app could not read');
+      throw new Error(`${label} returned a model list this app could not read`);
     }
   } catch (error) {
+    if (custom) {
+      clearTimeout(timer);
+      return [];
+    }
     if (abort.signal.aborted) throw new Error('OpenRouter model list request timed out');
     if (error instanceof Error && error.message === 'response_body_too_large') {
       throw new Error('OpenRouter model list response body was too large');
@@ -2387,7 +2479,10 @@ async function allGoalModels(): Promise<GoalModel[]> {
     clearTimeout(timer);
   }
   const raw = parsed && typeof parsed === 'object' ? (parsed as { data?: unknown }).data : null;
-  if (!Array.isArray(raw)) throw new Error('OpenRouter returned a model list this app could not read');
+  if (!Array.isArray(raw)) {
+    if (custom) return [];
+    throw new Error('OpenRouter returned a model list this app could not read');
+  }
   const models: GoalModel[] = [];
   for (const entry of raw) {
     if (models.length >= MAX_MODELS) break;

--- a/src/main/goal.ts
+++ b/src/main/goal.ts
@@ -71,7 +71,7 @@ import {
   GOAL_SYSTEM_TRAILER,
   goalObjectiveMessage
 } from '../shared/goal.js';
-import type { GoalMode, GoalProviderKind } from '../shared/types.js';
+import type { GoalMode, GoalProviderKind, GoalReasoning } from '../shared/types.js';
 
 /** Where OpenRouter lives. One host, both routes. */
 const OPENROUTER_BASE = 'https://openrouter.ai/api/v1';
@@ -92,10 +92,16 @@ export interface GoalEndpoint {
   baseUrl: string;
 }
 
-export function goalEndpoint(): GoalEndpoint {
-  const provider = getConfig().goal.provider;
+type GoalSettingsSnapshot = ReturnType<typeof getConfig>['goal'];
+
+function endpointFor(settings: GoalSettingsSnapshot): GoalEndpoint {
+  const provider = settings.provider;
   if (provider?.kind === 'custom') return { kind: 'custom', baseUrl: provider.baseUrl };
   return { kind: 'openrouter', baseUrl: OPENROUTER_BASE };
+}
+
+export function goalEndpoint(): GoalEndpoint {
+  return endpointFor(getConfig().goal);
 }
 
 /**
@@ -334,6 +340,9 @@ export interface GoalDraftView {
 // so there is no second place where a draft can be described as retryable and be wrong.
 interface GoalDraft extends Omit<GoalDraftView, 'retryable'> {
   backend: GoalBackend;
+  /** Provider selection frozen with model/prompts; its matching key is read by kind at start. */
+  endpoint: GoalEndpoint;
+  providerReasoning: GoalReasoning;
   sessionId: string;
   /** Frozen with the draft, just like its model, so one request never mixes two settings saves. */
   systemPrompt: string;
@@ -952,7 +961,10 @@ export function goalSettings(): { enabled: boolean; mode: GoalMode; model: strin
 }
 
 export function goalBackendFor(mode: GoalMode): GoalBackend {
-  const settings = getConfig().goal;
+  return backendFor(getConfig().goal, mode);
+}
+
+function backendFor(settings: GoalSettingsSnapshot, mode: GoalMode): GoalBackend {
   return mode === 'loop' ? settings.loopBackend ?? 'chatgpt' : settings.backend ?? 'chatgpt';
 }
 export async function goalKeyPresent(mode: GoalMode = goalDrivingMode()): Promise<boolean> {
@@ -1232,16 +1244,19 @@ export function startGoalDraft(input: StartGoalDraftInput): GoalDraftView {
     drafts.delete(input.conversationId);
   }
   const settings = getConfig().goal;
-  const backend = goalBackendFor(goalDrivingMode(input.conversationId));
+  const mode = goalDrivingMode(input.conversationId);
+  const backend = backendFor(settings, mode);
   const draft: GoalDraft = {
     token: `goal-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`,
     conversationId: input.conversationId,
     sessionId: input.sessionId,
     backend,
+    endpoint: endpointFor(settings),
+    providerReasoning: settings.reasoning,
     systemPrompt: settings.prompt,
     objectiveSystemPrompt: settings.objectivePrompt,
     loopSystemPrompt: settings.loopPrompt,
-    mode: goalDrivingMode(input.conversationId),
+    mode,
     objective: goalObjectiveFor(input.conversationId),
     clientId,
     turnId: input.turnId,
@@ -1308,6 +1323,14 @@ interface GoalRequest {
   sourceSessionId?: string;
   backend?: GoalBackend;
   reasoning?: 'none';
+  /**
+   * Frozen provider endpoint and reasoning for this request, snapshotted once by the
+   * caller next to the key read. Re-reading live config down here is what once let a
+   * mid-flight provider switch mix key-A with endpoint-B, so the api path below must
+   * not call goalEndpoint() or read settings.reasoning itself.
+   */
+  endpoint: GoalEndpoint;
+  providerReasoning: GoalReasoning;
   key: string;
   model: string;
   /**
@@ -1382,7 +1405,7 @@ async function requestGoalDecision(request: GoalRequest): Promise<GoalDecision |
     }
     return decision;
   }
-  const endpoint = goalEndpoint();
+  const endpoint = request.endpoint;
   let baseUrl: string;
   try {
     baseUrl = resolveGoalBaseUrl(endpoint);
@@ -1411,20 +1434,21 @@ async function requestGoalDecision(request: GoalRequest): Promise<GoalDecision |
   // Reasoning may still be used, but it is never part of the response body this app parses.
   // OpenRouter documents `exclude` as supported across models even when effort selection is
   // not. `default` therefore means "provider-selected effort", not "return its scratchpad".
-  // A custom endpoint gets the effort alone: `exclude` is OpenRouter vocabulary, and an
-  // endpoint that rejects unknown fields should run with reasoning `default`, which omits
-  // the block entirely.
+  // A custom endpoint gets the OpenAI-compatible top-level `reasoning_effort` instead:
+  // `reasoning` is OpenRouter vocabulary, and an endpoint that rejects unknown fields
+  // should run with reasoning `default`, which omits the field entirely.
   if (!custom) {
     body['reasoning'] = {
-      ...(request.reasoning ? { effort: request.reasoning } : settings.reasoning === 'default' ? {} : { effort: settings.reasoning }),
+      ...(request.reasoning ? { effort: request.reasoning } : request.providerReasoning === 'default' ? {} : { effort: request.providerReasoning }),
       exclude: true
     };
-  } else if (settings.reasoning !== 'default') {
-    body['reasoning'] = { effort: settings.reasoning };
+  } else if (request.providerReasoning !== 'default') {
+    body['reasoning_effort'] = request.providerReasoning;
   }
 
   const response = await fetch(`${baseUrl}/chat/completions`, {
     method: 'POST',
+    redirect: 'error',
     headers: {
       ...(request.key ? { authorization: `Bearer ${request.key}` } : {}),
       'content-type': 'application/json',
@@ -1472,14 +1496,13 @@ async function requestDrivingDecision(
 
 async function run(draft: GoalDraft): Promise<void> {
   if (await astraFinishOnly(draft.sessionId, draft.conversationId)) return settle(draft, 'no-reply');
-  const endpoint = goalEndpoint();
-  const key = await goalProviderKey(endpoint.kind);
+  const key = await goalProviderKey(draft.endpoint.kind);
   if (draft.acknowledged || drafts.get(draft.conversationId) !== draft) return;
   // Only the OpenRouter api backend fails here without a key. A custom endpoint may be a
   // keyless local server (key arrives as '' and no Authorization header is sent), and the
-  // other backends never needed one. A provider switch retires in-flight drafts at the
-  // settings boundary, so reading the endpoint live here cannot mix two configurations.
-  if (draft.backend === 'api' && !key && endpoint.kind === 'openrouter') return settle(draft, 'failed', 'no_api_key');
+  // other backends never needed one. Endpoint, model and reasoning were frozen together
+  // when this draft was created; this read asks only for that endpoint kind's matching key.
+  if (draft.backend === 'api' && !key && draft.endpoint.kind === 'openrouter') return settle(draft, 'failed', 'no_api_key');
   const messages = await conversationMessages(draft.sessionId);
   if (draft.acknowledged || drafts.get(draft.conversationId) !== draft) return;
   // Goal Mode is supposed to continue *the user's objective*. A partially recovered recorder
@@ -1501,6 +1524,8 @@ async function run(draft: GoalDraft): Promise<void> {
     const decision = draft.backend === 'templates' ? templateGoalDecision(messages.filter((message) => message.role === 'assistant').at(-1)?.content ?? '', Math.floor(Math.random() * 200), Math.floor(Math.random() * 200)) : await requestDrivingDecision({
       backend: draft.backend,
       sourceSessionId: draft.sessionId,
+      endpoint: draft.endpoint,
+      providerReasoning: draft.providerReasoning,
       key: key ?? '',
       model: draft.model,
       mode: draft.mode,
@@ -1596,8 +1621,11 @@ async function run(draft: GoalDraft): Promise<void> {
  */
 /** Finish asks the existing Loop driver for the next instruction; its caller owns delivery. */
 export async function draftFastFollowup(sessionId: string, signal: AbortSignal = AbortSignal.timeout(180000), preparedMessages?: ChatMessage[], publish?: GoalRequest['publish'], mode: GoalMode = 'loop'): Promise<string | null> {
-  const backend = goalBackendFor(mode);
-  const endpoint = goalEndpoint();
+  const settings = getConfig().goal;
+  const backend = backendFor(settings, mode);
+  const endpoint = endpointFor(settings);
+  const providerReasoning = settings.reasoning;
+  const model = settings.model;
   const key = await goalProviderKey(endpoint.kind);
   // Custom endpoints may be keyless; only OpenRouter fails here without one.
   if (backend === 'api' && !key && endpoint.kind === 'openrouter') throw new Error('Configure the Goal API key for automatic finish follow-ups, or choose Notify me');
@@ -1610,11 +1638,10 @@ export async function draftFastFollowup(sessionId: string, signal: AbortSignal =
     ['tool', 'sent'].includes(entry.state)).slice(-5).map(entry => entry.text);
   const messages = preparedMessages ?? await conversationMessages(sessionId, appInput, new Set(inputs.filter(entry => entry.finishOwner).map(entry => entry.id)));
   if (!objective && !messages.some(message => message.role === 'user')) throw new Error('No recorded user request is available for Goal');
-  const settings = getConfig().goal;
   const prompt = mode === 'loop' ? settings.loopPrompt : objective ? settings.objectivePrompt : settings.prompt;
   const decision = backend === 'templates'
     ? templateGoalDecision(messages.filter(message => message.role === 'assistant').at(-1)?.content ?? '', Math.floor(Math.random() * 200), Math.floor(Math.random() * 200))
-    : await requestDrivingDecision({ sourceSessionId: sessionId, backend, key: key ?? '', model: settings.model, mode,
+    : await requestDrivingDecision({ sourceSessionId: sessionId, backend, endpoint, providerReasoning, key: key ?? '', model, mode,
     system: objective ? [prompt, goalObjectiveMessage(objective)] : [prompt],
     messages,
     trailer: mode === 'loop' ? GOAL_LOOP_TRAILER : objective ? GOAL_OBJECTIVE_TRAILER : GOAL_SYSTEM_TRAILER, signal, publish });
@@ -1630,12 +1657,15 @@ export async function draftFastFollowup(sessionId: string, signal: AbortSignal =
 export async function draftTaskPlan(prompt: string, backend: 'api' | 'chatgpt', onProgress?: (progress: TaskProgressUpdate) => void, signal?: AbortSignal): Promise<string[]> {
   onProgress?.({ phase: 'preparing', text: '' });
   if (!prompt.trim() || prompt.length > 16000) throw new Error('Enter a task of at most 16000 characters');
-  const endpoint = goalEndpoint();
+  const settings = getConfig().goal;
+  const endpoint = endpointFor(settings);
+  const providerReasoning = settings.reasoning;
+  const model = settings.model;
   const key = backend === 'api' ? await goalProviderKey(endpoint.kind) : null;
   // Custom endpoints may be keyless; only OpenRouter fails here without one.
   if (backend === 'api' && !key && endpoint.kind === 'openrouter') throw new Error('Configure a Goal API key or choose ChatGPT');
   onProgress?.({ phase: 'generating', text: '' });
-  const result = await requestGoalDecision({ backend, lifetime: 'temporary-planner', key: key ?? '', model: getConfig().goal.model, mode: 'goal', publish: text => onProgress?.({ phase: 'generating', text: planProgressText(text) }),
+  const result = await requestGoalDecision({ backend, lifetime: 'temporary-planner', endpoint, providerReasoning, key: key ?? '', model, mode: 'goal', publish: text => onProgress?.({ phase: 'generating', text: planProgressText(text) }),
     system: ['You are a task planner, not the executor. Divide the user request into 2 to 12 sequential, self-contained stages. Preserve all requirements and constraints. Include implementation and meaningful verification phases, with a final full acceptance check. Do not invent unrelated work. Return action continue; its reply must be a JSON string encoding {"stages":["first task", "next task"]}. Keep the entire plan below 12000 characters. Each stage is sent to the same working conversation only after it finishes the previous stage.'],
     messages: [{ role: 'user', content: prompt.trim() }], trailer: 'Produce the staged plan now. Do not execute the task.', signal: signal ? AbortSignal.any([signal, AbortSignal.timeout(REQUEST_TIMEOUT_MS)]) : AbortSignal.timeout(REQUEST_TIMEOUT_MS) })
     .catch(error => { throw nativeGoalFailure(`request_failed: ${error instanceof Error ? error.message : error}`, backend); });
@@ -1659,24 +1689,29 @@ export async function draftOpeningMessage(
   signal?.throwIfAborted();
   onProgress?.({ phase: 'preparing', text: '' });
   if (!goal) return { error: 'no_objective' };
-  const endpoint = goalEndpoint();
+  const settings = getConfig().goal;
+  const mode = named ?? goalDrivingMode();
+  const backend = backendFor(settings, mode);
+  const endpoint = endpointFor(settings);
+  const providerReasoning = settings.reasoning;
+  const model = backend === 'chatgpt' ? settings.helperModel ?? 'gpt-5.6-sol' : settings.model;
+  const prompt = mode === 'loop' ? settings.loopPrompt : settings.objectivePrompt;
   const key = await goalProviderKey(endpoint.kind);
-  const backend = goalBackendFor(named ?? goalDrivingMode());
   if (backend === 'templates') return { reply: goal + GOAL_MARKER_INSTRUCTION, model: 'Offline Goal' };
   // Custom endpoints may be keyless; only OpenRouter fails here without one.
   if (backend === 'api' && !key && endpoint.kind === 'openrouter') return { error: 'no_api_key' };
-  const model = backend === 'chatgpt' ? getConfig().goal.helperModel ?? 'gpt-5.6-sol' : getConfig().goal.model;
   const abort = new AbortController();
   const timer = setTimeout(() => abort.abort(), REQUEST_TIMEOUT_MS);
   try {
-    const mode = named ?? goalDrivingMode();
     const decision = await requestDrivingDecision({
       backend,
+      endpoint,
+      providerReasoning,
       key: key ?? '',
       model,
       mode,
       system: [
-        mode === 'loop' ? getConfig().goal.loopPrompt : getConfig().goal.objectivePrompt,
+        prompt,
         goalObjectiveMessage(goal)
       ],
       messages: [{ role: 'user', content: GOAL_OBJECTIVE_OPENING_TURN }],
@@ -2450,6 +2485,7 @@ async function allGoalModels(): Promise<GoalModel[]> {
   try {
     const baseUrl = resolveGoalBaseUrl(endpoint);
     response = await fetch(`${baseUrl}/models`, {
+      redirect: 'error',
       headers: {
         // The listing is public; the key is sent when there is one so a key with a restricted
         // model set sees its own set rather than the catalogue.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -578,7 +578,8 @@ export function registerIpc(getWindow: () => BrowserWindow | null, quitToInstall
       throw new Error('Secure OS credential storage is unavailable, so the key cannot be stored safely.');
     }
     await setSecret(key, value);
-    if (key === 'openRouterApiKey' || key === 'customProviderApiKey') retireGoalDrafts();
+    const activeProviderKey = getConfig().goal.provider.kind === 'custom' ? 'customProviderApiKey' : 'openRouterApiKey';
+    if (key === activeProviderKey) retireGoalDrafts();
     const what = key === 'openRouterApiKey' ? 'openrouter key' : key === 'customProviderApiKey' ? 'custom provider key' : 'api key';
     logInfo(value.trim() === '' ? `${what} cleared` : `${what} stored`);
     return buildState();

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -29,6 +29,7 @@ import { z } from 'zod';
 import {
   CAPABILITIES,
   GOAL_MODES,
+  GOAL_PROVIDERS,
   GOAL_REASONING_LEVELS,
   RELEASES_PAGE,
   type AppState,
@@ -182,24 +183,35 @@ const settingsPatch = z.object({
     // Which of the two standing modes the switch runs. One field, so the renderer has no way
     // to describe a state where Goal and Loop are both on.
     mode: z.enum(GOAL_MODES),
-    // An OpenRouter model id, and validated only as a shape: the catalogue changes weekly,
-    // and an allow-list here would mean this app deciding which models exist.
+    // Which LLM endpoint Goal/Loop drafts run on, plus the custom endpoint's base URL.
+    // The URL is stored verbatim and validated at draft time (see resolveGoalBaseUrl):
+    // a shape check here would either duplicate that logic or silently rewrite the address.
+    provider: z.object({
+      kind: z.enum(GOAL_PROVIDERS),
+      baseUrl: z.string().max(2048)
+    }),
+    // An OpenRouter model id while the provider is openrouter, validated only as a shape:
+    // the catalogue changes weekly, and an allow-list here would mean this app deciding
+    // which models exist.
     // The leading `~` is OpenRouter's own marker for an alias that always resolves to the
     // newest model in a family — `~deepseek/deepseek-v4-flash-latest` and eleven others. The
     // picker lists them because the listing does, so refusing them here meant the one kind
     // of entry most worth choosing was the one kind that could not be saved.
-    model: z
-      .string()
-      .min(1)
-      .max(160)
-      .regex(
-        /^~?[a-z0-9._\-]+\/[a-z0-9._\-]+(:[a-z0-9._\-]+)?$/i,
-        'Expected an OpenRouter model id like vendor/model'
-      ),
+    // A custom endpoint names its own models (`llama3.1`, a deployment id), so while custom
+    // it is any non-empty id instead.
+    model: z.string().min(1).max(160),
     reasoning: z.enum(GOAL_REASONING_LEVELS),
     prompt: z.string().trim().min(1).max(MAX_GOAL_SYSTEM_PROMPT_CHARS),
     objectivePrompt: z.string().trim().min(1).max(MAX_GOAL_SYSTEM_PROMPT_CHARS),
     loopPrompt: z.string().trim().min(1).max(MAX_GOAL_SYSTEM_PROMPT_CHARS)
+  }).superRefine((goal, ctx) => {
+    if (goal.provider.kind !== 'custom' && !/^~?[a-z0-9._-]+\/[a-z0-9._-]+(:[a-z0-9._-]+)?$/i.test(goal.model)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['model'],
+        message: 'Expected an OpenRouter model id like vendor/model'
+      });
+    }
   })
 });
 
@@ -292,6 +304,10 @@ function mergeSettings(current: Config, base: SettingsSnapshot, wanted: Settings
       helperReasoning: pick(current.goal.helperReasoning, base.goal.helperReasoning, wanted.goal.helperReasoning),
       enabled: pick(current.goal.enabled, base.goal.enabled, wanted.goal.enabled),
       mode: pick(current.goal.mode, base.goal.mode, wanted.goal.mode),
+      provider: {
+        kind: pick(current.goal.provider.kind, base.goal.provider.kind, wanted.goal.provider.kind),
+        baseUrl: pick(current.goal.provider.baseUrl, base.goal.provider.baseUrl, wanted.goal.provider.baseUrl)
+      },
       model: pick(current.goal.model, base.goal.model, wanted.goal.model),
       reasoning: pick(current.goal.reasoning, base.goal.reasoning, wanted.goal.reasoning),
       prompt: pick(current.goal.prompt, base.goal.prompt, wanted.goal.prompt),
@@ -332,6 +348,7 @@ async function buildState(): Promise<AppState> {
     secureStorage: await secureStorageStatus(),
     hasApiKey: await hasSecret('openaiApiKey'),
     hasGoalKey: await hasSecret('openRouterApiKey'),
+    hasCustomProviderKey: await hasSecret('customProviderApiKey'),
     resolvedBinary: resolvedBinary(config),
     bundledTunnelVersion: bundledVersion(),
     bridge: await bridgeStatus(),
@@ -401,6 +418,8 @@ export function registerIpc(getWindow: () => BrowserWindow | null, quitToInstall
       before.goal.backend !== next.goal.backend ||
       before.goal.loopBackend !== next.goal.loopBackend ||
       before.goal.helperModel !== next.goal.helperModel || before.goal.helperReasoning !== next.goal.helperReasoning ||
+      before.goal.provider.kind !== next.goal.provider.kind ||
+      before.goal.provider.baseUrl !== next.goal.provider.baseUrl ||
       before.goal.reasoning !== next.goal.reasoning ||
       before.goal.includeToolCalls !== next.goal.includeToolCalls ||
       before.goal.prompt !== next.goal.prompt ||
@@ -550,14 +569,17 @@ export function registerIpc(getWindow: () => BrowserWindow | null, quitToInstall
    */
   handle('secret:set', async (payload) => {
     const { value, key } = z
-      .object({ value: z.string().max(500), key: z.enum(['openaiApiKey', 'openRouterApiKey']).default('openaiApiKey') })
+      .object({
+        value: z.string().max(500),
+        key: z.enum(['openaiApiKey', 'openRouterApiKey', 'customProviderApiKey']).default('openaiApiKey')
+      })
       .parse(payload);
     if (!(await isEncryptionAvailable())) {
       throw new Error('Secure OS credential storage is unavailable, so the key cannot be stored safely.');
     }
     await setSecret(key, value);
-    if (key === 'openRouterApiKey') retireGoalDrafts();
-    const what = key === 'openRouterApiKey' ? 'openrouter key' : 'api key';
+    if (key === 'openRouterApiKey' || key === 'customProviderApiKey') retireGoalDrafts();
+    const what = key === 'openRouterApiKey' ? 'openrouter key' : key === 'customProviderApiKey' ? 'custom provider key' : 'api key';
     logInfo(value.trim() === '' ? `${what} cleared` : `${what} stored`);
     return buildState();
   });

--- a/src/main/secrets.ts
+++ b/src/main/secrets.ts
@@ -57,11 +57,12 @@ function enqueue<T>(operation: () => Promise<T>): Promise<T> {
  * config.json, the log and the renderer.
  */
 /**
- * `bridgeToken` is not a user credential either way; `openRouterApiKey` is one, and is the
- * only credential in here that a *model* can cause to be spent, so it lives under the same
- * OS-backed encrypted blob as the rest and never leaves the main process.
+ * `bridgeToken` is not a user credential either way; `openRouterApiKey` and
+ * `customProviderApiKey` are the two credentials a *model* can cause to be spent (Goal/Loop
+ * drafts, one per active provider), so they live under the same OS-backed encrypted blob
+ * as the rest and never leave the main process.
  */
-export type SecretKey = 'openaiApiKey' | 'bridgeToken' | 'openRouterApiKey';
+export type SecretKey = 'openaiApiKey' | 'bridgeToken' | 'openRouterApiKey' | 'customProviderApiKey';
 
 export function initSecretsPath(userDataDir: string): void {
   secretsPath = path.join(userDataDir, FILE_NAME);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -41,7 +41,7 @@ export interface SettingsPatch {
   goal: Config['goal'];
 }
 
-/** One page of the OpenRouter catalogue, as the model picker asks for it. */
+/** One page of the model catalogue, as the model picker asks for it. */
 export interface GoalModelPage {
   models: Array<{ id: string; name: string; created: number; contextLength: number }>;
   total: number;
@@ -85,6 +85,8 @@ const api = {
   setApiKey: (value: string) => call<AppState>('secret:set', { value }),
   // The goal loop's own credential. Same channel, named slot; the value only ever goes in.
   setGoalKey: (value: string) => call<AppState>('secret:set', { value, key: 'openRouterApiKey' }),
+  // The same, for a custom provider endpoint. Optional: keyless local servers need nothing stored.
+  setCustomProviderKey: (value: string) => call<AppState>('secret:set', { value, key: 'customProviderApiKey' }),
   listGoalModels: (offset: number) => call<GoalModelPage>('goal:models', { offset }),
   pickBinary: () => call<AppState>('binary:pick'),
   connect: () => call<AppState>('connection:connect'),

--- a/src/renderer/chat.ts
+++ b/src/renderer/chat.ts
@@ -2191,9 +2191,17 @@ export function chatSettingsPatch(current: Config): {
       loopBackend: $<HTMLSelectElement>('loopBackend').value as Config['goal']['loopBackend'],
       helperModel: $<HTMLSelectElement>('helperModel').value || current.goal.helperModel || 'gpt-5.6-sol',
       helperReasoning: ($<HTMLSelectElement>('helperReasoning').value || current.goal.helperReasoning || 'high') as Config['goal']['helperReasoning'],
-      // The chosen model is held here rather than in an input, because it is picked from a
-      // list and never typed. `current` is the fallback for the first save after a repaint.
-      model: goalModel || current.goal.model,
+      provider: {
+        kind: ($<HTMLSelectElement>('goalProvider').value || current.goal.provider?.kind || 'openrouter') as Config['goal']['provider']['kind'],
+        baseUrl: $<HTMLInputElement>('goalBaseUrl').value.trim()
+      },
+      // The api-backend model is picked from the catalogue and never typed, except on a
+      // custom endpoint whose id is typed in its own field instead. `current` is the
+      // fallback for the first save after a repaint.
+      model:
+        $<HTMLSelectElement>('goalProvider').value === 'custom'
+          ? $<HTMLInputElement>('goalCustomModel').value.trim() || current.goal.model
+          : goalModel || current.goal.model,
       reasoning: $<HTMLSelectElement>('goalReasoning').value as Config['goal']['reasoning'],
       // Blank means "restore the safe default", not "send an unconstrained system message".
       prompt: $<HTMLTextAreaElement>('goalPrompt').value.trim() || DEFAULT_GOAL_SYSTEM_PROMPT,
@@ -2342,6 +2350,17 @@ function applyGoal(state: AppState, previous?: Config): void {
     config.goal.loopPrompt,
     previous?.goal.loopPrompt
   );
+  // Which endpoint the api backend talks to. The key sentence below only applies to
+  // OpenRouter: a custom endpoint is often keyless, so a missing key never means custom.
+  const customProvider = config.goal.provider?.kind === 'custom';
+  const providerBaseUrl = config.goal.provider?.baseUrl ?? '';
+  applyChatValue($<HTMLSelectElement>('goalProvider'), customProvider ? 'custom' : 'openrouter', previous?.goal.provider?.kind);
+  applyChatValue($<HTMLInputElement>('goalBaseUrl'), providerBaseUrl, previous?.goal.provider?.baseUrl);
+  applyChatValue($<HTMLInputElement>('goalCustomModel'), config.goal.model, previous?.goal.model);
+  $('goalCustomPanel').hidden = !customProvider;
+  $('goalPickerRow').hidden = customProvider;
+  if (customProvider) $('goalModels').hidden = true;
+  $('goalKeyField').hidden = customProvider;
   $('goalModelName').textContent = config.goal.model;
   const goalKey = $<HTMLInputElement>('goalKey');
   goalKey.placeholder = state.hasGoalKey ? '•••••••• stored' : 'sk-or-v1-…';
@@ -2353,6 +2372,16 @@ function applyGoal(state: AppState, previous?: Config): void {
       : 'Stored with secure OS credential storage. It never leaves this app, and the browser is only ever handed the reply.';
   $('goalKeyState').classList.toggle('is-warn', !secureStorageAvailable);
   $<HTMLButtonElement>('goalKeyRemove').disabled = !state.hasGoalKey || !secureStorageAvailable;
+  const goalCustomKey = $<HTMLInputElement>('goalCustomKey');
+  goalCustomKey.placeholder = state.hasCustomProviderKey ? '•••••••• stored' : 'leave empty for a keyless local server';
+  goalCustomKey.disabled = !secureStorageAvailable;
+  $('goalCustomKeyState').textContent = !secureStorageAvailable
+    ? (state.secureStorage?.detail ?? 'Secure credential storage is unavailable.')
+    : state.hasCustomProviderKey
+      ? 'A key is stored with secure OS credential storage. Type a new one to replace it.'
+      : 'Optional. Stored with secure OS credential storage. It never leaves this app, and the browser is only ever handed the reply.';
+  $('goalCustomKeyState').classList.toggle('is-warn', !secureStorageAvailable);
+  $<HTMLButtonElement>('goalCustomKeyRemove').disabled = !state.hasCustomProviderKey || !secureStorageAvailable;
   if (goalModels.length > 0) paintGoalModels();
 }
 
@@ -2437,6 +2466,27 @@ function wireGoal(save: () => Promise<void>): void {
       toast('OpenRouter key removed');
     }
   });
+  // Same blur-to-save discipline as the OpenRouter key above. Empty submits nothing:
+  // a keyless local endpoint is a supported configuration, not a key being removed.
+  $('goalCustomKey').addEventListener('blur', async () => {
+    const input = $<HTMLInputElement>('goalCustomKey');
+    const submitted = input.value;
+    const key = submitted.trim();
+    if (key === '') return;
+    const next = await run(api.setCustomProviderKey(key));
+    if (next) {
+      if (input.value === submitted) input.value = '';
+      applyGoal(next);
+      toast('Custom provider key stored');
+    }
+  });
+  $('goalCustomKeyRemove').addEventListener('click', async () => {
+    const next = await run(api.setCustomProviderKey(''));
+    if (next) {
+      applyGoal(next);
+      toast('Custom provider key removed');
+    }
+  });
 }
 
 /**
@@ -2471,6 +2521,9 @@ const CHAT_INPUTS = [
   'maWorkers',
   'allowUnattributedCalls',
   'recoverAgentTabs',
+  'goalProvider',
+  'goalBaseUrl',
+  'goalCustomModel',
   'goalReasoning',
   'goalPrompt',
   'goalObjectivePrompt',

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -625,7 +625,32 @@
                   </div>
                 <h2 class="settings-section-title">API provider</h2>
                 <div class="pane">
-                  <div class="field">
+                  <div class="setting">
+                    <span class="setting-text">
+                      <b>Provider</b>
+                      <em>OpenRouter, or your own OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, a gateway) for the API response source.</em>
+                    </span>
+                    <select id="goalProvider">
+                      <option value="openrouter">OpenRouter</option>
+                      <option value="custom">Custom endpoint</option>
+                    </select>
+                  </div>
+
+                  <div class="field" id="goalCustomPanel" hidden>
+                    <label for="goalBaseUrl">Endpoint base URL</label>
+                    <input id="goalBaseUrl" type="text" spellcheck="false" placeholder="http://localhost:11434/v1" autocomplete="off" />
+                    <p class="hint">https, or http on localhost. <code>/chat/completions</code> and <code>/models</code> are called under it.</p>
+                    <label for="goalCustomModel">Model</label>
+                    <input id="goalCustomModel" type="text" spellcheck="false" placeholder="llama3.1" autocomplete="off" />
+                    <p class="hint">Your endpoint's own model id, typed exactly as it serves it.</p>
+                    <label for="goalCustomKey">Endpoint API key (optional)</label>
+                    <input id="goalCustomKey" type="password" spellcheck="false" placeholder="leave empty for a keyless local server" autocomplete="off" />
+                    <p class="hint" id="goalCustomKeyState"></p>
+                    <div class="step-actions">
+                      <button class="btn" id="goalCustomKeyRemove" type="button">Remove stored key</button>
+                    </div>
+                  </div>
+                  <div class="field" id="goalKeyField">
                     <label for="goalKey">OpenRouter API key</label>
                     <input id="goalKey" type="password" spellcheck="false" placeholder="sk-or-v1-…" autocomplete="off" />
                     <p class="hint" id="goalKeyState"></p>
@@ -636,7 +661,12 @@
                       </button>
                     </div>
                   </div>
-                  <div class="setting">
+                  <!--
+                    The catalogue is several hundred models long and changes weekly, so it is
+                    not fetched until somebody actually asks to change the one in use - and
+                    then twenty at a time, newest release first.
+                  -->
+                  <div class="setting" id="goalPickerRow">
                     <span class="setting-text">
                       <b>Model</b>
                       <em id="goalModelName"></em>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -187,12 +187,13 @@ export type GoalReasoning = (typeof GOAL_REASONING_LEVELS)[number];
  * The goal loop: a second model, standing in for the user, that keeps a chat going.
  *
  * When ChatGPT finishes a turn, the recorded conversation — every user message and every
- * final ChatGPT answer, and nothing else — is sent to an OpenRouter model with an editable
+ * final ChatGPT answer, and nothing else — is sent to the configured provider's model with an editable
  * continuation-gate instruction. A completion claim produces `NO_REPLY`; only a concrete
  * requested item the final answer explicitly leaves unfinished becomes a user message.
  *
- * Off by default, and useless without an OpenRouter API key: the key is the credential the
- * whole feature runs on, so the UI says so rather than failing quietly at the first turn.
+ * Off by default, and useless without a key for the configured provider: the key is the credential the
+ * whole feature runs on, so the UI says so rather than failing quietly at the first turn. A custom
+ * keyless local endpoint is the one exception — there is nothing to store for it.
  */
 /**
  * Which of the two standing modes the switch runs.
@@ -206,6 +207,27 @@ export const GOAL_MODES = ['goal', 'loop'] as const;
 export type GoalMode = (typeof GOAL_MODES)[number];
 
 export type GoalBackend = 'api' | 'chatgpt' | 'templates';
+/**
+ * Where the Goal/Loop second model runs when the backend is `api`.
+ *
+ * `openrouter` is the shipped default: OpenRouter's catalogue, key and routing. `custom`
+ * points at any OpenAI-compatible `/chat/completions` endpoint the user runs themselves
+ * (Ollama, vLLM, LM Studio, a gateway) and is used with that endpoint's own model id.
+ * The other backends (`chatgpt`, `templates`) never read this block.
+ */
+export const GOAL_PROVIDERS = ['openrouter', 'custom'] as const;
+export type GoalProviderKind = (typeof GOAL_PROVIDERS)[number];
+
+export interface GoalProviderSettings {
+  kind: GoalProviderKind;
+  /**
+   * Base URL of a custom provider, e.g. `http://localhost:11434/v1`. Ignored unless
+   * kind is `custom`. Stored verbatim; validated when a draft is started, not when saved,
+   * so a typo fails loudly at use time rather than silently rewriting the user's text.
+   */
+  baseUrl: string;
+}
+
 export interface GoalSettings {
   /** Optional active-turn Goal impulses; zero disables them. */
   impulseMinutes?: number;
@@ -223,7 +245,8 @@ export interface GoalSettings {
    * with the switch off runs as `goal`, because Loop is a thing the user switches on.
    */
   mode: GoalMode;
-  /** An OpenRouter model id, exactly as its `/models` listing spells it. */
+  provider: GoalProviderSettings;
+  /** A model id: an OpenRouter id while the provider is openrouter, the endpoint's own id while custom. */
   model: string;
   reasoning: GoalReasoning;
   /** Editable continuation-gate instruction sent as the OpenRouter system message. */
@@ -507,8 +530,10 @@ export interface AppState {
   secureStorage: SecureStorageInfo;
   /** True when an OpenAI control-plane API key is stored. The key itself never leaves the main process. */
   hasApiKey: boolean;
-  /** True when an OpenRouter key is stored, which is what the goal loop spends. Same rule: the key stays here. */
+  /** True when an OpenRouter key is stored, which is what the goal loop spends on that provider. Same rule: the key stays here. */
   hasGoalKey: boolean;
+  /** True when a custom-provider key is stored. Only meaningful beside a custom endpoint, which may also run keyless. */
+  hasCustomProviderKey: boolean;
   /** Resolved path of the tunnel binary we would run, or null if we cannot find one. */
   resolvedBinary: string | null;
   /** Version of the tunnel-client copy shipped inside the app, for diagnostics. */

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -84,6 +84,9 @@ describe('settings migration', () => {
     expect(loaded.capabilities.create).toBe(true);
     expect(loaded.capabilities.clipboardRead).toBe(false);
     expect(loaded.capabilities.clipboardWrite).toBe(false);
+    // A config written before custom providers existed keeps OpenRouter with no URL:
+    // an upgrade never moves a running Goal loop onto an endpoint nobody chose.
+    expect(loaded.goal.provider).toEqual({ kind: 'openrouter', baseUrl: '' });
     expect(loaded.ui.autoConnect).toBe(true);
     expect(loaded.ui.privacyScreenshots).toBe(false);
     // The one tunnel id a pre-split config had is Core's, because Core is the connector
@@ -474,6 +477,7 @@ describe('the goal loop settings', () => {
       helperReasoning: 'high',
       enabled: true,
       mode: 'loop',
+      provider: { kind: 'openrouter', baseUrl: '' },
       model: 'openai/gpt-5.2-mini:nitro',
       reasoning: 'high',
       prompt,
@@ -620,6 +624,7 @@ describe('the goal loop settings', () => {
       helperReasoning: 'high',
       enabled: false,
       mode: 'goal',
+      provider: { kind: 'openrouter', baseUrl: '' },
       model: DEFAULT_GOAL_MODEL,
       reasoning: 'default',
       prompt: defaultConfig().goal.prompt,

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -13154,6 +13154,15 @@ describe('the goal loop', () => {
     });
     // Idle says nothing at all rather than an empty panel.
     expect(view({ phase: '', error: '', model: MODEL, draft: null })).toBeNull();
+    // A custom endpoint is named as one: the OpenRouter default above must not leak into a
+    // run that never touched OpenRouter.
+    expect(view({ phase: 'requesting', error: '', model: 'llama3.1', provider: 'custom', draft: null })).toMatchObject({
+      stage: 'Sending the answer to custom endpoint',
+      detail: 'llama3.1'
+    });
+    expect(
+      view({ phase: 'drafting', error: '', model: 'llama3.1', provider: 'custom', draft: { stage: 'failed' } })
+    ).toMatchObject({ detail: 'custom endpoint did not answer' });
     // A running job owns the panel: a compaction is the bigger event, and the loop refuses to
     // act during one anyway.
     expect(hook.stageView({ job: { stage: 'opening', busy: true }, goal: { phase: 'settling', model: MODEL, draft: null } })).toMatchObject({

--- a/test/goal-provider-freeze.test.ts
+++ b/test/goal-provider-freeze.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Provider freeze: one Goal request uses a single consistent
+ * one provider configuration even if settings change mid-flight.
+ *
+ * A provider switch landing between run()'s key read and the fetch used to mix
+ * key-A with endpoint-B, because the endpoint and reasoning were re-read live at
+ * request time. The draft now freezes endpoint/model/reasoning before reading that
+ * provider kind's matching key.
+ * This test pins the interleaving deterministically: the transcript read stays
+ * pending while the switch is fully applied, so only a live re-read can observe B.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '', getVersion: () => '0.0.0' },
+  safeStorage: {
+    isAsyncEncryptionAvailable: async () => true,
+    getSelectedStorageBackend: () => 'gnome_libsecret',
+    encryptStringAsync: async (value: string) => Buffer.from(value, 'utf8'),
+    decryptStringAsync: async (buffer: Buffer) => ({ result: buffer.toString('utf8'), shouldReEncrypt: false })
+  }
+}));
+
+let releaseTranscript: ((events: unknown[]) => void) | null = null;
+vi.mock('../src/main/session/store.js', () => ({
+  getSession: async () => null,
+  readEvents: async () => [],
+  readHandoff: async () => null,
+  readRecentEvents: () =>
+    new Promise((resolve) => {
+      releaseTranscript = resolve as (events: unknown[]) => void;
+    })
+}));
+
+const { defaultConfig, initConfigPath, saveConfig } = await import('../src/main/config.js');
+const { initSecretsPath, setSecret } = await import('../src/main/secrets.js');
+const goal = await import('../src/main/goal.js');
+const { makeTempDir, removeTempDir } = await import('./helpers.js');
+
+const realFetch = globalThis.fetch;
+let dir: string;
+
+function decision(action: 'stop' | 'continue', reply = ''): Response {
+  return Response.json({
+    choices: [{ message: { content: JSON.stringify({ action, reply }) } }]
+  });
+}
+
+async function settled(conversationId: string): Promise<NonNullable<ReturnType<typeof goal.goalViewFor>>> {
+  for (let attempt = 0; attempt < 400; attempt++) {
+    const view = goal.goalViewFor(conversationId);
+    if (view && view.stage !== 'sending' && view.stage !== 'answering') return view;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error('the draft never settled');
+}
+
+beforeAll(async () => {
+  dir = await makeTempDir('clf-goal-freeze-');
+  initConfigPath(dir);
+  initSecretsPath(dir);
+});
+
+afterAll(async () => {
+  await removeTempDir(dir);
+  globalThis.fetch = realFetch;
+});
+
+beforeEach(async () => {
+  goal.resetGoalStateForTests();
+  releaseTranscript = null;
+  await saveConfig({
+    ...defaultConfig(),
+    goal: {
+      ...defaultConfig().goal,
+      enabled: true,
+      backend: 'api',
+      loopBackend: 'api',
+      model: 'llama3.1',
+      reasoning: 'high',
+      provider: { kind: 'custom', baseUrl: 'http://127.0.0.1:9501/v1' }
+    }
+  });
+  await setSecret('customProviderApiKey', 'sk-custom-A');
+  await setSecret('openRouterApiKey', '');
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('a mid-flight provider switch', () => {
+  it('keeps the frozen endpoint, model and reasoning with its matching provider key', async () => {
+    let sent: any = null;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      sent = { url, headers: init.headers, body: JSON.parse(String(init.body)), redirect: init.redirect };
+      return decision('continue', 'check the tokenizer first');
+    }) as never;
+
+    // run() starts synchronously through beginGoalDraft and suspends inside the
+    // transcript read below: endpoint A, key A and reasoning high are already frozen.
+    goal.startGoalDraft({ sessionId: 's-freeze', conversationId: 'c-freeze', turnId: 'g-1' });
+    for (let attempt = 0; attempt < 200 && releaseTranscript === null; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(releaseTranscript).not.toBeNull();
+
+    // Fully applied while the request above is suspended: URL, key and reasoning all
+    // change. A live re-read at request time would mix key-A with endpoint-B.
+    await saveConfig({
+      ...defaultConfig(),
+      goal: {
+        ...defaultConfig().goal,
+        enabled: true,
+        backend: 'api',
+        loopBackend: 'api',
+        model: 'qwen3:8b',
+        reasoning: 'low',
+        provider: { kind: 'custom', baseUrl: 'http://127.0.0.1:9502/v1' }
+      }
+    });
+    await setSecret('customProviderApiKey', 'sk-custom-B');
+
+    releaseTranscript!([
+      { kind: 'user_message', message: { text: 'build the parser', truncated: false, chars: 16 } }
+    ]);
+    const view = await settled('c-freeze');
+
+    expect(view.stage).toBe('ready');
+    expect(sent.url).toBe('http://127.0.0.1:9501/v1/chat/completions');
+    expect((sent.headers as Record<string, string>).authorization).toBe('Bearer sk-custom-A');
+    expect(sent.body.model).toBe('llama3.1');
+    expect(sent.body.reasoning_effort).toBe('high');
+    expect(sent.body).not.toHaveProperty('reasoning');
+    expect(sent.redirect).toBe('error');
+  });
+});

--- a/test/goal.test.ts
+++ b/test/goal.test.ts
@@ -2360,3 +2360,174 @@ it('never owes or generates a browser continuation for Astra even with Goal arme
   await vi.waitFor(() => expect(goal.goalViewFor(conversationId)?.stage).toBe('no-reply'));
   expect(fetch).not.toHaveBeenCalled();
 });
+
+describe('a custom OpenAI-compatible provider', () => {
+  async function useCustom(over: Record<string, unknown> = {}): Promise<void> {
+    await saveConfig({
+      ...defaultConfig(),
+      goal: {
+        ...defaultConfig().goal,
+        enabled: true,
+        // The api backend is the only one that fetches; the other backends never read
+        // the provider block.
+        backend: 'api',
+        loopBackend: 'api',
+        model: 'llama3.1',
+        reasoning: 'default',
+        provider: { kind: 'custom', baseUrl: 'http://localhost:11434/v1' },
+        ...over
+      }
+    });
+    // Keyless unless the test stores one: a local server usually needs no secret, and the
+    // OpenRouter key from the outer beforeEach must never leak into a custom request.
+    await setSecret('customProviderApiKey', '');
+  }
+
+  async function userSession(conversationId: string): Promise<{ id: string }> {
+    const session = await createSession({ title: 'goal', conversationId });
+    await appendEvent(session.id, {
+      time: 1_000,
+      source: 'extension',
+      kind: 'user_message',
+      message: { text: 'build the parser', truncated: false, chars: 16 }
+    });
+    return session;
+  }
+
+  it('posts plain chat completions with no vendor fields and no key when keyless', async () => {
+    await useCustom();
+    const session = await userSession('c-custom-1');
+    let sent: any = null;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      sent = { url, headers: init.headers, body: JSON.parse(String(init.body)) };
+      return decision('continue', 'check the tokenizer first');
+    }) as never;
+
+    goal.startGoalDraft({ sessionId: session.id, conversationId: 'c-custom-1', turnId: 'g-1' });
+    const view = await settled('c-custom-1');
+
+    expect(view.stage).toBe('ready');
+    expect(sent.url).toBe('http://localhost:11434/v1/chat/completions');
+    expect(sent.headers).not.toHaveProperty('authorization');
+    expect(sent.headers).not.toHaveProperty('HTTP-Referer');
+    expect(sent.headers).not.toHaveProperty('X-Title');
+    expect(sent.body.model).toBe('llama3.1');
+    // run() always streams to the panel consumer on this base; the bounded parse is unchanged.
+    expect(sent.body.stream).toBe(true);
+    expect(sent.body).not.toHaveProperty('plugins');
+    expect(sent.body).not.toHaveProperty('provider');
+    expect(sent.body).not.toHaveProperty('reasoning');
+    expect(sent.body.response_format).toMatchObject({
+      type: 'json_schema',
+      json_schema: { name: 'goal_decision', strict: true }
+    });
+  });
+
+  it('sends the custom key and the bare reasoning effort when both are configured', async () => {
+    await useCustom({ reasoning: 'high' });
+    await setSecret('customProviderApiKey', 'sk-custom-test');
+    const session = await userSession('c-custom-2');
+    let sent: any = null;
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      sent = { url, headers: init.headers, body: JSON.parse(String(init.body)) };
+      return decision('stop');
+    }) as never;
+
+    goal.startGoalDraft({ sessionId: session.id, conversationId: 'c-custom-2', turnId: 'g-1' });
+    const view = await settled('c-custom-2');
+
+    expect(view.stage).toBe('no-reply');
+    expect((sent.headers as Record<string, string>).authorization).toBe('Bearer sk-custom-test');
+    // `exclude` is OpenRouter vocabulary; a custom endpoint gets the effort alone.
+    expect(sent.body.reasoning).toEqual({ effort: 'high' });
+  });
+
+  it('fails settled on an invalid base URL instead of retrying forever', async () => {
+    await useCustom();
+    await saveConfig({
+      ...defaultConfig(),
+      goal: {
+        ...defaultConfig().goal,
+        enabled: true,
+        backend: 'api',
+        model: 'llama3.1',
+        provider: { kind: 'custom', baseUrl: 'nota url' }
+      }
+    });
+    const session = await userSession('c-custom-3');
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return decision('continue', 'never reached');
+    }) as never;
+
+    goal.startGoalDraft({ sessionId: session.id, conversationId: 'c-custom-3', turnId: 'g-1' });
+    const view = await settled('c-custom-3');
+
+    expect(view.stage).toBe('failed');
+    expect(view.error).toMatch(/^invalid_provider/);
+    expect(view.retryable).toBe(false);
+    expect(calls).toBe(0);
+  });
+
+  it('reads a vanilla OpenAI model list, and an empty one when unreachable', async () => {
+    await useCustom();
+    globalThis.fetch = (async (url: string) => {
+      expect(String(url)).toBe('http://localhost:11434/v1/models');
+      return Response.json({ data: [{ id: 'llama3.1' }, { id: 'qwen3:8b', created: 1_700_000_000 }] });
+    }) as never;
+    const page = await goal.listGoalModels(0, 20);
+    expect(page.models.map((model) => model.id).sort()).toEqual(['llama3.1', 'qwen3:8b']);
+    expect(page.models.find((model) => model.id === 'llama3.1')?.name).toBe('llama3.1');
+
+    globalThis.fetch = (async () => {
+      throw new TypeError('fetch failed');
+    }) as never;
+    // A different endpoint is a different cache scope, so this really exercises the
+    // failure path rather than the five-minute catalogue cache from the fetch above.
+    await saveConfig({
+      ...defaultConfig(),
+      goal: {
+        ...defaultConfig().goal,
+        enabled: true,
+        model: 'llama3.1',
+        provider: { kind: 'custom', baseUrl: 'http://localhost:11435/v1' }
+      }
+    });
+    const empty = await goal.listGoalModels(0, 20);
+    expect(empty).toEqual({ models: [], total: 0 });
+  });
+
+  it('requires a key for OpenRouter but not for a custom endpoint', async () => {
+    await saveConfig({
+      ...defaultConfig(),
+      goal: {
+        ...defaultConfig().goal,
+        backend: 'api',
+        provider: { kind: 'custom', baseUrl: 'http://localhost:11434/v1' }
+      }
+    });
+    await setSecret('openRouterApiKey', '');
+    await setSecret('customProviderApiKey', '');
+    expect(await goal.goalKeyPresent()).toBe(true);
+
+    await saveConfig({
+      ...defaultConfig(),
+      goal: { ...defaultConfig().goal, backend: 'api', provider: { kind: 'openrouter', baseUrl: '' } }
+    });
+    expect(await goal.goalKeyPresent()).toBe(false);
+    await setSecret('openRouterApiKey', 'sk-or-test');
+    expect(await goal.goalKeyPresent()).toBe(true);
+  });
+
+  it('accepts https and loopback http base URLs and refuses the rest', () => {
+    const open = (baseUrl: string) => goal.resolveGoalBaseUrl({ kind: 'custom', baseUrl });
+    expect(open('https://llm.example.com/v1/')).toBe('https://llm.example.com/v1');
+    expect(open('http://localhost:11434/v1')).toBe('http://localhost:11434/v1');
+    expect(open('http://127.0.0.1:11434')).toBe('http://127.0.0.1:11434');
+    for (const bad of ['notaurl', '', 'http://llm.example.com/v1', 'https://user:pass@llm.example.com/v1', 'ftp://llm.example.com']) {
+      expect(() => open(bad), bad).toThrow(/^invalid_provider/);
+    }
+    expect(goal.resolveGoalBaseUrl({ kind: 'openrouter', baseUrl: '' })).toBe('https://openrouter.ai/api/v1');
+  });
+});

--- a/test/goal.test.ts
+++ b/test/goal.test.ts
@@ -2399,7 +2399,7 @@ describe('a custom OpenAI-compatible provider', () => {
     const session = await userSession('c-custom-1');
     let sent: any = null;
     globalThis.fetch = (async (url: string, init: RequestInit) => {
-      sent = { url, headers: init.headers, body: JSON.parse(String(init.body)) };
+      sent = { url, headers: init.headers, body: JSON.parse(String(init.body)), redirect: init.redirect };
       return decision('continue', 'check the tokenizer first');
     }) as never;
 
@@ -2408,6 +2408,7 @@ describe('a custom OpenAI-compatible provider', () => {
 
     expect(view.stage).toBe('ready');
     expect(sent.url).toBe('http://localhost:11434/v1/chat/completions');
+    expect(sent.redirect).toBe('error');
     expect(sent.headers).not.toHaveProperty('authorization');
     expect(sent.headers).not.toHaveProperty('HTTP-Referer');
     expect(sent.headers).not.toHaveProperty('X-Title');
@@ -2438,8 +2439,10 @@ describe('a custom OpenAI-compatible provider', () => {
 
     expect(view.stage).toBe('no-reply');
     expect((sent.headers as Record<string, string>).authorization).toBe('Bearer sk-custom-test');
-    // `exclude` is OpenRouter vocabulary; a custom endpoint gets the effort alone.
-    expect(sent.body.reasoning).toEqual({ effort: 'high' });
+    // `reasoning` is OpenRouter vocabulary; custom OpenAI-compatible endpoints get
+    // the standard top-level effort field instead.
+    expect(sent.body.reasoning_effort).toBe('high');
+    expect(sent.body).not.toHaveProperty('reasoning');
   });
 
   it('fails settled on an invalid base URL instead of retrying forever', async () => {
@@ -2472,8 +2475,9 @@ describe('a custom OpenAI-compatible provider', () => {
 
   it('reads a vanilla OpenAI model list, and an empty one when unreachable', async () => {
     await useCustom();
-    globalThis.fetch = (async (url: string) => {
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
       expect(String(url)).toBe('http://localhost:11434/v1/models');
+      expect(init.redirect).toBe('error');
       return Response.json({ data: [{ id: 'llama3.1' }, { id: 'qwen3:8b', created: 1_700_000_000 }] });
     }) as never;
     const page = await goal.listGoalModels(0, 20);

--- a/test/ipc.test.ts
+++ b/test/ipc.test.ts
@@ -740,6 +740,61 @@ describe('the goal model id', () => {
     expect(reply.ok, reply.error).toBe(true);
     expect(getConfig().goal.model).toBe(defaultConfig().goal.model);
   });
+
+  it('accepts a bare endpoint id while custom and stores the base URL verbatim', async () => {
+    const patch = {
+      ...settings({ record: false, multiAgent: false }),
+      goal: {
+        ...defaultConfig().goal,
+        provider: { kind: 'custom' as const, baseUrl: 'http://localhost:11434/v1/' },
+        model: 'llama3.1'
+      }
+    };
+    const reply = await save(patch);
+    expect(reply.ok, reply.error).toBe(true);
+    expect(getConfig().goal.provider).toEqual({ kind: 'custom', baseUrl: 'http://localhost:11434/v1/' });
+    expect(getConfig().goal.model).toBe('llama3.1');
+  });
+
+  it('still refuses a bare id while on OpenRouter, and an unknown provider kind', async () => {
+    const custom = {
+      ...settings({ record: false, multiAgent: false }),
+      goal: {
+        ...defaultConfig().goal,
+        provider: { kind: 'custom' as const, baseUrl: 'http://localhost:11434/v1' },
+        model: 'llama3.1'
+      }
+    };
+    // Same model, OpenRouter provider: the vendor/model shape still applies.
+    const openrouter = {
+      ...custom,
+      goal: { ...custom.goal, provider: { kind: 'openrouter' as const, baseUrl: '' } }
+    };
+    expect((await save(openrouter)).ok).toBe(false);
+    const unknown = {
+      ...custom,
+      goal: { ...custom.goal, provider: { kind: 'own' as never, baseUrl: '' } }
+    };
+    expect((await save(unknown)).ok).toBe(false);
+  });
+});
+
+describe('the custom provider key slot', () => {
+  const storeSecret = (payload: unknown): Promise<any> =>
+    handlers.get('secret:set')!(null, payload) as Promise<any>;
+
+  it('stores a custom key in its own slot and refuses an unnamed one', async () => {
+    const stored = await storeSecret({ value: 'sk-custom-1', key: 'customProviderApiKey' });
+    expect(stored.ok, stored.error).toBe(true);
+    expect(stored.data.hasCustomProviderKey).toBe(true);
+    // The OpenRouter slot is untouched: naming is exact, never a shared bucket.
+    expect(stored.data.hasGoalKey).toBe(false);
+    const cleared = await storeSecret({ value: '', key: 'customProviderApiKey' });
+    expect(cleared.ok).toBe(true);
+    expect(cleared.data.hasCustomProviderKey).toBe(false);
+    const refused = await storeSecret({ value: 'x', key: 'nobodyDefinedThis' });
+    expect(refused.ok).toBe(false);
+  });
 });
 
 describe('the editable goal system prompt', () => {

--- a/test/ipc.test.ts
+++ b/test/ipc.test.ts
@@ -795,6 +795,39 @@ describe('the custom provider key slot', () => {
     const refused = await storeSecret({ value: 'x', key: 'nobodyDefinedThis' });
     expect(refused.ok).toBe(false);
   });
+
+  it('retires drafts only when the active provider credential changes', async () => {
+    const goal = await import('../src/main/goal.js');
+    const base = defaultConfig();
+    await saveConfig({
+      ...base,
+      goal: {
+        ...base.goal,
+        backend: 'api',
+        provider: { kind: 'custom', baseUrl: 'http://localhost:11434/v1' }
+      }
+    });
+
+    const inactive = goal.startGoalDraft({
+      sessionId: 'inactive-key-session',
+      conversationId: 'inactive-key-chat',
+      turnId: 'inactive-key-turn',
+      deferStart: true
+    });
+    expect((await storeSecret({ value: 'sk-openrouter-unused', key: 'openRouterApiKey' })).ok).toBe(true);
+    expect(goal.beginGoalDraft('inactive-key-chat', inactive.token)).toBe(true);
+
+    goal.resetGoalStateForTests();
+    const active = goal.startGoalDraft({
+      sessionId: 'active-key-session',
+      conversationId: 'active-key-chat',
+      turnId: 'active-key-turn',
+      deferStart: true
+    });
+    expect((await storeSecret({ value: 'sk-custom-active', key: 'customProviderApiKey' })).ok).toBe(true);
+    expect(goal.beginGoalDraft('active-key-chat', active.token)).toBe(false);
+    goal.resetGoalStateForTests();
+  });
 });
 
 describe('the editable goal system prompt', () => {


### PR DESCRIPTION
Lets the api backend run on a user-provided OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, or a gateway) instead of only OpenRouter.

Adds goal.provider {kind: openrouter|custom, baseUrl} (OpenRouter stays the default; old configs parse unchanged) plus a separate customProviderApiKey secret slot. Custom requests omit OpenRouter-only fields and use the OpenAI-compatible top-level reasoning_effort field when configured; keyless local servers send no Authorization header. Invalid base URLs fail settled, and both chat completions and model catalogue requests refuse redirects.

Provider selection is frozen per request: endpoint, model and reasoning remain consistent while the matching provider-kind key is read, so a provider switch cannot send one provider credential to another endpoint. Credential changes retire drafts only for the active provider.

Verification: deterministic provider-switch regression plus Goal and IPC coverage; 160 focused tests pass, along with typecheck and the privacy gate. The full suite passed 2852 tests; its only two failures are existing local-environment assertions (Homebrew rg shadowing the bundled binary, and the development tunnel resource fallback).