### PR TITLE
Honor the selected ChatGPT browser for startup and app launches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,6 +499,11 @@ single-instance lock
   → start non-blocking updater lifetime: immediate pass + unreferenced six-hour recheck schedule
 ```
 
+`ui.chatBrowser` owns the Chrome/Edge choice for OS-originated ChatGPT launches. `browser.ts`
+reads it at launch time and tries only that family's installations; failures propagate to the
+request owner instead of opening the system default browser. The setting does not select a
+profile or override connected-extension delivery/source-tab placement. Legacy configs use Chrome.
+
 The **window activation gate** is a real lifetime boundary, not UI polish. Electron may deliver
 `second-instance` after its own `ready` event while this app is still restoring durable state and
 before CSP/permission/IPC setup is complete. `window-lifecycle.ts` therefore drops/folds early

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ sha256sum Chat-On-Steroids-Linux-x64.AppImage     # Linux
 ## Requirements
 
 - **Windows 10/11**, **macOS 13 Ventura or newer**, or a current desktop **Linux**, on x64 or ARM64 matching the build you downloaded.
-- **Chrome 116 or newer** for the companion extension. Without it you still get the MCP tools, but not session attribution, Compact & Resume, worker chats or the Goal loop.
+- **Chrome 116 or newer**, or a current Microsoft Edge with the companion extension. Without it you still get the MCP tools, but not session attribution, Compact & Resume, worker chats or the Goal loop.
+
+Using Edge? Choose **Settings → Browser & history → ChatGPT browser → Microsoft Edge**. Install the companion and sign in to ChatGPT in that browser's active profile (`edge://extensions` for Edge). This choice controls app-originated launches, including startup model discovery; already connected tabs and source-tab continuations keep their browser. Older configurations retain Chrome. If the selected browser is missing or cannot start, the app reports an error instead of opening a different browser. The setting chooses a browser family, not a particular profile.
 - **Linux:** a Secret Service keyring such as GNOME Keyring or KWallet. The app refuses Electron's unencrypted `basic_text` fallback for stored keys.
 - A ChatGPT workspace with **Developer mode** and custom MCP apps. OpenAI currently documents full MCP support, including write actions, as a beta for Business, Enterprise and Edu, with Pro limited to read and fetch. Business needs an admin to enable it. Check OpenAI's [Developer mode and MCP apps](https://help.openai.com/en/articles/12584461-developer-mode-and-mcp-apps-in-chatgpt) page if your workspace looks different.
 - An **OpenRouter API key** only if you select the API source for plans, Goal or Loop. The default ChatGPT helper source uses your connected browser session.

--- a/src/main/browser.ts
+++ b/src/main/browser.ts
@@ -2,11 +2,15 @@ import { accessSync, constants, existsSync, statSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { launchCommand, runPowerShell } from './exec.js';
+import { getConfig } from './config.js';
+import type { ChatBrowser } from '../shared/types.js';
 
 type Exists = (candidate: string) => boolean;
 type Launch = typeof launchCommand;
 
 export interface PreferredBrowserOpenOptions {
+  /** Defaults to the saved ChatGPT browser choice. */
+  browser?: ChatBrowser;
   /** Start the owned helper without activating its Windows startup window. */
   backgroundStartup?: boolean;
   platform?: NodeJS.Platform;
@@ -31,46 +35,49 @@ function isExecutableBrowser(candidate: string, platform: NodeJS.Platform): bool
 }
 
 /**
- * Browsers which can run the unpacked companion extension, in preference order.
+ * Installations of the selected companion browser, in preference order.
  *
  * Nothing here can choose *which running instance* of that browser the URL reaches: the
  * platform resolves it to the one that last had focus. A chat that must be opened beside
  * another chat is therefore not opened from this module at all — the browser holding the
  * source chat opens it. See `bridge.ts::offerPlacement`.
  *
- * Worker/resume URLs are not ordinary links: the extension must redeem the command marker
- * embedded in them. Sending those URLs to Safari/Firefox merely opens a dead ChatGPT tab, so
- * browser-backed orchestration deliberately prefers the Chrome installation the setup guide
- * tells the user to load the extension into.
+ * Worker/resume URLs require the companion and the user's ChatGPT account. Browser family
+ * is a saved user choice, not inferred from executable availability or the OS URL handler.
+ * Never cross that choice just because another installed browser is easier to launch.
  */
 export function preferredBrowserCandidates(
   platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
-  home = env.HOME ?? env.USERPROFILE ?? os.homedir()
+  home = env.HOME ?? env.USERPROFILE ?? os.homedir(),
+  browser: ChatBrowser = 'chrome'
 ): string[] {
   if (platform === 'win32') {
     const p = path.win32;
-    return [
-      env.LOCALAPPDATA && p.join(env.LOCALAPPDATA, 'Google', 'Chrome', 'Application', 'chrome.exe'),
-      env.ProgramFiles && p.join(env.ProgramFiles, 'Google', 'Chrome', 'Application', 'chrome.exe'),
-      env['ProgramFiles(x86)'] && p.join(env['ProgramFiles(x86)'], 'Google', 'Chrome', 'Application', 'chrome.exe')
-    ].filter((candidate): candidate is string => Boolean(candidate));
+    const parts = browser === 'edge'
+      ? ['Microsoft', 'Edge', 'Application', 'msedge.exe']
+      : ['Google', 'Chrome', 'Application', 'chrome.exe'];
+    return [env.LOCALAPPDATA, env.ProgramFiles, env['ProgramFiles(x86)']]
+      .filter((root): root is string => Boolean(root))
+      .map(root => p.join(root, ...parts));
   }
 
   if (platform === 'darwin') {
-    // Chrome's release channels are separate .app bundles on macOS. A Beta/Dev/Canary-only
-    // install is still a perfectly valid place to load this unpacked Chrome extension, and the
-    // setup UI never requires Stable specifically. If orchestration only knows the Stable bundle,
-    // a worker/resume command falls through to the system default browser (commonly Safari) even
-    // though the compatible Chrome instance is sitting right there with the extension loaded.
-    const chromeChannels = [
+    // Release channels have separate bundles. Keep Beta/Dev/Canary-only installs usable
+    // without crossing the user's chosen browser family.
+    const channels = browser === 'edge' ? [
+      ['Microsoft Edge.app', 'Microsoft Edge'],
+      ['Microsoft Edge Beta.app', 'Microsoft Edge Beta'],
+      ['Microsoft Edge Dev.app', 'Microsoft Edge Dev'],
+      ['Microsoft Edge Canary.app', 'Microsoft Edge Canary']
+    ] : [
       ['Google Chrome.app', 'Google Chrome'],
       ['Google Chrome Beta.app', 'Google Chrome Beta'],
       ['Google Chrome Dev.app', 'Google Chrome Dev'],
       ['Google Chrome Canary.app', 'Google Chrome Canary'],
       ['Chromium.app', 'Chromium']
     ] as const;
-    return chromeChannels.flatMap(([bundle, executable]) => [
+    return channels.flatMap(([bundle, executable]) => [
       path.posix.join('/Applications', bundle, 'Contents', 'MacOS', executable),
       ...(home ? [path.posix.join(home, 'Applications', bundle, 'Contents', 'MacOS', executable)] : [])
     ]);
@@ -78,11 +85,8 @@ export function preferredBrowserCandidates(
 
   if (platform === 'linux') {
     const pathValue = env.PATH ?? '';
-    // Google ships Beta and Dev as separate Linux packages/binaries, just as it ships
-    // separate .app bundles on macOS. A user can legitimately have the companion loaded in
-    // one of those channels with Stable absent, so keep all Chrome channels ahead of the
-    // Chromium fallbacks rather than handing an orchestration marker to the default browser.
-    const names = [
+    // Search release-channel launchers too: the companion need not be installed in Stable.
+    const names = browser === 'edge' ? ['microsoft-edge', 'microsoft-edge-stable', 'microsoft-edge-beta', 'microsoft-edge-dev'] : [
       'google-chrome',
       'google-chrome-stable',
       'google-chrome-beta',
@@ -94,6 +98,11 @@ export function preferredBrowserCandidates(
       .split(':')
       .filter(Boolean)
       .flatMap((dir) => names.map((name) => path.posix.join(dir, name)));
+    if (browser === 'edge') return [...new Set([
+      ...fromPath,
+      ...names.map(name => path.posix.join('/usr/bin', name)),
+      '/opt/microsoft/msedge/msedge', '/opt/microsoft/msedge-beta/msedge', '/opt/microsoft/msedge-dev/msedge'
+    ])];
     // Chrome and Chromium are both widely installed through Flatpak on immutable Linux
     // desktops. Flatpak exports host launchers for installed applications under these
     // `exports/bin` directories (the exported Chrome desktop file uses the same path as
@@ -137,21 +146,22 @@ export function findPreferredBrowser(
 }
 
 /**
- * Opens an orchestration URL in the first Chromium browser that can actually be launched.
+ * Opens an orchestration URL in the saved browser family.
  *
  * Existence/executable checks are intentionally not the arbitration cut. A stale wrapper or a
  * damaged first Chrome install can pass those checks and still fail at spawn time; worker/resume
- * URLs must then try the next compatible Chromium candidate rather than falling straight through
- * to Safari/Firefox via the system default browser.
+ * URLs may try another installation of that family, never the system default or another family.
  */
 export async function openInPreferredBrowser(
   url: string,
   options: PreferredBrowserOpenOptions = {}
-): Promise<string | null> {
+): Promise<string> {
   const platform = options.platform ?? process.platform;
   const env = options.env ?? process.env;
   const usable = options.usable ?? ((candidate: string) => isExecutableBrowser(candidate, platform));
   const launch = options.launch ?? launchCommand;
+  const selected = options.browser ?? getConfig().ui.chatBrowser ?? 'chrome';
+  const label = selected === 'edge' ? 'Microsoft Edge' : 'Google Chrome / Chromium';
   // These switches only affect a newly started Chrome process; handing a URL to an
   // existing instance cannot change its policy. Memory Saver exclusions alone do not
   // prevent background timer/renderer throttling of long-running orchestration tabs.
@@ -162,7 +172,7 @@ export async function openInPreferredBrowser(
   ];
   let lastError: unknown = null;
 
-  for (const browser of preferredBrowserCandidates(platform, env, options.home)) {
+  for (const browser of new Set(preferredBrowserCandidates(platform, env, options.home, selected))) {
     if (!usable(browser)) continue;
     try {
       // A windowless Chrome exits once extensions load unless the profile has a
@@ -189,6 +199,6 @@ export async function openInPreferredBrowser(
     }
   }
 
-  if (lastError) throw lastError;
-  return null;
+  if (lastError) throw new Error(`${label} could not start: ${(lastError as Error).message}. Check Settings > Browser & history > ChatGPT browser.`);
+  throw new Error(`${label} was not found. Install it or change Settings > Browser & history > ChatGPT browser.`);
 }

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { z } from 'zod';
 import {
   CAPABILITIES,
+  CHAT_BROWSERS,
   DEFAULT_CAPABILITIES,
   GOAL_MODES,
   GOAL_REASONING_LEVELS,
@@ -258,6 +259,7 @@ const configSchema = z.object({
     binaryPath: z.string().max(4096)
   }),
   ui: z.object({
+    chatBrowser: z.enum(CHAT_BROWSERS).optional().default('chrome'),
     developerMode: z.boolean().optional(),
     finishTool: z.boolean().optional(),
     planBackend: z.enum(['chatgpt', 'api']).optional(),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,7 +4,7 @@ import { requestSessionFinishGoal, setFinishNotifier } from './session/finish.js
  */
 
 import path from 'node:path';
-import { app, Notification, BrowserWindow, Menu, Tray, nativeImage, nativeTheme, screen, session, shell } from 'electron';
+import { app, Notification, BrowserWindow, Menu, Tray, nativeImage, nativeTheme, screen, session } from 'electron';
 import { getConfig, initConfigPath, loadConfig } from './config.js';
 import { connect, disconnect, getStatus, onStatusChange, shutdownConnection } from './connection.js';
 import { registerIpc } from './ipc.js';
@@ -319,17 +319,8 @@ void app.whenReady().then(async () => {
   // a browser without this extension in it — from the one holding chat A. That decision belongs
   // to the browser that owns the source chat; see bridge.ts::offerPlacement.
   setBrowserOpener(async (url) => {
-    try {
-      const browser = await openInPreferredBrowser(url);
-      if (browser) return;
-    } catch (error) {
-      logWarn(`could not open ChatGPT in the preferred Chromium browser: ${(error as Error).message}`);
-    }
-    logWarn(
-      'Chrome/Chromium was not found for a browser-backed worker/resume command; falling back to the default browser. ' +
-        'If that browser does not have the Chat On Steroids extension loaded, open the generated ChatGPT URL in Chrome instead.'
-    );
-    await shell.openExternal(url);
+    // Let the command owner report launch failure; another browser may belong to another account.
+    await openInPreferredBrowser(url);
   });
 
   // Persistence is a process-lifetime dependency of the broker, not a feature-toggle

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -28,6 +28,7 @@ import { app, BrowserWindow, clipboard, dialog, ipcMain, nativeTheme, shell } fr
 import { z } from 'zod';
 import {
   CAPABILITIES,
+  CHAT_BROWSERS,
   GOAL_MODES,
   GOAL_REASONING_LEVELS,
   RELEASES_PAGE,
@@ -139,6 +140,7 @@ const settingsPatch = z.object({
     binaryPath: z.string().max(4096)
   }),
   ui: z.object({
+    chatBrowser: z.enum(CHAT_BROWSERS).optional(),
     developerMode: z.boolean().optional(),
     finishTool: z.boolean().optional(),
     planBackend: z.enum(['chatgpt', 'api']).optional(),
@@ -237,6 +239,7 @@ function mergeSettings(current: Config, base: SettingsSnapshot, wanted: Settings
       binaryPath: pick(current.tunnel.binaryPath, base.tunnel.binaryPath, wanted.tunnel.binaryPath)
     },
     ui: {
+      chatBrowser: pick(current.ui.chatBrowser, base.ui.chatBrowser, wanted.ui.chatBrowser),
       developerMode: pick(current.ui.developerMode, base.ui.developerMode, wanted.ui.developerMode),
       finishTool: pick(current.ui.finishTool, base.ui.finishTool, wanted.ui.finishTool),
       planBackend: pick(current.ui.planBackend, base.ui.planBackend, wanted.ui.planBackend),
@@ -806,8 +809,7 @@ export function registerIpc(getWindow: () => BrowserWindow | null, quitToInstall
     if (!conversationId || !/^[0-9a-z-]{8,64}$/i.test(conversationId)) {
       throw new Error('This session has no valid ChatGPT conversation');
     }
-    const browser = await openInPreferredBrowser(chatUrl(conversationId));
-    if (!browser) throw new Error('Chrome or Chromium was not found');
+    await openInPreferredBrowser(chatUrl(conversationId));
     return true;
   });
 

--- a/src/main/session/start-input.ts
+++ b/src/main/session/start-input.ts
@@ -5,7 +5,7 @@ import { openInPreferredBrowser } from '../browser.js';
 import { getConfig } from '../config.js';
 import { enqueueInput, cancelInput, listInputs, noteInputStartupError, type InputArgs, type InputEntry } from './input.js';
 
-let waking: { lastSeenAt: number | null; work: Promise<void>; failed: boolean } | null = null;
+let waking: { lastSeenAt: number | null; selected: string; work: Promise<void>; failed: boolean } | null = null;
 /** One browser startup per absence episode, shared by authored sends and read-only discovery. */
 export async function wakeBrowserUrl(url: string, retry = false, backgroundStartup = false): Promise<void> {
   const browser = await bridgeStatus();
@@ -14,14 +14,14 @@ export async function wakeBrowserUrl(url: string, retry = false, backgroundStart
   // Only an authenticated live transport can receive this newly published work.
   if (browserWakeConnected()) { waking = null; return; }
   if (retry && waking?.failed) waking = null;
+  const selected = getConfig().ui.chatBrowser ?? 'chrome';
   // Until the extension registers, another explicit send belongs to the same startup.
-  // Its outbox entry will be discovered by normal maintenance once Chrome is ready.
-  if (waking?.lastSeenAt === browser.lastSeenAt) return waking.work;
+  // Changing the saved browser ends that attempt's authority over subsequent launches.
+  if (waking?.lastSeenAt === browser.lastSeenAt && waking.selected === selected) return waking.work;
   const work = (async () => {
-    const opened = await (backgroundStartup ? openInPreferredBrowser(url, { backgroundStartup: true }) : openInPreferredBrowser(url));
-    if (!opened) throw new Error('Chrome or Chromium was not found');
+    await (backgroundStartup ? openInPreferredBrowser(url, { backgroundStartup: true }) : openInPreferredBrowser(url));
   })();
-  const attempt = { lastSeenAt: browser.lastSeenAt, work, failed: false };
+  const attempt = { lastSeenAt: browser.lastSeenAt, selected, work, failed: false };
   waking = attempt;
   try { await work; } catch (error) { attempt.failed = true; throw error; }
 }

--- a/src/renderer/chat.ts
+++ b/src/renderer/chat.ts
@@ -2459,6 +2459,7 @@ function applyAutoCompactHint(config: Config): void {
  * every other switch that decides what ChatGPT can reach, and saves from there.
  */
 const CHAT_INPUTS = [
+  'chatBrowser',
   'goalIncludeToolCalls',
   'planBackend',
   'finishTool', 'finishAction', 'finishLeadMinutes', 'workerModel', 'workerReasoning', 'backgroundChats',

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -600,6 +600,7 @@
                   </div>
                 <h2 class="settings-section-title">Browser & history</h2>
                 <div class="pane">
+                  <label class="setting"><span class="setting-text"><b>ChatGPT browser</b><em>Used when the app launches a browser. Install the companion and sign in to ChatGPT in this browser's active profile. Already connected tabs stay in their browser.</em></span><select id="chatBrowser"><option value="chrome">Google Chrome / Chromium</option><option value="edge">Microsoft Edge</option></select></label>
                   <label class="setting"><span class="setting-text"><b>Background chats</b><em>Keep app-created ChatGPT tabs in the background.</em></span><input id="backgroundChats" type="checkbox" /></label>
                   <p class="muted">Keeps as many app chat tabs as your worker limit. Above that, the longest-idle chats close after one minute without work. Active turns and unsent drafts stay open.</p>
                   <label class="setting"><span class="setting-text"><b>Overwrite ChatGPT tool rows</b><em>Show recorded local activity in the ChatGPT page.</em></span><input id="browserOverwrite" type="checkbox" disabled /></label>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -16,7 +16,7 @@ import { initBrowserPreferences } from './browser-preferences.js';
 
 import type { AppApi, SettingsPatch } from '../preload/index.js';
 import { requiresApprovedFilesystemRoot } from '../shared/capabilities.js';
-import type { AppState, Capability, LogEntry, SurfaceStatus } from '../shared/types.js';
+import type { AppState, Capability, ChatBrowser, LogEntry, SurfaceStatus } from '../shared/types.js';
 import {
   browserExtensionRequired,
   isNewer,
@@ -442,6 +442,7 @@ function save(over: { readOnly?: boolean; theme?: 'light' | 'dark' } = {}): Prom
       binaryPath: $<HTMLInputElement>('binaryPath').value.trim()
     },
     ui: {
+      chatBrowser: $<HTMLSelectElement>('chatBrowser').value as ChatBrowser,
       finishTool: $<HTMLInputElement>('finishTool').checked,
       planBackend: $<HTMLSelectElement>('planBackend').value as 'chatgpt' | 'api',
       finishAction: $<HTMLSelectElement>('finishAction').value as 'notify' | 'goal',
@@ -927,6 +928,7 @@ function apply(next: AppState): void {
   applyValue($<HTMLSelectElement>('finishAction'), config.ui.finishAction ?? 'notify', previousState?.config.ui.finishAction);
   applyValue($<HTMLSelectElement>('finishLeadMinutes'), String(config.ui.finishLeadMinutes ?? 5), String(previousState?.config.ui.finishLeadMinutes ?? 5));
   applyChecked($<HTMLInputElement>('backgroundChats'), config.ui.backgroundChats === true, previousState?.config.ui.backgroundChats);
+  applyValue($<HTMLSelectElement>('chatBrowser'), config.ui.chatBrowser ?? 'chrome', previousState?.config.ui.chatBrowser ?? 'chrome');
   applyChecked($<HTMLInputElement>('autoConnect'), config.ui.autoConnect, previousState?.config.ui.autoConnect);
   applyChecked($<HTMLInputElement>('developerMode'), config.ui.developerMode === true, previousState?.config.ui.developerMode);
   applyChecked(

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -923,12 +923,12 @@ function apply(next: AppState): void {
     previousState?.config.tunnel.desktopTunnelId
   );
   applyValue($<HTMLInputElement>('binaryPath'), config.tunnel.binaryPath, previousState?.config.tunnel.binaryPath);
+  applyValue($<HTMLSelectElement>('chatBrowser'), config.ui.chatBrowser ?? 'chrome', previousState?.config.ui.chatBrowser ?? 'chrome');
   $<HTMLSelectElement>('planBackend').value = config.ui.planBackend ?? 'chatgpt';
   applyChecked($<HTMLInputElement>('finishTool'), config.ui.finishTool === true, previousState?.config.ui.finishTool);
   applyValue($<HTMLSelectElement>('finishAction'), config.ui.finishAction ?? 'notify', previousState?.config.ui.finishAction);
   applyValue($<HTMLSelectElement>('finishLeadMinutes'), String(config.ui.finishLeadMinutes ?? 5), String(previousState?.config.ui.finishLeadMinutes ?? 5));
   applyChecked($<HTMLInputElement>('backgroundChats'), config.ui.backgroundChats === true, previousState?.config.ui.backgroundChats);
-  applyValue($<HTMLSelectElement>('chatBrowser'), config.ui.chatBrowser ?? 'chrome', previousState?.config.ui.chatBrowser ?? 'chrome');
   applyChecked($<HTMLInputElement>('autoConnect'), config.ui.autoConnect, previousState?.config.ui.autoConnect);
   applyChecked($<HTMLInputElement>('developerMode'), config.ui.developerMode === true, previousState?.config.ui.developerMode);
   applyChecked(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -120,8 +120,6 @@ export const CHAT_BROWSERS = ['chrome', 'edge'] as const;
 export type ChatBrowser = (typeof CHAT_BROWSERS)[number];
 
 export interface UiPrefs {
-  /** Browser for app-originated launches; connected source tabs retain placement ownership. */
-  chatBrowser?: ChatBrowser;
   backgroundChats?: boolean;
   /** Actual app-owned tabs to retain; active work and drafts stay protected. Omitted uses workers + 2. */
   tabsToKeepOpen?: number;
@@ -134,6 +132,8 @@ export interface UiPrefs {
   autoConnect: boolean;
   /** Default screenshots to the active window instead of the whole primary monitor. */
   privacyScreenshots: boolean;
+  /** Browser for app-originated launches; connected source tabs retain placement ownership. */
+  chatBrowser?: ChatBrowser;
   /** Explicit choice, never inherited from the OS: the window looks how you left it. */
   theme: 'light' | 'dark';
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -116,7 +116,12 @@ export interface TunnelSettings {
   binaryPath: string;
 }
 
+export const CHAT_BROWSERS = ['chrome', 'edge'] as const;
+export type ChatBrowser = (typeof CHAT_BROWSERS)[number];
+
 export interface UiPrefs {
+  /** Browser for app-originated launches; connected source tabs retain placement ownership. */
+  chatBrowser?: ChatBrowser;
   backgroundChats?: boolean;
   /** Actual app-owned tabs to retain; active work and drafts stay protected. Omitted uses workers + 2. */
   tabsToKeepOpen?: number;

--- a/test/browser-selection.test.ts
+++ b/test/browser-selection.test.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { afterAll, beforeAll, expect, it, vi } from 'vitest';
+import { defaultConfig, initConfigPath, loadConfig, saveConfig } from '../src/main/config.js';
+import { openInPreferredBrowser, preferredBrowserCandidates } from '../src/main/browser.js';
+import { makeTempDir, removeTempDir } from './helpers.js';
+
+let dir: string;
+beforeAll(async () => { dir = await makeTempDir('clf-browser-choice-'); initConfigPath(dir); });
+afterAll(async () => { await removeTempDir(dir); });
+
+it('uses the persisted Edge choice for cold minimized discovery without an option override', async () => {
+  const config = defaultConfig();
+  await saveConfig({ ...config, ui: { ...config.ui, chatBrowser: 'edge' } });
+  expect((await loadConfig()).ui.chatBrowser).toBe('edge');
+  const edge = 'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe';
+  const powershell = vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0, timedOut: false, truncated: false, durationMs: 1 }));
+  const launch = vi.fn();
+  const opened = await openInPreferredBrowser('https://chatgpt.com/?cos-model-catalog=owned', {
+    platform: 'win32', env: { 'ProgramFiles(x86)': 'C:\\Program Files (x86)' },
+    backgroundStartup: true, usable: () => true, powershell, launch
+  });
+  expect(opened).toBe(edge);
+  expect(powershell).toHaveBeenCalledWith(expect.stringContaining(`-FilePath '${edge}'`), path.win32.dirname(edge), 10_000);
+  expect(powershell).toHaveBeenCalledWith(expect.stringContaining('-WindowStyle Minimized'), expect.any(String), 10_000);
+  expect(launch).not.toHaveBeenCalled();
+});
+
+it('migrates a config without a browser choice to Chrome without losing its other settings', async () => {
+  const old = defaultConfig();
+  delete old.ui.chatBrowser;
+  old.ui.autoConnect = true;
+  await fs.writeFile(path.join(dir, 'config.json'), JSON.stringify(old));
+  expect((await loadConfig()).ui).toMatchObject({ chatBrowser: 'chrome', autoConnect: true });
+});
+
+it('finds Edge installations on each platform without mixing in Chrome', () => {
+  expect(preferredBrowserCandidates('win32', { LOCALAPPDATA: 'C:\\Local', ProgramFiles: 'C:\\Apps', 'ProgramFiles(x86)': 'C:\\Apps86' }, undefined, 'edge'))
+    .toEqual(['C:\\Local\\Microsoft\\Edge\\Application\\msedge.exe', 'C:\\Apps\\Microsoft\\Edge\\Application\\msedge.exe', 'C:\\Apps86\\Microsoft\\Edge\\Application\\msedge.exe']);
+  const mac = preferredBrowserCandidates('darwin', {}, '/Users/example', 'edge');
+  expect(mac).toContain('/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge');
+  expect(mac).toContain('/Users/example/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge');
+  expect(mac.every(candidate => candidate.includes('Microsoft Edge'))).toBe(true);
+  const linux = preferredBrowserCandidates('linux', { PATH: '/custom/bin:/usr/bin' }, '/home/example', 'edge');
+  expect(linux).toContain('/custom/bin/microsoft-edge');
+  expect(linux).toContain('/usr/bin/microsoft-edge-stable');
+  expect(linux.every(candidate => !/chrome|chromium/.test(candidate))).toBe(true);
+});

--- a/test/browser-startup.test.ts
+++ b/test/browser-startup.test.ts
@@ -1,11 +1,25 @@
 import { beforeEach, expect, it, vi } from 'vitest';
 const browser = vi.hoisted(() => ({ connected: false, present: false, lastSeenAt: null as number | null }));
-const open = vi.hoisted(() => vi.fn(async (_url: string): Promise<string | null> => 'chrome'));
+const config = vi.hoisted(() => ({ ui: { chatBrowser: 'chrome' } }));
+vi.mock('../src/main/config.js', () => ({ getConfig: () => config }));
+const open = vi.hoisted(() => vi.fn(async (_url: string): Promise<string> => 'chrome'));
 vi.mock('../src/main/bridge.js', () => ({ bridgeStatus: async () => ({ ...browser }), browserWakeConnected: () => browser.connected, startBridge: async () => true }));
 vi.mock('../src/main/browser.js', () => ({ openInPreferredBrowser: open }));
 vi.mock('../src/main/connection.js', () => ({ connect: vi.fn(), getStatus: vi.fn(), onStatusChange: vi.fn() }));
 import { resetInputStartupForTests, wakeBrowserUrl } from '../src/main/session/start-input.js';
-beforeEach(() => { resetInputStartupForTests(); browser.connected = false; browser.present = false; browser.lastSeenAt = null; open.mockReset().mockResolvedValue('chrome'); });
+beforeEach(() => { resetInputStartupForTests(); config.ui.chatBrowser = 'chrome'; browser.connected = false; browser.present = false; browser.lastSeenAt = null; open.mockReset().mockResolvedValue('chrome'); });
+
+it('allows the newly selected browser to start without reusing the previous browser attempt', async () => {
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=old');
+  config.ui.chatBrowser = 'edge';
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=new');
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=repeat');
+  expect(open).toHaveBeenCalledTimes(2);
+  browser.connected = true;
+  config.ui.chatBrowser = 'chrome';
+  await wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=connected');
+  expect(open).toHaveBeenCalledTimes(2);
+});
 
 it('shares one successful absence episode across input and discovery retries', async () => {
   await Promise.all([wakeBrowserUrl('https://chatgpt.com/?cos-input=one'), wakeBrowserUrl('https://chatgpt.com/?cos-model-catalog=two', true)]);
@@ -18,7 +32,7 @@ it('shares one successful absence episode across input and discovery retries', a
   expect(open).toHaveBeenCalledTimes(2);
 });
 it('retries a rejected launch only after explicit retry and keeps successful retry shared', async () => {
-  open.mockResolvedValueOnce(null);
+  open.mockRejectedValueOnce(new Error('Microsoft Edge was not found'));
   await expect(wakeBrowserUrl('https://chatgpt.com/')).rejects.toThrow(/not found/);
   await expect(wakeBrowserUrl('https://chatgpt.com/')).rejects.toThrow(/not found/);
   expect(open).toHaveBeenCalledTimes(1);

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -5,6 +5,39 @@ import { findPreferredBrowser, openInPreferredBrowser, preferredBrowserCandidate
 import { runPowerShell } from '../src/main/exec.js';
 
 describe('browser-backed ChatGPT commands', () => {
+  it('launches selected Edge when Chrome is also installed', async () => {
+    const edge = 'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe';
+    const chrome = 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe';
+    const launch = vi.fn(async () => ({ pid: 123 }));
+    const url = 'https://chatgpt.com/?cos-model-catalog=selected';
+    const opened = await openInPreferredBrowser(url, {
+      browser: 'edge', platform: 'win32',
+      env: { ProgramFiles: 'C:\\Program Files', 'ProgramFiles(x86)': 'C:\\Program Files (x86)' },
+      usable: candidate => candidate === edge || candidate === chrome, launch
+    });
+    expect(opened).toBe(edge);
+    expect(launch).toHaveBeenCalledExactlyOnceWith(edge,
+      ['--disable-renderer-backgrounding', '--disable-background-timer-throttling', url], path.win32.dirname(edge));
+  });
+
+  it('does not open Chrome when selected Edge is absent', async () => {
+    const launch = vi.fn(async () => ({ pid: 123 }));
+    await expect(openInPreferredBrowser('https://chatgpt.com/', {
+      browser: 'edge', platform: 'win32', env: { ProgramFiles: 'C:\\Program Files' },
+      usable: candidate => candidate.endsWith('chrome.exe'), launch
+    })).rejects.toThrow(/Microsoft Edge.*not found/);
+    expect(launch).not.toHaveBeenCalled();
+  });
+
+  it('reports selected Edge launch failure without switching browser families', async () => {
+    const launch = vi.fn(async () => { throw new Error('cannot start'); });
+    await expect(openInPreferredBrowser('https://chatgpt.com/', {
+      browser: 'edge', platform: 'win32', env: { ProgramFiles: 'C:\\Program Files' },
+      usable: () => true, launch
+    })).rejects.toThrow(/Microsoft Edge.*cannot start/);
+    expect(launch.mock.calls).toHaveLength(1);
+  });
+
   it('cold background startup gives Chrome one owned tab in a minimized startup window', async () => {
     const calls: string[] = [];
     const launch = vi.fn();

--- a/test/ipc.test.ts
+++ b/test/ipc.test.ts
@@ -483,6 +483,19 @@ describe('bounded IPC identities and OS launch results', () => {
 });
 
 describe('settings writes from more than one UI', () => {
+  it('persists Edge and keeps it through an unrelated stale renderer save', async () => {
+    const base = defaultConfig();
+    await saveConfig(base);
+    const result = await save({ ...base, ui: { ...base.ui, chatBrowser: 'edge' } }, base);
+    expect(result.ok, result.error).toBe(true);
+    expect(JSON.parse(await fs.readFile(path.join(dir, 'config.json'), 'utf8')).ui.chatBrowser).toBe('edge');
+    const stale = await save({ ...base, ui: { ...base.ui, theme: 'light' } }, base);
+    expect(stale.ok, stale.error).toBe(true);
+    expect(getConfig().ui).toMatchObject({ chatBrowser: 'edge', theme: 'light' });
+    const current = getConfig();
+    expect((await save({ ...current, ui: { ...current.ui, chatBrowser: 'unsupported' } }, current)).ok).toBe(false);
+    expect(getConfig().ui.chatBrowser).toBe('edge');
+  });
   it('saves helper settings and tab retention through the renderer schema and merge boundary', async () => {
     const base = defaultConfig();
     await saveConfig(base);

--- a/test/ipc.test.ts
+++ b/test/ipc.test.ts
@@ -482,7 +482,7 @@ describe('bounded IPC identities and OS launch results', () => {
   });
 });
 
-describe('settings writes from more than one UI', () => {
+describe('ChatGPT browser settings', () => {
   it('persists Edge and keeps it through an unrelated stale renderer save', async () => {
     const base = defaultConfig();
     await saveConfig(base);
@@ -496,6 +496,9 @@ describe('settings writes from more than one UI', () => {
     expect((await save({ ...current, ui: { ...current.ui, chatBrowser: 'unsupported' } }, current)).ok).toBe(false);
     expect(getConfig().ui.chatBrowser).toBe('edge');
   });
+});
+
+describe('settings writes from more than one UI', () => {
   it('saves helper settings and tab retention through the renderer schema and merge boundary', async () => {
     const base = defaultConfig();
     await saveConfig(base);

--- a/test/renderer-state.test.ts
+++ b/test/renderer-state.test.ts
@@ -420,6 +420,20 @@ async function mountChat(
 
 const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
 
+it('saves the ChatGPT browser choice from its settings control and restores it on state push', async () => {
+  const mounted = await mountChat();
+  const w = mounted.window;
+  const browser = w.document.getElementById('chatBrowser') as HTMLSelectElement;
+  expect(browser.value).toBe('chrome'); // older config has no field
+  browser.value = 'edge';
+  browser.dispatchEvent(new w.Event('change', { bubbles: true }));
+  await vi.waitFor(() => expect(mounted.calls).toHaveLength(1));
+  expect(mounted.calls[0].ui.chatBrowser).toBe('edge');
+  expect(browser.value).toBe('edge');
+  mounted.push({ ...mounted.state, config: { ...mounted.state.config, ui: { ...mounted.state.config.ui, chatBrowser: 'chrome' } } });
+  expect(browser.value).toBe('chrome');
+});
+
 it('preserves native Desktop permissions when saving unrelated settings on Linux', async () => {
   const mounted = await mountChat({
     platform: { family: 'linux', name: 'Linux', desktopAutomation: false }


### PR DESCRIPTION
Starting the app could open Chrome for an Edge user because cold model discovery and other app-originated ChatGPT launches only searched for Chrome. Add a persisted **Settings → Browser & history → ChatGPT browser** choice and make the shared opener honor it. Selecting Edge now uses Edge installations; missing or failed launches report the selected browser instead of switching to the OS default or another family.

The same choice applies to discovery, desktop input, recorded-chat opening and OS worker/resume launches. A changed choice invalidates the previous disconnected startup attempt. Existing connected-extension delivery and source-tab placement keep their current ownership. Older configurations retain Chrome; install the companion and sign in in the chosen browser's active profile. This selects a browser family, not a profile, and does not automatically migrate browser sessions.

Fixes #99.

### Validation

- Three targeted regressions failed on the previous opener (Edge and Chrome both installed, missing selected Edge, selected Edge launch failure) and pass with this change.
- Configuration reload, stale IPC save, renderer selection, minimized startup, browser-choice changes and connected-extension suppression are covered.
- Final `npm run verify` passed with `VITEST_MAX_WORKERS=4`: 2,930 ordinary tests plus 2 isolated shutdown tests passed; 23 skipped. TypeScript and the public-history privacy gate passed. The session-store suite also passed independently (126 tests) after an earlier high-concurrency run was interrupted for slow progress.
- `npm run build` passed.
- Launch tests intercept process creation; live ChatGPT account/extension validation and native Edge startup on macOS/Linux were not performed.

### Compatibility with open PRs

Checked all 18 open PR heads against main `0f3ec753` and this branch using `git merge-tree --write-tree` on 2026-09-07.

- Clean merges: #95, #94, #93, #92, #91, #88, #87, #86, #78, #43, #39.
- #68, #62, #47, #18, #17, #16 and #15 already conflict with main; combining this fix introduced no additional conflicted files in those checks.
- Also materialized the combined tree with #91 at `ce8cb60a`: TypeScript and 124 tests across 9 browser/startup/model/IPC/renderer suites passed. Its HTTP-presence suppression, Browser only setting and other lifecycle changes remain intact.