### PR TITLE
Stop the Linux DEB smoke failing on its own teardown

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,21 @@ jobs:
         run: |
           set -euo pipefail
           deb_smoke_root="$(mktemp -d)"
-          trap 'rm -rf "$deb_smoke_root"' EXIT
+          cleanup_path_with_retries() {
+            target="$1"
+            for attempt in 1 2 3 4 5; do
+              rm -rf "$target" 2>/dev/null && return 0
+              sleep 0.2
+            done
+            # Cleanup is not product evidence, the same rule the AppImage smoke below follows.
+            # `timeout` signals xvfb-run rather than the process tree beneath it, so an Electron
+            # helper can still be writing into the sandbox here, and `rm -rf` over a directory
+            # that is still gaining entries fails with "Directory not empty". Under `set -e`
+            # that teardown race outranked a smoke test whose own assertions had all passed,
+            # and skipped the release assembly with every package job green.
+            rm -rf "$target" 2>/dev/null || true
+          }
+          trap 'cleanup_path_with_retries "$deb_smoke_root"' EXIT
           mkdir -p \
             "$deb_smoke_root/home" \
             "$deb_smoke_root/config" \

--- a/test/packaging.test.ts
+++ b/test/packaging.test.ts
@@ -233,7 +233,11 @@ describe('cross-platform packaging targets', () => {
     expect(workflow).toContain("grep -Fxq 'Name=Chat On Steroids' \"$desktop\"");
     expect(workflow).toContain("grep -Fxq 'Icon=chat-on-steroids' \"$desktop\"");
     expect(debGui).toContain('deb_smoke_root="$(mktemp -d)"');
-    expect(debGui).toContain("trap 'rm -rf \"$deb_smoke_root\"' EXIT");
+    // Same shape the AppImage smoke below is held to: the teardown may retry, and may fail,
+    // but it may never decide the step. Only the assertions under it do that.
+    expect(debGui).toContain('cleanup_path_with_retries()');
+    expect(debGui).toContain("trap 'cleanup_path_with_retries \"$deb_smoke_root\"' EXIT");
+    expect(debGui).toContain('rm -rf "$target" 2>/dev/null || true');
     expect(debGui).toContain('HOME="$deb_smoke_root/home"');
     expect(debGui).toContain('XDG_CONFIG_HOME="$deb_smoke_root/config"');
     expect(debGui).toContain('XDG_CACHE_HOME="$deb_smoke_root/cache"');


### PR DESCRIPTION
Fixes #129.

### The failure

`Package Linux x64` fails **after** its smoke test has passed. All three required log lines are present, no renderer error, and then:

```
[info] app started
[info] renderer state ready
[info] window loaded
rm: cannot remove '/tmp/tmp.vFazdhiPWK/config/chat-on-steroids': Directory not empty
##[error]Process completed with exit code 1.
```

Second run, same job, different sandbox, same ending (`/tmp/tmp.8LD6aePKeX/config`).

Because `Assemble release candidate` has `needs: [package, sources]`, that one job skips it — so a release candidate with **every** package job green produced no assembled output and no `Chat-On-Steroids-Extension.zip`.

### Why

```bash
deb_smoke_root="$(mktemp -d)"
trap 'rm -rf "$deb_smoke_root"' EXIT
...
CLF_DEBUG=1 timeout --signal=TERM --kill-after=5s 45s xvfb-run -a /usr/bin/chat-on-steroids
```

`timeout` signals `xvfb-run`, not the process tree beneath it. An Electron helper can still be writing into `$XDG_CONFIG_HOME` when the trap fires immediately after the greps, and `rm -rf` walking a directory that is gaining entries fails with `Directory not empty`. Under `set -euo pipefail` that cleanup becomes the step's verdict.

It is timing-dependent, which is why it stays invisible until a runner is slow or the app has more to shut down.

### The change

This workflow already solves exactly this problem, twenty lines further down in the AppImage smoke, and already states the rule:

```bash
# Cleanup is not product evidence. A process that created one last profile file
# after the smoke already proved renderer readiness must not turn the release red.
rm -rf "$target" 2>/dev/null || true
```

So this is not a new idea, just the same `cleanup_path_with_retries` helper applied to the one sandbox that never got it — deliberately the identical shape and name, so a reader meets one idiom rather than two.

Every existing assertion still decides the outcome: the `status -ne 124` check, the three required log lines, and the renderer-failure check are untouched. The only thing that changes is that a teardown race can no longer outrank them.

### Verified

`bash -n` clean on the extracted step body; indentation and block-scalar structure unchanged.

Behaviourally: the same branch that failed this job twice in a row now completes it. Before and after runs are linked in the comment below.

### Note on the comment style

The added comment avoids the em dash used elsewhere in the codebase, because this file is otherwise plain ASCII.
