### PR TITLE
fix: make companion version mismatch recovery actionable

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The MCP connector uses ChatGPT's documented Developer mode and Secure MCP Tunnel
 
 - **Tools missing or stale after a permission change:** tool-schema changes schedule a connector refresh after a 20-second debounce. If it fails, refresh the custom app in ChatGPT; this is separate from reloading the companion extension.
 - **Extension says app not found:** recording or multi-agent mode must be on for the bridge to run. Then reopen the popup.
-- **Extension version mismatch:** reload the unpacked extension after every app update.
+- **Extension version mismatch:** the popup shows both app and extension versions/protocols. After updating the app, click **Reload companion**, or open your browser's Extensions page, enable **Developer mode**, and click **Update / Reload**. If the mismatch remains, use **Open extension folder** in the app and load that folder. Reopen the popup to verify the connection; **Looking for the app** is not a successful handshake.
 - **`agents` says `UNIDENTIFIED_CALLER`:** use that conversation in the paired browser so the extension can observe its request id. The app will not guess identity from the active tab.
 - **`COMPACTION_IN_PROGRESS` in a chat:** that chat is being handed off. Let it write the brief; work continues in the replacement.
 - **OS warning about an unverified app:** expected for the unsigned beta. Verify `SHA256SUMS.txt` before overriding.

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -27,7 +27,8 @@
         <h1>Chat On Steroids</h1>
       </header>
 
-      <p class="pill" id="pill"><span class="dot"></span><span id="state">Looking for the app</span></p>
+      <p class="pill off" id="pill"><span class="dot"></span><span id="state">Looking for the app</span></p>
+      <p class="alert" id="alert" hidden></p>
       <div class="actions reload-action">
         <button id="reloadBtn" type="button" aria-describedby="reloadStatus">Reload companion</button>
       </div>
@@ -76,8 +77,6 @@
         </div>
       </details>
     </section>
-
-    <p class="alert" id="alert" hidden></p>
 
     <p class="caption">Augment ChatGPT</p>
     <section class="card">

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -112,7 +112,7 @@ function pipeline(info, ready) {
       read: readStage,
       sent: ['failed', pending ? `${pending} held` : ''],
       proc: ['off'],
-      why: ['bad', 'The app is not reachable. Nothing is leaving this browser.']
+      why: ['bad', 'Delivery is blocked. Check the app connection or version warning above.']
     };
   }
   if (sent && sent.ok === false) {
@@ -223,7 +223,8 @@ function paintHeader(status) {
   // connection that has not finished yet, which is what it looked like back when the next
   // poll would silently undo it.
   const off = status && status.disconnected === true && !paired;
-  const ready = connected && paired && !incompatible;
+  // An unknown compatibility result is not a successful handshake.
+  const ready = connected && paired && status.compatible === true;
 
   $('pill').className = `pill ${ready ? '' : incompatible ? 'bad' : 'off'}`;
   $('state').textContent = incompatible
@@ -248,7 +249,12 @@ function paintAlert(status, info) {
   const pairError = status && status.pairError;
   const error = page && page.lastError;
   const text = incompatible
-    ? 'The app and this extension speak different bridge protocols.'
+    ? `App v${status.appVersion || '?'} (protocol ${status.appProtocol ?? '?'}) · ` +
+      `extension v${status.extensionVersion || '?'} (protocol ${status.extensionProtocol ?? '?'}). ` +
+      'These bridge protocols are incompatible. After updating the app, click Reload companion, ' +
+      'or open your browser’s Extensions page → Developer mode → Update / Reload. ' +
+      'If the mismatch remains, use Open extension folder in the app and load that folder. ' +
+      'Reopen this popup to verify the connection.'
     : pairError && pairError.message
       ? pairError.message
       : pairError && pairError.error === 'secure_storage_unavailable'

--- a/test/extension-popup.test.ts
+++ b/test/extension-popup.test.ts
@@ -7,11 +7,11 @@ const script = await readFile(new URL('../extension/popup.js', import.meta.url),
 let popup: JSDOM | undefined;
 afterEach(() => { popup?.window.close(); });
 
-function openPopup(reload: () => void) {
+function openPopup(reload: () => void, sendMessage?: (message: { type: string }) => Promise<unknown>) {
   popup = new JSDOM(html, { url: 'https://extension-popup.test/', runScripts: 'outside-only' });
   const unavailable = () => new Promise(() => undefined);
   Object.assign(popup.window, {
-    chrome: { runtime: { reload, sendMessage: unavailable }, storage: { local: { get: unavailable } } },
+    chrome: { runtime: { reload, sendMessage: sendMessage ?? unavailable }, storage: { local: { get: unavailable } } },
     setInterval: () => 0
   });
   popup.window.eval(script);
@@ -38,4 +38,72 @@ it('reports a synchronous Chrome reload failure and allows another explicit atte
   expect(document.getElementById('reloadStatus')?.textContent).toContain('Extension context invalidated');
   button.click();
   expect(reload).toHaveBeenCalledTimes(2);
+});
+
+const mismatch = {
+  connected: true, paired: true, compatible: false, port: 8765,
+  appVersion: '2.0.6', appProtocol: 12, extensionVersion: '2.0.2', extensionProtocol: 8
+};
+const capturedTab = {
+  isChat: true, recorder: true, pending: 28,
+  page: { events: 29, calls: 0, trace: [] }
+};
+
+it('keeps the initial popup neutral until the worker answers', () => {
+  const document = openPopup(vi.fn());
+  expect(document.getElementById('pill')?.classList.contains('off')).toBe(true);
+  expect(document.getElementById('state')?.textContent).toBe('Looking for the app');
+});
+
+it('shows both versions, protocols and manual recovery beside the existing reload action', async () => {
+  const reload = vi.fn();
+  const document = openPopup(reload, async ({ type }) => type === 'status' ? mismatch : capturedTab);
+  await popup!.window.eval('refresh()');
+  const alert = document.getElementById('alert')!;
+  expect(alert.hidden).toBe(false);
+  expect(alert.textContent).toContain('App v2.0.6 (protocol 12)');
+  expect(alert.textContent).toContain('extension v2.0.2 (protocol 8)');
+  expect(alert.textContent).toContain('Reload companion');
+  expect(alert.textContent).toContain('Extensions');
+  expect(alert.textContent).toContain('Developer mode');
+  expect(alert.textContent).toContain('Update');
+  expect(alert.textContent).toContain('Open extension folder');
+  expect(alert.closest('details')).toBeNull();
+  expect(alert.compareDocumentPosition(document.getElementById('reloadBtn')!) & 4).toBe(4);
+  expect(document.getElementById('why')?.textContent).not.toContain('not reachable');
+  expect(document.getElementById('n-sent')?.textContent).toBe('28 held');
+  expect(reload).not.toHaveBeenCalled();
+});
+
+it('does not report recovery until a compatible, paired connection is confirmed', async () => {
+  let status: Record<string, unknown> = mismatch;
+  const document = openPopup(vi.fn(), async ({ type }) => type === 'status' ? status : null);
+  await popup!.window.eval('refresh()');
+  expect(document.getElementById('state')?.textContent).toBe('Version mismatch');
+
+  // Equal release versions alone are not evidence of protocol compatibility.
+  status = { ...mismatch, extensionVersion: '2.0.6', compatible: null };
+  await popup!.window.eval('refresh()');
+  expect(document.getElementById('pill')?.classList.contains('off')).toBe(true);
+  expect(document.getElementById('state')?.textContent).not.toContain('Connected');
+
+  status = { ...status, compatible: true, paired: false };
+  await popup!.window.eval('refresh()');
+  expect(document.getElementById('state')?.textContent).not.toContain('Connected');
+
+  status = { ...status, paired: true, extensionProtocol: 12 };
+  await popup!.window.eval('refresh()');
+  expect(document.getElementById('state')?.textContent).toBe('Connected · Port 8765');
+  expect(document.getElementById('alert')?.hidden).toBe(true);
+  expect(document.getElementById('r-app')?.className).toBe('row off');
+});
+
+it('does not turn missing version metadata into a guessed version or HTML', async () => {
+  const status = { ...mismatch, appVersion: null, appProtocol: null, extensionVersion: '<b>test</b>' };
+  const document = openPopup(vi.fn(), async ({ type }) => type === 'status' ? status : null);
+  await popup!.window.eval('refresh()');
+  const alert = document.getElementById('alert')!;
+  expect(alert.textContent).toContain('App v? (protocol ?)');
+  expect(alert.textContent).toContain('extension v<b>test</b> (protocol 8)');
+  expect(alert.querySelector('b')).toBeNull();
 });


### PR DESCRIPTION
Refs #31, specifically the extension upgrade/recovery follow-up.

## What changed

After an app update, the files in the stable extension folder can be current while the browser still runs the previous companion. The popup then says only that the protocols differ; the versions are under Advanced, and the delivery drawer misleadingly describes the app as unreachable.

Current main already has a direct **Reload companion** action. This PR reuses it:

- Show both app/extension versions and protocols, followed by the manual recovery steps, next to that action and above Session capture.
- Explain the browser **Extensions → Developer mode → Update / Reload** fallback and the **Open extension folder** path if the mismatch remains.
- Start **Looking for the app** in a neutral color. Require explicit compatibility plus pairing before the header reports Connected; equal version labels or an unanswered status request are not sufficient.
- Describe blocked delivery without misdiagnosing a protocol mismatch as network unreachability. Keep the existing per-chat delivery/processing evidence separate from the connection badge.

No automatic reload, new permissions, storage, protocol, identity-enforcement or updater changes. The installed app and live browser extension were not replaced for this PR. Production diff: **+11/-6** across the two popup files; documentation **+1/-1**; tests **+70/-2**.

## Validation

- [x] Four new regression tests fail on the original implementation and pass after the change. Existing direct-reload and reload-error tests still pass.
- [x] Popup, service-worker extension and extension-path suites: **112/112 passed** on Node 22 / macOS arm64.
- [x] Typecheck, production build, public-history privacy check and `git diff --check` pass.
- [x] Browser UI smoke with the actual popup HTML/CSS/JS and mocked Chrome responses: mismatch versions/instructions are visible; the explicit reload action reports its request and disables duplicate clicks; pending discovery stays neutral; a compatible paired connection clears the mismatch without claiming the chat has been processed.
- [x] Isolated shutdown tests: **2/2 passed**.
- [x] Full `npm run verify` is green locally
- [x] No unrelated changes, generated artifacts, private data or dependency changes included.

The browser smoke verifies this popup presentation and its mocked reload callback, not a fresh installed-extension or ChatGPT end-to-end run. This is a plain extension resource change; no native/macOS packaging change is claimed.
