### PR TITLE
Honour the classifier's access-limit verdict in any language

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -2495,7 +2495,10 @@
         kind: 'chat_error',
         text: error.text,
         turnId: recordedTurn || undefined,
-        recoverable: error.recoverable === true
+        recoverable: error.recoverable === true,
+        // The dialog branch above is the only thing that sets this, and it is what tells the
+        // app a provider access limit was identified without the app re-reading the prose.
+        blocking: error.blocking === true
       });
     }
 

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -893,6 +893,7 @@ function parseObservations(input: unknown): ChatObservation[] {
     }
     if (typeof item['detail'] === 'string') observation.detail = item['detail'].slice(0, 500);
     if (typeof item['recoverable'] === 'boolean') observation.recoverable = item['recoverable'];
+    if (item['blocking'] === true) observation.blocking = true;
     if (Array.isArray(item['calls'])) observation.calls = parseCallEvidence(item['calls']);
     out.push(observation);
   }
@@ -5535,7 +5536,16 @@ async function noteRecoveryObservations(
   const now = Date.now();
   for (const item of observations) {
     if (item.kind !== 'chat_error') continue;
-    if (/^too many requests\b.*temporarily limited.*access.*few minutes/i.test((item.text ?? '').replace(/\s+/g, ' '))) {
+    // A provider access limit is the page saying it will not carry this chat for a few
+    // minutes; reloading it is useless. The DOM classifier already identifies that dialog
+    // and marks it blocking, so honour its verdict rather than re-deriving one here — this
+    // prose only ever matched the English notice, so the same limit in Korean ran the
+    // silence watchdog down and asked the browser to recover against a live block. The
+    // English match stays for extension documents older than the flag.
+    if (
+      item.blocking === true ||
+      /^too many requests\b.*temporarily limited.*access.*few minutes/i.test((item.text ?? '').replace(/\s+/g, ' '))
+    ) {
       endActivity(conversationId);
       continue;
     }

--- a/src/main/session/recorder.ts
+++ b/src/main/session/recorder.ts
@@ -1582,6 +1582,8 @@ export interface ChatObservation {
   goalEligible?: boolean;
   /** chat_error only: explicit recovery authority from a transport failure or app watchdog. */
   recoverable?: boolean;
+  /** chat_error only: the DOM classifier identified a provider access limit, in any language. */
+  blocking?: boolean;
   /** tool_evidence only: the connector requests this turn's message model holds. */
   calls?: PageCallEvidence[];
 }

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -5321,6 +5321,24 @@ describe('unattributed activity recovery', () => {
     } finally { vi.useRealTimers(); }
   });
 
+  // The same dialog, in the language the account is actually reading. The DOM classifier
+  // already recognises it and marks it blocking; only the app's English prose match decided
+  // whether the chat came off the silence clock, so a Korean user's rate limit ran the
+  // response watchdog down and asked the browser to reload against a provider block.
+  it('records a provider access limit the classifier flagged, whatever language it is in', async () => {
+    vi.useFakeTimers();
+    try {
+      await pair();
+      await events(PRIME, [openTurn('limited-turn-ko')]);
+      await events(PRIME, [{ kind: 'chat_error', time: Date.now(), turnId: 'limited-turn-ko',
+        recoverable: false, blocking: true,
+        text: '요청이 너무 많습니다 요청을 너무 빠르게 보내고 있습니다. 데이터를 보호하기 위해 대화에 대한 액세스가 일시적으로 제한되었습니다. 몇 분 후 다시 시도해 주세요.' }]);
+      expect(await maintenance()).toBeNull();
+      await vi.advanceTimersByTimeAsync(180_000);
+      expect(await maintenance()).toBeNull();
+    } finally { vi.useRealTimers(); }
+  });
+
   it.each([false, undefined])('does not spend recovery on an informational alert (recoverable: %s)', async recoverable => {
     await pair();
     // Older loaded extension documents queued this toast before New Chat had an id.

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -7452,6 +7452,30 @@ describe('how a turn is recorded as having ended', () => {
     expect(emitted(live.sent, 'chat_error')).toHaveLength(1);
   });
 
+  it('forwards the access-limit verdict the dialog classifier reached, in any language', async () => {
+    live = await harness();
+    startGenerating(live.document);
+    assistantTurn(live.document, 'turn-1', []);
+    live.hook.observe();
+    await settle();
+
+    // The Korean rendering of the same "Too many requests" dialog. The app must not have to
+    // read this prose to know what it is — the classifier already decided, and its verdict is
+    // what travels, so a limit in a language nobody wrote a pattern for still ends the chat's
+    // recovery clock instead of spending it on a reload the provider will refuse.
+    const notice = live.document.createElement('div');
+    notice.setAttribute('role', 'dialog');
+    Object.defineProperty(notice, 'getClientRects', { value: () => [{ width: 400, height: 200 }] });
+    notice.innerHTML = '<h2>요청이 너무 많습니다</h2><p>요청을 너무 빠르게 보내고 있습니다. 데이터를 보호하기 위해 대화에 대한 액세스가 일시적으로 제한되었습니다. 몇 분 후 다시 시도해 주세요.</p><button>알겠습니다</button>';
+    live.document.body.append(notice);
+    live.hook.observe();
+    await settle();
+
+    const [limit] = emitted(live.sent, 'chat_error').map(entry => entry.event);
+    expect(limit.blocking).toBe(true);
+    expect(limit.recoverable).toBe(false);
+  });
+
   it('does not republish a banner ChatGPT simply leaves on screen', async () => {
     live = await harness();
     startGenerating(live.document);


### PR DESCRIPTION
Closes the second half of #107.

### What 2.0.8 already fixed, and what it left

The DOM classifier now recognises the Korean rendering of ChatGPT's rate-limit dialog, marks it `blocking: true, recoverable: false`, and acknowledges it through its own `알겠습니다` button:

```js
const korean = headingText === '요청이 너무 많습니다' && value.includes(…) && value.includes(…);
if (value.length >= 500 || (!english && !korean)) continue;
out.push({ text: notice, node, turnId: null, recoverable: false, blocking: true });
```

The app never hears about that verdict. `noteRecoveryObservations` reaches its own conclusion from the English prose:

```ts
if (/^too many requests\b.*temporarily limited.*access.*few minutes/i.test(…)) {
  endActivity(conversationId);
  continue;
}
```

`blocking` never leaves the extension — `content.js` emits only `text`, `turnId` and `recoverable` — so for a Korean account that branch cannot match, `endActivity` is never called, and the chat stays on its silence clock. Three minutes later the watchdog asks the browser to recover a page the provider is deliberately refusing to carry.

That is the failure @ventianima-lab documented in the follow-up comment: a recognised, acknowledged, non-recoverable notice, followed by `assistant transport failure — asking the browser to recover`. The app had already identified the dialog; it was the one thing it would not act on.

### The change

The classifier's verdict travels with the event instead of being recomputed downstream:

- `extension/content.js` forwards `blocking` on the `chat_error` emission;
- `parseObservations` accepts it (`item['blocking'] === true` only, like every other flag);
- `ChatObservation` documents it as chat_error-only;
- the access-limit branch honours `item.blocking === true` **or** the existing English prose.

Four lines of behaviour. The English match stays deliberately: a 2.0.8 app paired with an older extension document still gets the English case right, so a mixed-version pair never regresses.

The reason this is a flag rather than a second regex is #112 and everything after it. Adding `요청이 너무 많습니다` to `bridge.ts` would create a second locale list to keep in sync with the extension's, and Arabic, Japanese and the rest would each need both edited. With the flag, every locale the classifier learns is covered the moment it learns it — the classification stays in the one place that can see the dialog.

### Verified — both halves fail before, pass after

`test/content-script.test.ts` — the Korean dialog must reach the app carrying the verdict:

```
AssertionError: expected undefined to be true    (without the content.js change)
```

`test/bridge.test.ts` — a flagged limit must not schedule a reload, mirroring the existing English test three lines above it:

```
+ Received:
{ "conversationId": "abababab-…", "focus": false, "reason": "silence", "token": "1yM4FfbjNUkS" }
   at expect(await maintenance()).toBeNull()      (without the bridge change)
```

Both pass with the change. `npm run typecheck` clean. Full suite: 3404 passed; the 4 failures in `test/renderer-usage.test.ts` and `test/mcp.test.ts` reproduce identically on unmodified `upstream/main` (067c40d) and are unrelated to this change.

### Scope

Recognition and acknowledgement of the dialog are unchanged — this only stops the app from re-deriving a judgement the classifier already made. It grants no retry authority, changes no concurrency, and does not treat the acknowledgement as evidence the limit has ended.
