### PR TITLE
Read a right-to-left answer in its own direction

### DIFF
--- a/src/renderer/chat.ts
+++ b/src/renderer/chat.ts
@@ -1090,6 +1090,11 @@ async function loadHandoff(): Promise<void> {
 
 function textBlock(className: string, value: string, truncated: boolean, chars: number): HTMLElement {
   const node = el('p', className, value);
+  // Recorded text is whatever language the user and ChatGPT were speaking. The stylesheet is
+  // written left-to-right throughout, so an Arabic or Hebrew message rendered without this
+  // reads with its punctuation and numbers on the wrong side. `auto` resolves from the first
+  // strong character, so Latin text is unaffected.
+  node.setAttribute('dir', 'auto');
   if (truncated) {
     node.append(el('span', 'cut', ` … cut, ${compactNumber(chars)} characters in the original`));
   }
@@ -1221,6 +1226,9 @@ export function renderedMarkdown(source: string, capture?: StoredText): HTMLElem
 
 export function renderedMessage(html: StoredText | null | undefined, fallback: string): HTMLElement {
   const box = el('div', 'msg');
+  // Same reason as textBlock, for the markdown path — and it is the fallback rather than the
+  // authority: an element below that carried its own direction keeps it.
+  box.setAttribute('dir', 'auto');
   const safeFallback = fallback.slice(0, MAX_RENDERED_HTML_CHARS);
   // A capture the store had to cut is markup that stops mid-element — very often inside a
   // code block, whose wrapper chrome is far larger than the code in it — so it presents part
@@ -1257,7 +1265,14 @@ export function renderedMessage(html: StoredText | null | undefined, fallback: s
       const start = tagName === 'OL' ? element.getAttribute('start') : null;
       const colSpan = tagName === 'TD' || tagName === 'TH' ? element.getAttribute('colspan') : null;
       const rowSpan = tagName === 'TD' || tagName === 'TH' ? element.getAttribute('rowspan') : null;
+      // ChatGPT marks the direction of its own right-to-left content. Stripping every
+      // attribute threw that away and re-rendered the message left-to-right; the container's
+      // `dir="auto"` then resolved the whole message from its first strong character, which a
+      // mixed-language answer gets wrong paragraph by paragraph. Presentational only, with a
+      // closed set of values, so it carries no script or navigation surface.
+      const dir = element.getAttribute('dir')?.toLowerCase();
       for (const attribute of [...element.attributes]) element.removeAttribute(attribute.name);
+      if (dir === 'ltr' || dir === 'rtl' || dir === 'auto') element.setAttribute('dir', dir);
       if (href) {
         element.setAttribute('href', href);
         element.setAttribute('target', '_blank');
@@ -2929,7 +2944,11 @@ async function refreshInputQueue(): Promise<void> {
     if (entry.attachments?.length) files.append(...entry.attachments.map(file => attachmentCard(file)));
     for (const image of entry.images ?? []) { const preview = document.createElement('img'); preview.src = image.dataUrl; preview.alt = image.name; files.append(preview); }
     if (files.childElementCount) row.append(files);
-    if (entry.text) row.append(el('div', 'pending-message-text', entry.text));
+    if (entry.text) {
+      const text = el('div', 'pending-message-text', entry.text);
+      text.setAttribute('dir', 'auto');
+      row.append(text);
+    }
     const receipt = el('span', 'pending-message-status');
     receipt.title = status; receipt.setAttribute('aria-label', status);
     if (entry.error || entry.state === 'failed') {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1954,7 +1954,8 @@ input[readonly] {
   overflow-wrap: anywhere;
   padding: 4px 7px;
   border: 1px solid var(--line);
-  text-align: left;
+  /* `start`, not `left`: a table inside a right-to-left answer aligns with its own text. */
+  text-align: start;
   vertical-align: top;
 }
 
@@ -2544,7 +2545,7 @@ nav button:hover, nav button.is-sel { background: var(--hover); color: var(--ink
 .composer-options { display: flex; flex-wrap: nowrap; align-items: center; gap: 2px; }
 .composer-options select { border: 0; background: transparent; color: var(--soft); font: inherit; font-size: 11px; max-width: 130px; padding: 5px; }
 .input-queue { width: 100%; margin: 0 auto; }
-.pending-message { position: relative; display: flex; flex-direction: column; align-items: flex-end; gap: 8px; margin: 4px 0 26px auto; width: fit-content; max-width: 82%; text-align: left; }
+.pending-message { position: relative; display: flex; flex-direction: column; align-items: flex-end; gap: 8px; margin: 4px 0 26px auto; width: fit-content; max-width: 82%; text-align: start; }
 .pending-message-text { white-space: pre-wrap; overflow-wrap: anywhere; font-size: 15px; line-height: 1.75; }
 .pending-message-status { position: absolute; right: 30px; top: calc(100% + 1px); height: 22px; display: inline-flex; align-items: center; justify-content: center; font-size: 12px; line-height: 1.45; color: var(--soft); }
 .pending-message.is-delivery-error .pending-message-status { position: static; display: block; height: auto; margin-top: 4px; font-size: 11px; font-weight: 400; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/test/renderer-html.test.ts
+++ b/test/renderer-html.test.ts
@@ -234,4 +234,24 @@ describe('a capture that could not be carried whole', () => {
     expect(rendered.classList.contains('rich')).toBe(false);
     expect(rendered.textContent).toBe(MARKDOWN);
   });
+
+  it('reads a right-to-left answer in its own direction', () => {
+    // Nothing in the recording says which way this runs, and the stylesheet is left-to-right
+    // throughout, so the container has to resolve it from the text itself.
+    expect(renderedMarkdown('مرحبا بالعالم').getAttribute('dir')).toBe('auto');
+  });
+
+  it('keeps the direction ChatGPT marked on a mixed-language answer', () => {
+    // One first strong character cannot describe two paragraphs that run opposite ways, so
+    // where the capture carried the answer, sanitisation has to leave it there.
+    const rendered = renderedMessage(whole('<p dir="rtl">مرحبا بالعالم</p><p dir="ltr">Hello world</p>'), 'fallback');
+
+    expect([...rendered.querySelectorAll('p')].map((node) => node.getAttribute('dir'))).toEqual(['rtl', 'ltr']);
+  });
+
+  it('drops a direction value that is not one of the three', () => {
+    const rendered = renderedMessage(whole('<p dir="javascript:alert(1)">text</p>'), 'fallback');
+
+    expect(rendered.querySelector('p')!.hasAttribute('dir')).toBe(false);
+  });
 });


### PR DESCRIPTION
Addresses #112.

The report is short — "Arabic direction not show correct" — so I went looking for what the renderer actually does with right-to-left text. The answer is nothing, and there is one place where it actively throws the answer away.

### What the code does today

`grep -rn 'dir=' src/renderer/` matches nothing. There is no `dir` attribute anywhere in the app, and `styles.css` is written left-to-right throughout. So an Arabic or Hebrew message is laid out left-to-right, which puts its punctuation and numbers on the wrong side of the line.

That part is a missing feature. This part is a bug: ChatGPT marks the direction of its own RTL content, the recording keeps that markup — and then the rendered-HTML sanitiser removes it:

```ts
for (const attribute of [...element.attributes]) element.removeAttribute(attribute.name);
if (href) { … }
if (title) element.setAttribute('title', title.slice(0, 500));
if (start && /^\d{1,6}$/.test(start)) element.setAttribute('start', start);
```

`dir` is not on that re-add list, so the one piece of direction evidence the app already had never reaches the screen. Pinned by a test that fails before the change with `expected [ null, null ] to deeply equal [ 'rtl', 'ltr' ]`.

### The change

Three parts, none of which covers the others:

1. **`dir="auto"` on message containers** — `textBlock` (user rows, chat errors, tool text), `renderedMessage` (both the rich and fallback paths), and the pending user row. `auto` resolves from the first strong character, so Latin text renders exactly as before.
2. **`dir` survives sanitisation** when its value is one of `ltr` / `rtl` / `auto`. A mixed-language answer cannot be resolved from one first character — its paragraphs run opposite ways and only the capture knows which is which. The attribute is presentational with a closed value set, so it carries no script or navigation surface; anything else is still dropped, and there is a test for that too.
3. **`text-align: left` → `text-align: start`** on the two rules that apply to message *content*: table cells inside a rendered answer (`.msg.rich th, .msg.rich td`) and the pending user row. Otherwise direction would be resolved correctly and the text would still be flushed to the wrong edge. Identical rendering for left-to-right text.

Deliberately untouched: every other `text-align: left` in the stylesheet — `.plugin-entry`, `nav button`, `.composer-popover button`, the agent-panel rows and so on. Those are chrome, not recorded content, and turning the whole app RTL is a much larger decision than making a recorded message readable.

### Verified

Three new tests in `test/renderer-html.test.ts`, two of which fail before the change:

```
× reads a right-to-left answer in its own direction
    AssertionError: expected null to be 'auto'
× keeps the direction ChatGPT marked on a mixed-language answer
    AssertionError: expected [ null, null ] to deeply equal [ 'rtl', 'ltr' ]
```

Both pass after. The third (an unrecognised `dir` value is dropped) guards the sanitiser change.

`npm run typecheck` clean. All 5 renderer test files pass (163 tests). Full suite: 3405 passed; the failures in `test/renderer-usage.test.ts` and `test/mcp.test.ts` reproduce identically on unmodified `upstream/main` (067c40d) — the `mcp.test.ts` "cut pipeline" one is timing-sensitive and does not fail on every run.

### One thing I could not check

@ShabanElmoogy — this fixes direction in the **app's own session view**. If what you are seeing is on the ChatGPT page itself rather than in the Chat On Steroids window, that is a different surface and this will not change it. A screenshot of where the text looks wrong would settle which one it is.
