### PR TITLE
Spend the caller-evidence window once per request, not once per call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@ the app refuses the extension and asks you to reload the matching copy.
   applied there to a caption, and not to the action that kills live work. A client that really
   is unready is still replaced, one interval later.
 
+## Unreleased
+
+### Fixed
+- **A chat whose page has stopped reporting no longer spends half a minute per tool call finding
+  that out.** Every tool call of one ChatGPT turn carries the same request id, and the wait for
+  the page evidence that names the caller was charged to each of them separately. Against a chat
+  that could no longer report — a worker past its context ceiling, in the run this came from —
+  that was 30 seconds per call, repeatedly. A handful of those is long enough for ChatGPT to give
+  up on the turn with "Message delivery timed out", so the waiting ended the turn rather than the
+  missing evidence, which was going to fail those calls in any case.
+
+  The window is now spent once per request id. Nothing else changes: the first call still waits
+  it in full, a different turn is unaffected, and evidence that arrives late is still answered
+  immediately, because the already-known answer is read before any of this is consulted.
+
 ## [2.0.7] — 2026-09-07
 
 **plus = gpt 5.6; pro = astra**

--- a/src/main/session/correlation.ts
+++ b/src/main/session/correlation.ts
@@ -51,6 +51,33 @@ const CORRELATIONS_STATE_VERSION = 5;
 
 const byRequest = new Map<string, RequestCorrelation>();
 const waiters = new Map<string, Set<() => void>>();
+
+/**
+ * Requests whose evidence window has already gone by unanswered.
+ *
+ * The wait exists because a call can reach this app before the page that proves who made it —
+ * measured at about eight seconds late in the case it was written for. What it is not is a
+ * per-call cost: every tool call of one ChatGPT turn carries the same request id, so a page
+ * that has stopped answering makes each of them spend the whole window again. On 2026-09-08
+ * that was 30 seconds per call against a chat whose page could no longer report, and a handful
+ * of those is long enough for ChatGPT to abandon the turn with "Message delivery timed out" —
+ * the waiting, not the missing evidence, is what ends it.
+ *
+ * So the window is spent once per request id. Later calls still get the answer the moment it
+ * exists, because the immediate read below runs first and this is only consulted when it comes
+ * back empty; they simply do not wait for it a second time.
+ */
+const spentEvidenceWindows = new Set<string>();
+const MAX_SPENT_WINDOWS = 2_000;
+
+function noteEvidenceWindowSpent(requestId: string): void {
+  spentEvidenceWindows.add(requestId);
+  while (spentEvidenceWindows.size > MAX_SPENT_WINDOWS) {
+    const oldest = spentEvidenceWindows.values().next();
+    if (oldest.done) break;
+    spentEvidenceWindows.delete(oldest.value);
+  }
+}
 let restored = false;
 let restoring: Promise<void> | null = null;
 
@@ -145,6 +172,7 @@ function merge(input: RequestCorrelation): 'stored' | 'same' | 'refused' {
   const previous = byRequest.get(input.requestId);
   if (!previous) {
     byRequest.set(input.requestId, { ...input });
+    spentEvidenceWindows.delete(input.requestId);
     trim();
     wake(input.requestId);
     return 'stored';
@@ -299,6 +327,9 @@ export async function awaitRequestCorrelation(requestId: string | null | undefin
   if (!requestId) return null;
   const immediate = requestCorrelation(requestId);
   if (immediate || timeoutMs <= 0) return immediate;
+  // This request already spent one full window with nothing arriving. Spending another buys
+  // the same answer at the same price, and the price is charged to the turn.
+  if (spentEvidenceWindows.has(requestId)) return null;
 
   let timer: NodeJS.Timeout | null = null;
   await new Promise<void>((resolve) => {
@@ -313,12 +344,15 @@ export async function awaitRequestCorrelation(requestId: string | null | undefin
     timer.unref?.();
   });
   if (timer) clearTimeout(timer);
-  return requestCorrelation(requestId);
+  const settled = requestCorrelation(requestId);
+  if (!settled) noteEvidenceWindowSpent(requestId);
+  return settled;
 }
 
 /** A conversation being closed cannot invalidate an already issued request. */
 export function resetCorrelationRegistryForTests(): void {
   byRequest.clear();
+  spentEvidenceWindows.clear();
   restored = false;
   restoring = null;
   for (const requestId of [...waiters.keys()]) wake(requestId);

--- a/test/correlation.test.ts
+++ b/test/correlation.test.ts
@@ -15,11 +15,54 @@ import {
   observeRequestCorrelations,
   requestCorrelation,
   restoreRequestCorrelations,
-  resetCorrelationRegistryForTests
+  resetCorrelationRegistryForTests,
+  awaitRequestCorrelation
 } from '../src/main/session/correlation.js';
 
 describe('request correlation ownership', () => {
   beforeEach(() => resetCorrelationRegistryForTests());
+
+  /**
+   * The evidence window is a turn's cost, not a call's.
+   *
+   * Every tool call of one ChatGPT turn carries the same request id, so a page that has stopped
+   * reporting made each of them wait the whole window again. Measured on 2026-09-08 against a
+   * worker chat that had reached its context ceiling: 30 seconds per call, repeatedly, until
+   * ChatGPT abandoned the turn with "Message delivery timed out". The wait was the cost, not
+   * the missing evidence — the calls were going to fail either way.
+   */
+  it('waits the evidence window once per request, not once per call', async () => {
+    const requestId = 'wfr_no_page_evidence';
+    const window = 60;
+
+    const first = Date.now();
+    expect(await awaitRequestCorrelation(requestId, window)).toBeNull();
+    const firstCost = Date.now() - first;
+    expect(firstCost, 'the first call still waits the full window').toBeGreaterThanOrEqual(window - 15);
+
+    // Same turn, next call. Nothing has changed, so there is nothing to wait for.
+    const second = Date.now();
+    expect(await awaitRequestCorrelation(requestId, window)).toBeNull();
+    expect(Date.now() - second, 'a later call in the same turn must not pay it again').toBeLessThan(window / 2);
+
+    // A different turn is unaffected: it has spent nothing yet.
+    const other = Date.now();
+    expect(await awaitRequestCorrelation('wfr_other_turn', window)).toBeNull();
+    expect(Date.now() - other).toBeGreaterThanOrEqual(window - 15);
+
+    // And evidence that does arrive later is still answered, immediately.
+    expect(
+      observeRequestCorrelation({
+        requestId,
+        conversationId: 'conv-late',
+        sessionId: 'session-late',
+        messageId: 'msg-late',
+        tool: 'read',
+        observedAt: Date.now()
+      })
+    ).toBe('stored');
+    expect((await awaitRequestCorrelation(requestId, window))?.conversationId).toBe('conv-late');
+  });
 
   it('keeps one turn-level request id owned across different MCP messages and tools', () => {
     const requestId = 'wfr_shared_turn';


### PR DESCRIPTION
From a real run's log, not a hypothesis. The interesting lines:

```
15:02:12  multi-agent: worker-34 passed the 400000 token ceiling; it keeps working but cannot be woken again
15:16:30  tool write_stdin rejected in 15002 ms: session 89859 is not proven to belong to this durable session
15:16:30  request POST mcp/core → 200 in 30015ms
15:16:50  warn request attribution: no page evidence for wfr_01a0…780a within 20000ms
15:17:09  tool exec_command rejected in 15002 ms: CALLER_IDENTITY_REQUIRED
15:17:09  request POST mcp/core → 200 in 30010ms
```

Same request id on both. **30 seconds per tool call**, one after another, against a chat whose
page could no longer report who it was.

### Why the wait exists, and where it is charged wrongly

`awaitRequestCorrelation` waits because a call can arrive before the page evidence that names
its conversation — the case it was written for was about eight seconds late. That is sound.

What it is not is a per-call cost. Every tool call of one ChatGPT turn carries the same request
id, so once the page stops reporting, **each call spends the whole window again for the same
answer**. A handful of those is long enough for ChatGPT to abandon the turn with "Message
delivery timed out. Please try again."

The calls in that log were going to fail either way; the evidence was genuinely gone. It was the
waiting that ended the turn.

### Change

The window is spent once per request id. A later call in the same turn gets the answer
immediately instead of repeating it.

Nothing else moves, and the ordering is what keeps that true:

- the immediate read of an already-known owner runs **first**, so evidence that lands late is
  still returned normally;
- a different turn has spent nothing and waits in full;
- a correlation that does arrive clears the mark, so nothing stays remembered as hopeless once
  it is not;
- the set is bounded.

### Verification

`test/correlation.test.ts` — *waits the evidence window once per request, not once per call* —
asserts all four: the first call pays the window, a second call in the same turn does not, an
unrelated turn still does, and late evidence is answered.

Against the previous behaviour it fails with
`a later call in the same turn must not pay it again: expected 67 to be less than 30`.

`npm run typecheck` clean. 3161 passing. The three failures left are environmental and reproduce
identically on a pristine `main` checkout here, which has one more.

### Scope

This does not fix the chat in that log — a worker past its context ceiling has a real problem
that this cannot solve. It stops that problem from costing 30 seconds a call while the turn is
still trying to work, which is what turned a stalled worker into an abandoned turn.

Same symptom as #110, different route to it: there a request in flight was destroyed, here every
request pays for evidence that is not coming.
