### PR TITLE
Fix Compact & Resume recovery loop on blocked handoff

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -2830,6 +2830,9 @@ const HANDLERS = {
         ...(typeof message.token === 'string' && message.sourceAttempt === true
           ? { token: message.token, sourceAttempt: true }
           : {}),
+        ...(typeof message.token === 'string' && message.sourceLost === true
+          ? { token: message.token, sourceLost: true }
+          : {}),
         ...(typeof message.token === 'string' && message.sourceDispatch === true
           ? { token: message.token, sourceDispatch: true }
           : {}),

--- a/extension/content.js
+++ b/extension/content.js
@@ -8032,19 +8032,29 @@
       CLF_DOM.conversationId() === forId;
     let attemptCrossed = false;
     const automaticTicket = job && job.automatic === true;
-    const abandonBeforeSend = async (why) => {
+    const abandonBeforeSend = async (why, retireAutomatic = false) => {
       if (!current()) return;
       nativeBusy = false;
       nativePhase = '';
       pressedAt = 0;
       localError = why;
-      // A page/DOM failure is not a verdict on an automatic ticket. Keep it on the
-      // continuation WAL so the app's next pickup reload can collect the same work. A manual
-      // press keeps its historical immediate-abort behaviour; the user is still present and
-      // can retry it without leaving an invisible job behind.
+      // A transient page/DOM failure is not a verdict on an automatic ticket. Keep it on the
+      // continuation WAL so the app's next pickup reload can collect the same work. A composer
+      // already holding another draft is different: ChatGPT restores that draft across reloads,
+      // so the caller can retire this pre-Send ticket instead of scheduling the same refusal.
+      // A manual press keeps its historical immediate-abort behaviour; the user is still present
+      // and can retry it without leaving an invisible job behind.
       if (!automaticTicket) {
         job = null;
         await ask({ type: 'compact', conversationId: forId, cancel: true }).catch(() => undefined);
+      } else if (retireAutomatic) {
+        // This is not the user-facing Cancel path. The bridge accepts sourceLost only while its
+        // durable checkpoint still proves no Send happened (`not-attempted` or
+        // `attempted-unresolved`). If another page crossed sourceDispatch meanwhile, this refuses
+        // and the ambiguous attempt remains alive rather than being cancelled underneath it.
+        const lost = await ask({ type: 'compact', conversationId: forId, token, sourceLost: true }).catch(() => null);
+        if (lost && lost.ok === true && lost.data && lost.data.aborted === true) job = null;
+        else localError = replyError(lost) || 'The blocked handoff could not be safely retired; it was not sent twice.';
       }
       if (!current()) return;
       renderControl();
@@ -8059,10 +8069,33 @@
       nativePhase = 'prompting';
       renderControl();
       const squeeze = (value) => String(value || '').replace(/\s+/g, '');
-      const existing = CLF_DOM.composer();
+      let existing = CLF_DOM.composer();
+      const existingText = existing?.textContent || '';
+      // ChatGPT restores unsent composer text across reloads. A rejected older continuation can
+      // therefore become the draft every recovery pickup inherits. Clear only text that proves
+      // it is app-owned and stale: a *different* CLF token plus one of the two canonical COS
+      // continuation instructions. Same-token text may be a user edit of the current prompt and
+      // ordinary drafts have neither proof, so both remain untouched.
+      const stale = /^\s*\[\[CLF-(HANDOFF|RESUME):([A-Za-z0-9_-]{16,64})\]\]/.exec(existingText);
+      const staleAppDraft =
+        stale &&
+        stale[2] !== token &&
+        (stale[1] === 'HANDOFF'
+          ? existingText.includes('Chat On Steroids is compacting this conversation so a fresh chat can continue the work.')
+          : existingText.includes('Continuing a Chat On Steroids session that was compacted.'));
+      if (staleAppDraft && CLF_DOM.clearPromptExact(existingText)) existing = CLF_DOM.composer();
+      const occupiedByOtherDraft =
+        Boolean(existing && (existing.textContent || '').trim()) &&
+        squeeze(existing?.textContent) !== squeeze(prompt);
       if (squeeze(existing?.textContent) !== squeeze(prompt) && !CLF_DOM.insertPrompt(prompt)) {
         return void (await abandonBeforeSend(
-          'ChatGPT would not accept the handoff instruction — clear the message box and try again.'
+          'ChatGPT would not accept the handoff instruction — clear the message box and try again.',
+          // An occupied composer is durable state: ChatGPT restores drafts across reloads. Leaving
+          // an automatic ticket open here makes every compaction pickup reload the same draft and
+          // hit this same refusal forever. Retire only this provably pre-Send ticket; the draft
+          // itself stays untouched. Missing/replaced composer failures remain recoverable on the
+          // existing WAL.
+          occupiedByOtherDraft
         ));
       }
       await Promise.resolve();

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -143,6 +143,7 @@ import {
 import {
   abortContinuation,
   abortContinuationNow,
+  abortContinuationSourceBeforeSendNow,
   attachSummary,
   beginContinuationDestinationSendNow,
   beginContinuationSourceSendNow,
@@ -2221,6 +2222,30 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
     }
     const id = conversationId(body['conversationId']);
     if (!id) return json(res, 400, { error: 'bad_conversation_id' }, origin);
+    if (body['sourceLost'] === true) {
+      const entry = continuationByToken(checkpointToken);
+      if (!entry || entry.from !== id) return json(res, 409, { error: 'no_such_continuation' }, origin);
+      let aborted = false;
+      try {
+        aborted = await abortContinuationSourceBeforeSendNow(checkpointToken, 'handoff_never_sent');
+      } catch (err) {
+        logWarn(
+          `bridge: could not durably abandon the unsent source handoff for ${entry.sessionId} — ${err instanceof Error ? err.message : String(err)}`
+        );
+        return json(
+          res,
+          503,
+          { error: 'source_abort_not_durable', retryable: true, sessionId: entry.sessionId, job: resumeJobFor(entry.sessionId) },
+          origin
+        );
+      }
+      if (!aborted) return json(res, 409, { error: 'source_send_not_releasable' }, origin);
+      rejectAutomaticCompactionForCurrentTurn(entry);
+      compactionWatch.delete(id);
+      if (repairsInFlight.get(id)?.reason === 'compaction') repairsInFlight.delete(id);
+      changed();
+      return json(res, 200, { aborted: true, sessionId: entry.sessionId, job: resumeJobFor(entry.sessionId) }, origin);
+    }
     // The last durable write before the click, quoting the claim handed out above. A false
     // answer means this document was reclaimed while it was composing and must submit nothing.
     if (body['sourceDispatch'] === true) {
@@ -4818,6 +4843,27 @@ interface ActivityGrant {
 
 const activeUntil = new Map<string, ActivityGrant>();
 
+/**
+ * A working turn whose automatic compaction was terminally refused before source Send.
+ *
+ * The context threshold is a level, so without this turn-local fence the very next interim/tool
+ * observation can immediately file a brand-new ticket for the same turn. A persistent composer
+ * draft would then retire that ticket too, and its pickup would recreate the reload loop under a
+ * new token. The refusal is therefore spent by a real turn boundary, not by another observation
+ * from the turn that already proved it cannot currently compact.
+ *
+ * Process memory is intentional. This is pickup/retry scheduling state, not continuation
+ * authority; the durable continuation WAL remains the only source of send/commit truth.
+ */
+const compactionRejectedTurn = new Map<string, { sessionId: string; turnId: string | null }>();
+
+function rejectAutomaticCompactionForCurrentTurn(entry: ContinuationView): void {
+  if (!entry.automatic) return;
+  const grant = activeUntil.get(entry.from);
+  if (!grant || grant.sessionId !== entry.sessionId) return;
+  compactionRejectedTurn.set(entry.from, { sessionId: entry.sessionId, turnId: grant.turnId });
+}
+
 /** Chats reloaded by the app whose page has given no sign of life since. */
 const awaitingReturn = new Set<string>();
 
@@ -4827,6 +4873,10 @@ function grantActivity(conversationId: string, sessionId: string, at = Date.now(
   if (!sessionId) return;
   const previous = activeUntil.get(conversationId);
   const ownership = turn ?? (previous?.sessionId === sessionId ? previous : { turnId: null, model: 'unknown' as const });
+  const rejected = compactionRejectedTurn.get(conversationId);
+  if (rejected && (rejected.sessionId !== sessionId || rejected.turnId !== ownership.turnId)) {
+    compactionRejectedTurn.delete(conversationId);
+  }
   if (ownership.model === 'pro' && (isChatBlocked(conversationId) || stopRequestedFor(conversationId))) return;
   const evidenceAt = previous?.sessionId === sessionId && previous.turnId === ownership.turnId ? Math.max(previous.evidenceAt, at) : at;
   activeUntil.set(conversationId, { sessionId, evidenceAt, until: evidenceAt + (ownership.model === 'pro' ? PRO_SILENCE_MS : window), turnId: ownership.turnId, model: ownership.model });
@@ -4959,6 +5009,7 @@ async function chatStillWorking(conversationId: string, turnId: string, sessionI
  */
 async function considerAutomaticCompaction(conversationId: string, sessionId: string): Promise<void> {
   if (!getConfig().compaction.auto || compactionFilings.has(conversationId)) return;
+  if (compactionRejectedTurn.get(conversationId)?.sessionId === sessionId) return;
   if (goalFencedChat(conversationId) || continuationForSession(sessionId) || !chatIsWorking(conversationId)) return;
   compactionFilings.add(conversationId);
   try {
@@ -5058,12 +5109,14 @@ function armResumedChat(sessionId: string, conversationId: string): void {
 /** A real terminal — stable final answer, explicit stop, worker finish — spends the deadline. */
 function endActivity(conversationId: string): void {
   activeUntil.delete(conversationId);
+  compactionRejectedTurn.delete(conversationId);
   armSilenceSweep();
 }
 
 /** Drops a chat out of the activity ledger entirely, once nothing is waiting on it. */
 function forgetActivity(conversationId: string): void {
   activeUntil.delete(conversationId);
+  compactionRejectedTurn.delete(conversationId);
   armSilenceSweep();
 }
 
@@ -6053,6 +6106,7 @@ async function inspectOwedCompactions(now: number): Promise<boolean> {
       if (repairsInFlight.get(entry.from)?.reason === 'compaction') repairsInFlight.delete(entry.from);
       try {
         await abortContinuationNow(entry.token, 'handoff_never_sent');
+        rejectAutomaticCompactionForCurrentTurn(entry);
         logWarn(
           `bridge: compaction ticket ${entry.token.slice(0, 8)} for ${entry.from} was never sent after ${schedule.attempts} pickups — giving up`
         );
@@ -7621,6 +7675,7 @@ export function resetBridgeForTests(): void {
   bridgeShutdownRequested = false;
   clearUnattributedIncident();
   activeUntil.clear();
+  compactionRejectedTurn.clear();
   awaitingReturn.clear();
   lastAttributedCallAt.clear();
   goalWatch.clear();

--- a/src/main/session/continuation.ts
+++ b/src/main/session/continuation.ts
@@ -812,6 +812,30 @@ export async function dispatchContinuationSourceSendNow(token: string): Promise<
   });
 }
 
+/**
+ * Terminally abandons a source handoff when the page can still prove no Send happened.
+ *
+ * This is the source-side counterpart to releasing a lost destination draft, except there is
+ * nothing useful to retry automatically in chat A: a composer that rejected the instruction is
+ * liable to survive reloads with the same stale draft and turn one bounded pickup schedule into
+ * repeated UI churn. Both `not-attempted` and `attempted-unresolved` are pre-Send proofs; once
+ * the dispatch fence has been crossed the outcome is ambiguous and only ChatGPT's marker or an
+ * explicit user cancellation may end the transaction.
+ */
+export async function abortContinuationSourceBeforeSendNow(token: string, reason: string): Promise<boolean> {
+  return withCheckpointLock(token, async () => {
+    const entry = byToken.get(token);
+    if (!entry || !isOpen(entry) || entry.state !== 'awaiting-summary' || !sendUnattempted(entry.sourceSend)) {
+      return false;
+    }
+    await transitionNow(entry, (current) => ({ ...current, state: 'aborted', error: reason }));
+    cancelPrimeTransfer(entry.from);
+    logWarn(`continuation ${entry.token.slice(0, 8)} durably abandoned before source Send — ${reason}`);
+    noteAbandoned(entry, reason);
+    return true;
+  });
+}
+
 /** Binds the marked source prompt to ChatGPT's stable user-message identity. */
 export async function bindContinuationSourceMessageNow(token: string, messageId: string, progress?: number): Promise<boolean> {
   if (!messageId || messageId.length > 200) return false;

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -1552,6 +1552,101 @@ describe('automatic compaction', () => {
     expect(continuationForSession(session!.id)).toBeNull();
   });
 
+  it('durably ends an automatic ticket when the source page proves the handoff never reached Send', async () => {
+    await pair();
+    const conversationId = 'a1a1a1a1-0000-4000-8000-00000000ac08';
+    await request('POST', '/events', {
+      body: {
+        conversationId,
+        events: [{ kind: 'user_message', time: Date.now(), text: 'composer rejected the handoff', messageId: 'm-auto-lost' }]
+      }
+    });
+    const filed = await request('POST', '/compact', {
+      body: { conversationId, ticket: true, automatic: true }
+    });
+    const token = filed.body.token as string;
+    expect((await request('POST', '/compact', { body: { conversationId, token, sourceAttempt: true } })).body.allowed).toBe(true);
+
+    const lost = await request('POST', '/compact', { body: { conversationId, token, sourceLost: true } });
+    expect(lost.status).toBe(200);
+    expect(lost.body.aborted).toBe(true);
+    expect(continuationByToken(token)).toMatchObject({ state: 'aborted', error: 'handoff_never_sent' });
+    expect(continuationForSession(filed.body.sessionId as string)).toBeNull();
+    expect((await request('POST', '/compact', { body: { conversationId, token, sourceDispatch: true } })).status).toBe(409);
+  });
+
+  it('does not immediately refile a rejected automatic compaction in the same working turn', async () => {
+    await pair();
+    const conversationId = 'a1a1a1a1-0000-4000-8000-00000000ac09';
+    await withThreshold(10_000, async () => {
+      await request('POST', '/events', {
+        body: {
+          conversationId,
+          events: [{ kind: 'turn_start', time: Date.now(), turnId: 'turn-rejected-compact' }, ...over()]
+        }
+      });
+      await settled();
+      const activity = await request('GET', `/activity?conversationId=${conversationId}`);
+      const sessionId = activity.body.sessionId as string;
+      const first = continuationForSession(sessionId);
+      expect(first).toMatchObject({ automatic: true, state: 'awaiting-summary' });
+
+      const lost = await request('POST', '/compact', {
+        body: { conversationId, token: first!.token, sourceLost: true }
+      });
+      expect(lost.status).toBe(200);
+      expect(continuationForSession(sessionId)).toBeNull();
+
+      // More live evidence from this exact turn must not create a fresh token behind the
+      // persistent composer draft that just rejected the previous one.
+      await request('POST', '/events', {
+        body: {
+          conversationId,
+          events: [{
+            kind: 'assistant_message',
+            time: Date.now(),
+            turnId: 'turn-rejected-compact',
+            text: 'still working',
+            renderedHtml: '<p>still working</p>',
+            messageId: 'a-rejected-compact',
+            state: 'streaming',
+            activeNow: true
+          }]
+        }
+      });
+      await settled();
+      expect(continuationForSession(sessionId)).toBeNull();
+
+      // A genuine turn boundary spends the refusal. The next working turn can compact again.
+      await request('POST', '/events', {
+        body: {
+          conversationId,
+          events: [{ kind: 'turn_end', time: Date.now(), turnId: 'turn-rejected-compact', outcome: 'completed' }]
+        }
+      });
+      await request('POST', '/events', {
+        body: {
+          conversationId,
+          events: [
+            { kind: 'turn_start', time: Date.now(), turnId: 'turn-after-rejection' },
+            {
+              kind: 'assistant_message',
+              time: Date.now(),
+              turnId: 'turn-after-rejection',
+              text: 'new turn is working',
+              renderedHtml: '<p>new turn is working</p>',
+              messageId: 'a-after-rejection',
+              state: 'streaming',
+              activeNow: true
+            }
+          ]
+        }
+      });
+      await settled();
+      expect(continuationForSession(sessionId)).toMatchObject({ automatic: true, state: 'awaiting-summary' });
+    });
+  });
+
   /**
    * Before the prompt has reached ChatGPT the pickup is a two-minute clock with five raised
    * reloads, and a ticket that still has not been sent after them is abandoned: nothing was

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -371,6 +371,7 @@ const startedCompactions = (harness: Harness): any[] =>
       !message.cancel &&
       !message.summary &&
       !message.sourceAttempt &&
+      !message.sourceLost &&
       !message.sourceDispatch &&
       !message.sourceMessageId &&
       !message.destinationAttempt &&
@@ -9743,9 +9744,47 @@ describe('the Compact & resume control', () => {
     expect(compacts[compacts.length - 1]).toMatchObject({ cancel: true });
   });
 
-  it('keeps an automatic ticket open when a page-side composer error happens before Send', async () => {
+  it('durably retires an automatic ticket blocked by a persistent user draft without changing the draft', async () => {
     const automaticJob = {
       sessionId: 's-auto-page-error',
+      stage: 'handoff-pending',
+      automatic: true,
+      busy: true,
+      handoffId: null,
+      error: null
+    };
+    live = await harness(undefined, {
+      activity: () => ({ ok: true, data: { entries: [], stream: [], nextSince: 0, pendingTools: 0, job: null } }),
+      compact: (message) =>
+        message.sourceLost
+          ? { ok: true, data: { aborted: true, job: null } }
+          : {
+              ok: true,
+              data: {
+                started: true,
+                token: 'tok-auto-page-error',
+                prompt: 'write the automatic handoff brief',
+                job: automaticJob
+              }
+            }
+    });
+    live.hook.injectControl();
+    live.document.querySelector('#prompt-textarea')!.textContent = 'draft that makes prompt insertion fail';
+
+    await live.hook.startCompact(true);
+
+    const compacts = live.sent.filter((message) => message.type === 'compact');
+    expect(compacts[0]).toMatchObject({ ticket: true, automatic: true });
+    expect(compacts).toContainEqual(expect.objectContaining({ token: 'tok-auto-page-error', sourceLost: true }));
+    expect(compacts.some((message) => message.cancel === true)).toBe(false);
+    expect(live.sent.some((message) => message.type === 'compact' && message.sourceAttempt === true)).toBe(false);
+    expect(composerText(live.document)).toBe('draft that makes prompt insertion fail');
+    expect(live.document.querySelector('.clf-pill-text')!.textContent).toContain('clear the message box');
+  });
+
+  it('keeps an automatic ticket recoverable when the composer itself is transiently missing', async () => {
+    const automaticJob = {
+      sessionId: 's-auto-missing-composer',
       stage: 'handoff-pending',
       automatic: true,
       busy: true,
@@ -9758,14 +9797,14 @@ describe('the Compact & resume control', () => {
         ok: true,
         data: {
           started: true,
-          token: 'tok-auto-page-error',
+          token: 'tok-auto-missing-composer',
           prompt: 'write the automatic handoff brief',
           job: automaticJob
         }
       })
     });
     live.hook.injectControl();
-    live.document.querySelector('#prompt-textarea')!.textContent = 'draft that makes prompt insertion fail';
+    live.document.querySelector('#prompt-textarea')!.remove();
 
     await live.hook.startCompact(true);
 
@@ -9773,6 +9812,80 @@ describe('the Compact & resume control', () => {
     expect(compacts[0]).toMatchObject({ ticket: true, automatic: true });
     expect(compacts.some((message) => message.cancel === true)).toBe(false);
     expect(live.document.querySelector('.clf-pill-text')!.textContent).toContain('clear the message box');
+  });
+
+  it('clears a proven stale COS handoff draft and lets the current automatic ticket reach its send fence', async () => {
+    let draftAtAttempt = '';
+    const pendingJob = {
+      sessionId: 's-auto-stale-draft',
+      stage: 'handoff-pending',
+      automatic: true,
+      busy: true,
+      handoffId: null,
+      error: null,
+      sourceSend: { state: 'not-attempted', messageId: null }
+    };
+    live = await harness(undefined, {
+      activity: () => ({
+        ok: true,
+        data: {
+          entries: [],
+          stream: [],
+          nextSince: 0,
+          pendingTools: 0,
+          job: pendingJob
+        }
+      }),
+      compact: (message) => {
+        if (message.sourceAttempt) {
+          draftAtAttempt = composerText(live!.document);
+          return { ok: true, data: { allowed: true } };
+        }
+        if (message.sourceDispatch) return { ok: true, data: { armed: true } };
+        if (message.sourceLost) return { ok: false, error: 'unexpected_source_lost' };
+        return {
+          ok: true,
+          data: {
+            started: false,
+            token: '0123456789abcdef0123456789abcdef',
+            prompt: '[[CLF-HANDOFF:0123456789abcdef0123456789abcdef]]\n\ncurrent handoff prompt',
+            job: pendingJob
+          }
+        };
+      }
+    });
+    live.hook.injectControl();
+    // The real rich editor accepts selectAll/delete. The general harness only needs insertText,
+    // so make this ownership-cleanup fixture model the native deletion path as well.
+    const document = live.document as Document & { execCommand: (...args: any[]) => boolean };
+    const originalExec = document.execCommand.bind(document);
+    document.execCommand = (...args: any[]) => {
+      if (args[0] === 'selectAll') return true;
+      if (args[0] === 'delete') {
+        document.querySelector('#prompt-textarea')?.replaceChildren();
+        return true;
+      }
+      return originalExec(...args);
+    };
+    const stale =
+      '[[CLF-HANDOFF:fedcba9876543210fedcba9876543210]]\n\n' +
+      'Chat On Steroids is compacting this conversation so a fresh chat can continue the work. Stop whatever you were doing and do only this.\n\n' +
+      'stale rejected handoff prompt';
+    live.document.querySelector('#prompt-textarea')!.textContent = stale;
+
+    await live.hook.pullActivity();
+    await settle();
+    await live.hook.pullActivity();
+    await settle();
+
+    expect(startedCompactions(live)).toHaveLength(1);
+    expect(live.sent.some((message) => message.type === 'compact' && message.cancel === true)).toBe(false);
+    expect(live.sent.some((message) => message.type === 'compact' && message.sourceLost === true)).toBe(false);
+    expect(live.sent.some((message) => message.type === 'compact' && message.sourceAttempt === true)).toBe(true);
+    expect(live.sent.some((message) => message.type === 'compact' && message.sourceDispatch === true)).toBe(true);
+    expect(draftAtAttempt).toContain('0123456789abcdef0123456789abcdef');
+    expect(draftAtAttempt).not.toContain('fedcba9876543210fedcba9876543210');
+    expect(composerText(live.document)).not.toBe(stale);
   });
 
   it('does not submit a compaction prompt after the composer changes during its pre-send wait', async () => {

--- a/test/continuation.test.ts
+++ b/test/continuation.test.ts
@@ -52,6 +52,7 @@ const {
   AUTOMATIC_HANDOVER_TTL_MS,
   CONTINUATION_TTL_MS,
   abortContinuation,
+  abortContinuationSourceBeforeSendNow,
   attachSummary,
   beginContinuationDestinationSendNow,
   beginContinuationSourceSendNow,
@@ -143,6 +144,32 @@ async function readyContinuation(): Promise<{ sessionId: string; token: string }
 }
 
 describe('capturing the brief', () => {
+  it('aborts only while the source checkpoint still proves no prompt was sent', async () => {
+    const untouched = await createSession({ title: 'untouched source', conversationId: CHAT_A });
+    const untouchedContinuation = await openContinuationNow(untouched.id, CHAT_A, true);
+    expect(await abortContinuationSourceBeforeSendNow(untouchedContinuation.token, 'handoff_never_sent')).toBe(true);
+    expect(continuationByToken(untouchedContinuation.token)).toMatchObject({
+      state: 'aborted',
+      error: 'handoff_never_sent'
+    });
+
+    const claimed = await createSession({ title: 'claimed source', conversationId: CHAT_B });
+    const claimedContinuation = await openContinuationNow(claimed.id, CHAT_B, true);
+    expect((await beginContinuationSourceSendNow(claimedContinuation.token))?.allowed).toBe(true);
+    expect(await abortContinuationSourceBeforeSendNow(claimedContinuation.token, 'handoff_never_sent')).toBe(true);
+    expect(continuationByToken(claimedContinuation.token)?.state).toBe('aborted');
+
+    const armed = await createSession({ title: 'armed source', conversationId: CHAT_C });
+    const armedContinuation = await openContinuationNow(armed.id, CHAT_C, true);
+    expect((await beginContinuationSourceSendNow(armedContinuation.token))?.allowed).toBe(true);
+    expect(await dispatchContinuationSourceSendNow(armedContinuation.token)).toBe(true);
+    expect(await abortContinuationSourceBeforeSendNow(armedContinuation.token, 'handoff_never_sent')).toBe(false);
+    expect(continuationByToken(armedContinuation.token)).toMatchObject({
+      state: 'awaiting-summary',
+      sourceSend: { state: 'dispatched-unresolved' }
+    });
+  });
+
   it('answers a repeated capture with the handoff it already wrote', async () => {
     const summary = await createSession({ title: 'work', conversationId: CHAT_A });
     const opened = await openContinuationNow(summary.id, CHAT_A);

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1277,7 +1277,7 @@ describe('worker settings authority', () => {
     expect(posted).toEqual([{ autoCompact: false, conversationId: CHAT }]);
   });
 
-  it('forwards compaction ticket and both irreversible dispatch checkpoints', async () => {
+  it('forwards compaction ticket, safe source loss, and both irreversible dispatch checkpoints', async () => {
     const posted: Record<string, unknown>[] = [];
     const fetch = vi.fn(async (input: string, init: Record<string, unknown> = {}) => {
       const url = new URL(input);
@@ -1295,11 +1295,13 @@ describe('worker settings authority', () => {
     const token = '0123456789abcdef0123456789abcdef';
 
     await worker.send({ type: 'compact', conversationId: CHAT, ticket: true, automatic: true }, 44);
+    await worker.send({ type: 'compact', conversationId: CHAT, token, sourceLost: true }, 44);
     await worker.send({ type: 'compact', conversationId: CHAT, token, sourceDispatch: true }, 44);
     await worker.send({ type: 'compact', conversationId: CHAT, token, destinationDispatch: true }, 44);
 
     expect(posted).toEqual([
       expect.objectContaining({ conversationId: CHAT, ticket: true, automatic: true }),
+      expect.objectContaining({ conversationId: CHAT, token, sourceLost: true }),
       expect.objectContaining({ conversationId: CHAT, token, sourceDispatch: true }),
       expect.objectContaining({ conversationId: CHAT, token, destinationDispatch: true })
     ]);


### PR DESCRIPTION
Closes #126.

## What this fixes

Prevents automatic Compact & Resume from cycling through reload/recovery when ChatGPT restores an occupied or stale composer draft and the source handoff is rejected before Send.

The failure looked like:

- context crosses the auto-compaction threshold;
- COS files an automatic ticket;
- `[[CLF-HANDOFF:...]]` insertion is rejected because the composer already contains restored text;
- the ticket stays open;
- pickup reloads the same chat;
- ChatGPT restores the same draft;
- the same pre-Send rejection repeats.

The existing per-ticket watchdog is bounded, but because auto-compaction is level-triggered the same working turn could file another ticket after the previous one was abandoned.

## Changes

- **Content script:** distinguish a persistent occupied composer from transient DOM/composer loss.
  - Preserve ordinary user drafts.
  - Preserve same-token edits.
  - Clear only a proven stale COS-owned `CLF-HANDOFF` / `CLF-RESUME` draft with a different token and canonical COS text.
  - Report `sourceLost` when an automatic ticket is blocked before Send by a persistent other draft.

- **Continuation WAL:** add `abortContinuationSourceBeforeSendNow()`.
  - Allowed only while the source checkpoint still proves no Send happened (`not-attempted` / `attempted-unresolved`).
  - Refused after `sourceDispatch`, preserving at-most-once semantics.

- **Bridge:** handle `/compact { sourceLost: true }` durably.
  - Return retryable failure if the terminal WAL write cannot persist.
  - Clear the compaction watch/repair only after successful durable abort.

- **Auto-compaction scheduler:** fence the rejected automatic compaction for the current working turn.
  - More observations from that same turn cannot immediately file a new token.
  - A real turn boundary clears the fence and allows later compaction normally.

- **Extension worker:** forward the new `sourceLost` checkpoint.

## Safety properties

This intentionally does **not** broaden generic composer clearing or generic cancellation:

- user text remains untouched;
- transient missing/replaced composer failures remain recoverable;
- stale cleanup requires a COS marker, canonical COS instruction, and a different token;
- once `sourceDispatch` has been crossed, `sourceLost` is rejected rather than cancelling an ambiguous send.

## Tests

Added regressions for:

- persistent user draft -> durable pre-Send retirement without modifying the draft;
- transient missing composer -> ticket remains recoverable;
- stale COS draft -> clear stale text and reach the current send fence;
- durable source abort only before dispatch;
- no immediate auto-refile in the same working turn;
- re-arm after a genuine turn boundary;
- background forwarding of `sourceLost`.

## Validation

Validated on the 2.0.8 tree on macOS arm64:

- `npm run typecheck` ✅
- focused compaction/content/continuation/extension suites ✅
- `npm test` ✅ — **3335 passed, 106 skipped, 0 failed**
- production build ✅
- packaged macOS arm64 bundle/runtime smoke checks ✅

A locally packaged 2.0.8 build with this patch was also installed and run on the affected machine.
