### PR TITLE
Confirm a readiness failure before replacing the tunnel client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ The app and the `extension/` companion are versioned together. **Reload the
 extension after updating the app**. If their bridge protocols are incompatible,
 the app refuses the extension and asks you to reload the matching copy.
 
+## Unreleased
+
+### Fixed
+- **A chat no longer ends on "Message delivery timed out" because one readiness probe was
+  missed.** The tunnel watcher asks the client's `/readyz` once every 15 seconds, with a
+  three-second timeout and no retry, and a single `false` terminated the client and started a
+  replacement. Every request in flight travels through that process: the tool call the model
+  was waiting on died with it, no answer could arrive any more, and ChatGPT ended the turn with
+  its own transport error and a Retry button. Longer tasks were hit hardest, simply for being
+  in flight more of the time.
+
+  A probe can miss without the client being broken — mid-transfer, a briefly loaded machine, a
+  slow downstream readiness check. The watcher now requires the failure to survive into a
+  second pass before replacing anything, which is the rule the offline caption has followed
+  since `UNREACHABLE_CONFIRM_MS` was introduced: one failed poll is not a verdict. It was
+  applied there to a caption, and not to the action that kills live work. A client that really
+  is unready is still replaced, one interval later.
+
 ## [2.0.7] — 2026-09-07
 
 **plus = gpt 5.6; pro = astra**

--- a/src/main/tunnel/index.ts
+++ b/src/main/tunnel/index.ts
@@ -166,6 +166,23 @@ const OFFLINE_RECHECK_MS = 5_000;
  */
 const UNREACHABLE_CONFIRM_MS = 35_000;
 
+/**
+ * How long /readyz has to keep failing before the client is killed and replaced.
+ *
+ * The same reasoning as UNREACHABLE_CONFIRM_MS above, applied to the far more expensive
+ * action. That one governs a *caption*; this one governs terminating the process every live
+ * tool call is travelling through. A single missed probe used to be enough: /readyz is asked
+ * once, with a three-second timeout and no retry, and one `false` terminated the client. Any
+ * request in flight died with it, the model went on waiting for an answer that could no longer
+ * arrive, and the chat ended on ChatGPT's own "Message delivery timed out. Please try again."
+ *
+ * A probe can miss for reasons that are not a broken client — the client is mid-transfer, the
+ * machine is briefly loaded, the readiness check's own downstream probe is slow. Requiring the
+ * failure to survive into a second watch pass costs a genuinely dead client one extra interval
+ * before it is replaced, and costs a healthy one nothing at all.
+ */
+const UNREADY_CONFIRM_MS = 15_000;
+
 /** A run of unreachable complaints not yet contradicted by a completed poll. */
 export interface UnreachableRun {
   /** When the run began, or 0 when there is no run in progress. */
@@ -253,6 +270,8 @@ async function startOpenAiTunnel(opts: TunnelStartOptions): Promise<TunnelHandle
     unreachableReason: string;
     outage: UnreachableRun;
     lastHandshake: number | null;
+    /** When /readyz first failed in the current run of failures; 0 when it is answering. */
+    unreadySince: number;
     pollErrors: number;
     healthBase: string | null;
     health: TunnelHealth | null;
@@ -426,9 +445,25 @@ async function startOpenAiTunnel(opts: TunnelStartOptions): Promise<TunnelHandle
           const ready = await probe(`${run.healthBase}/readyz`);
           if (stopped || current !== run) return;
           if (!ready.ok) {
+            const now = Date.now();
+            if (run.unreadySince === 0) {
+              run.unreadySince = now;
+              logWarn(`${tag} did not answer its readiness check: ${ready.detail || 'no detail'} — rechecking before replacing it`);
+              watch(run);
+              return;
+            }
+            if (now - run.unreadySince < UNREADY_CONFIRM_MS) {
+              watch(run);
+              return;
+            }
             logWarn(`${tag} went unready: ${ready.detail}`);
             restart(run, ready.detail || 'The tunnel stopped responding.', true);
             return;
+          }
+          // Answered: whatever the earlier miss was, it was not this client being down.
+          if (run.unreadySince !== 0) {
+            logInfo(`${tag} answered its readiness check again; not replacing it`);
+            run.unreadySince = 0;
           }
 
           const read = await refreshHealth(run);
@@ -488,6 +523,7 @@ async function startOpenAiTunnel(opts: TunnelStartOptions): Promise<TunnelHandle
       unreachableReason: '',
       outage: NO_OUTAGE,
       lastHandshake: null,
+      unreadySince: 0,
       pollErrors: 0,
       healthBase: null,
       health: null,

--- a/test/tunnel-lifecycle.test.ts
+++ b/test/tunnel-lifecycle.test.ts
@@ -167,6 +167,58 @@ describe('OpenAI tunnel process ownership', () => {
     expect(fixture.children).toHaveLength(2);
   });
 
+  /**
+   * Terminating the client kills every request travelling through it.
+   *
+   * /readyz is asked once per pass, with a three-second timeout and no retry, and a single
+   * `false` used to replace the process outright. A probe can miss without the client being
+   * broken — mid-transfer, a briefly loaded machine, a slow downstream readiness check — and
+   * every tool call in flight died with it. The model then waited for an answer that could no
+   * longer arrive, which ChatGPT ends with "Message delivery timed out. Please try again."
+   *
+   * The same rule the offline caption already follows (see UNREACHABLE_CONFIRM_MS): one failed
+   * poll is not a verdict. A genuinely dead client still gets replaced one pass later.
+   */
+  it('replaces the client only after a readiness failure survives a second pass', async () => {
+    vi.useFakeTimers();
+    let ready = true;
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL) => {
+      const url = new URL(String(input));
+      if (url.pathname === '/readyz') return ready ? new Response('ok') : new Response('mcp probe failed', { status: 503 });
+      if (url.pathname === '/metrics') return new Response('commands_poll_last_successful_timestamp_seconds 1\ncommands_poll_errors_total 0\n');
+      if (url.pathname === '/api/status') return Response.json({ uptime_seconds: 50, channels: [] });
+      return new Response('missing', { status: 404 });
+    }));
+    const handle = await startTunnel({
+      localUrl: 'http://127.0.0.1:1234/secret',
+      settings,
+      apiKey: 'sk-tunnel-test',
+      report: () => undefined
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    fixture.health.url = 'http://127.0.0.1:34567';
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(fixture.children).toHaveLength(1);
+
+    // One missed probe, then the client answers again: the run it was carrying is untouched.
+    ready = false;
+    await vi.advanceTimersByTimeAsync(16_000);
+    expect(fixture.children, 'a single missed probe must not replace the client').toHaveLength(1);
+    expect(fixture.terminate).not.toHaveBeenCalled();
+    ready = true;
+    await vi.advanceTimersByTimeAsync(32_000);
+    expect(fixture.children, 'a recovered client must not be replaced later either').toHaveLength(1);
+
+    // Genuinely unready: it keeps failing, and the next pass replaces it.
+    ready = false;
+    await vi.advanceTimersByTimeAsync(16_000);
+    expect(fixture.children).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(fixture.children, 'a client that stays unready is still replaced').toHaveLength(2);
+
+    await handle.stop();
+  });
+
   it('does not wait on a client that already died by signal before starting its replacement', async () => {
     vi.useFakeTimers();
     const reports: any[] = [];


### PR DESCRIPTION
Reported symptom: on longer tasks the main chat waits, then ends on ChatGPT's own **"Message
delivery timed out. Please try again."** with a Retry button. Reported as a regression — not
seen on 2.0.2, regular since.

### Cause

`watch()` in `src/main/tunnel/index.ts` asks the client's `/readyz` once every 15 seconds.
`probe()` gives it **three seconds and no retry**. A single `false` ran:

```ts
restart(run, ready.detail || 'The tunnel stopped responding.', true);
```

`terminate: true` — the client is killed and replaced. Every request in flight travels through
that process, so the tool call the model was waiting on dies with it. Nothing can answer after
that, and ChatGPT ends the turn with its transport error. Longer tasks are hit hardest for the
mundane reason that they are in flight more of the time.

A probe can miss without the client being broken: mid-transfer, a briefly loaded machine, or a
slow downstream check — `/readyz` runs its own MCP probe, and its 503 body is quoted in the code
as `"mcp probe failed: …"`.

### Why this is the odd one out

The rule already exists in this file, for the *other* failure:

> `UNREACHABLE_CONFIRM_MS = 35_000` — *"One failed poll is not an outage. … a single dropped
> read — routine on home Wi-Fi — used to flip the UI to offline"*

That governs a **caption**. Terminating the process that carries live work had no confirmation
at all. This applies the same reasoning to the action with the real consequences.

### Change

`ClientRun` gains `unreadySince`. The first failed probe records the time and logs; the client
is replaced only once the failure survives into a second pass. Any successful probe clears it.
Detection of a genuinely dead client costs one extra interval; a healthy one costs nothing.

### Verification

`test/tunnel-lifecycle.test.ts` — *replaces the client only after a readiness failure survives a
second pass* — asserts both halves: one missed probe followed by a recovery leaves the client
alone and calls no terminate, and a client that keeps failing is still replaced.

Checked the way that matters: against the previous watcher it fails with
`a single missed probe must not replace the client: expected [ … ] to have a length of 1 but got 2`.

`npm run typecheck` clean. 3159 passing. The three failures left are environmental and reproduce
identically on a pristine `main` checkout here — PowerShell execution policy blocking `.ps1`, and
a locale that formats decimals with a comma — which has one more.

### What this does not claim

I have the mechanism, not a capture of it happening on the reporter's machine. What is certain
from the code is that this is the one path where the app itself tears down a tool call that is
already in flight, and that a single three-second timeout was enough to trigger it. Whether it
accounts for every occurrence of that banner is not something I can prove from here — ChatGPT
raises the same message for its own reasons too.

Related to #23, which lists the same watcher's confirmation handling among its causes.
