### PR TITLE
Preserve window size when reopening

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -136,7 +136,13 @@ function createWindow(): void {
   window.once('ready-to-show', () => {
     // A renderer can finish loading after Cmd+Q has already entered bounded teardown. Never let
     // that late native event make the app visible again while `will-quit` is draining.
-    if (!quitting) showWindow();
+    if (!quitting) {
+      // Newly created windows intentionally start maximized. Keep that startup-only presentation
+      // here so later tray/Dock/native activation can show an existing user-sized window without
+      // overwriting its geometry.
+      if (!window?.isFullScreen()) window?.maximize();
+      showWindow();
+    }
   });
 
   // A renderer that fails to load leaves a blank window with no other clue, so
@@ -200,9 +206,6 @@ function showWindow(): void {
     return;
   }
   if (window.isMinimized()) window.restore();
-  // Apply maximization before showing the window so startup has the native maximized
-  // frame from its first visible paint. Preserve a user's explicit F11 fullscreen choice.
-  if (!window.isFullScreen()) window.maximize();
   window.show();
   window.focus();
 }

--- a/test/window-lifecycle.test.ts
+++ b/test/window-lifecycle.test.ts
@@ -13,35 +13,44 @@ import {
 } from '../src/main/window-lifecycle.js';
 
 describe('native window activation', () => {
-  it('maximizes before showing on launch and native reopen, preserving explicit fullscreen', () => {
+  it('maximizes only on initial presentation and preserves user-sized geometry on reopen', () => {
     const source = readFileSync(new URL('../src/main/index.ts', import.meta.url), 'utf8');
     const present = source.slice(source.indexOf('function showWindow()'), source.indexOf('\nsetFinishNotifier(', source.indexOf('function showWindow()'))).replace('function showWindow(): void', 'function showWindow()');
     const operations: string[] = [];
-    const state = { minimized: false, fullscreen: false };
-    const native = { isMinimized: () => state.minimized, isFullScreen: () => state.fullscreen,
-      restore: () => operations.push('restore'), maximize: () => operations.push('maximize'),
+    const state = { minimized: false };
+    const native = { isMinimized: () => state.minimized,
+      restore: () => operations.push('restore'),
       show: () => operations.push('show'), focus: () => operations.push('focus') };
     const createWindow = vi.fn();
     const context = vm.createContext({ window: native, quitting: false, createWindow });
     vm.runInContext(present + '\nshowWindow();', context);
-    expect(operations.splice(0)).toEqual(['maximize', 'show', 'focus']);
+    expect(operations.splice(0)).toEqual(['show', 'focus']);
     state.minimized = true;
     vm.runInContext('showWindow()', context);
-    expect(operations.splice(0)).toEqual(['restore', 'maximize', 'show', 'focus']);
-    state.minimized = false; state.fullscreen = true;
-    vm.runInContext('showWindow()', context);
-    expect(operations.splice(0)).toEqual(['show', 'focus']);
+    expect(operations.splice(0)).toEqual(['restore', 'show', 'focus']);
     context.quitting = true;
     vm.runInContext('showWindow()', context);
     expect(operations).toEqual([]);
 
     let ready!: () => void;
     const startup = source.slice(source.indexOf("  window.once('ready-to-show'"), source.indexOf('  // A renderer that fails', source.indexOf("  window.once('ready-to-show'")));
-    const showWindow = vi.fn();
-    const launch = vm.createContext({ window: { once: (_event: string, listener: () => void) => { ready = listener; } }, quitting: false, showWindow });
+    const startupOperations: string[] = [];
+    const startupState = { fullscreen: false };
+    const showWindow = vi.fn(() => startupOperations.push('showWindow'));
+    const launch = vm.createContext({ window: {
+      once: (_event: string, listener: () => void) => { ready = listener; },
+      isFullScreen: () => startupState.fullscreen,
+      maximize: () => startupOperations.push('maximize')
+    }, quitting: false, showWindow });
     vm.runInContext(startup, launch);
-    ready(); expect(showWindow).toHaveBeenCalledTimes(1);
-    launch.quitting = true; ready(); expect(showWindow).toHaveBeenCalledTimes(1);
+    ready();
+    expect(startupOperations.splice(0)).toEqual(['maximize', 'showWindow']);
+    startupState.fullscreen = true;
+    ready();
+    expect(startupOperations.splice(0)).toEqual(['showWindow']);
+    launch.quitting = true;
+    ready();
+    expect(showWindow).toHaveBeenCalledTimes(2);
   });
   it('discovers on first visible use only when there is no saved catalog, never on repeat show or quit', async () => {
     const source = readFileSync(new URL('../src/main/index.ts', import.meta.url), 'utf8');


### PR DESCRIPTION
Fixes #121.

## What changed

`showWindow()` was applying the startup maximization policy every time an existing window was reopened. A minimized window was restored and then immediately maximized, discarding the user's previous size.

This keeps the existing native-maximized presentation for a newly created window by moving `maximize()` into the `ready-to-show` path, while `showWindow()` now only restores, shows, and focuses an existing window. The window lifecycle regression test covers both initial presentation and minimized reopen.

## Validation

- [x] Added or updated a deterministic regression test where behavior changed.
- [ ] `npm run verify` passes. Local verification reaches the test suite but has two environment-dependent baseline failures that reproduce unchanged on clean `upstream/main`: the machine-wide `/opt/homebrew/bin/rg` wins the bundled-ripgrep assertion, and a locally available tunnel client is discovered by the explicit-binary fallback test. The window change is not involved in either failure.
- [x] Packaging/runtime smoke was run when the change can differ after bundling.
- [x] No unrelated formatting, generated output, local debugging notes, or private data is included.
- [x] Screenshots, logs and examples use placeholders instead of real usernames, paths, chat text, IDs or credentials.
- [x] Security-sensitive details are being handled privately instead of disclosed here.

Additional results:

- `npm test -- --run test/window-lifecycle.test.ts`: 12/12 passed
- `npm run typecheck`: passed
- `npm run verify:privacy`: passed
- `npm run dist:dir:mac:arm64`: passed
- packaged darwin-arm64 native/runtime smoke: passed
- macOS arm64 bundle audit: passed
- manual installed-app check: a resized window retains its size after minimize and Dock reopen
