### PR TITLE
Give the three every-session callers every session

### DIFF
--- a/src/main/mcp/session-tool.ts
+++ b/src/main/mcp/session-tool.ts
@@ -13,7 +13,7 @@
 import { createHash } from 'node:crypto';
 import { z } from 'zod';
 import type { SessionEvent, SessionSummary, StoredText } from '../../shared/session.js';
-import { getSession, listAllSessions, readEvents } from '../session/store.js';
+import { getSession, readEverySummary, readEvents } from '../session/store.js';
 import { noteCount, noteDetail } from './call-context.js';
 import { expandStored, fail, guard, ok, type SurfaceRegistrar, type ToolResult } from './kernel.js';
 
@@ -189,7 +189,11 @@ async function searchSessions(queryInput?: string, cursorInput?: string): Promis
     offset = cursor.offset;
   }
 
-  const sessions = await listAllSessions();
+  // The bounded list would make the two answers below lie: past the cap this reports
+  // "No older recorded sessions remain" and search_complete to the model while older
+  // sessions exist. It is also the cheaper path once the catalog is warm, since it reads
+  // the in-process catalog instead of a readdir plus a meta read per folder.
+  const sessions = await readEverySummary();
   if (sessions.length === 0) return ok('No recorded sessions exist on this machine yet.');
   if (offset >= sessions.length) return ok('No older recorded sessions remain.\nsearch_complete: true');
 

--- a/src/main/session/correlation.ts
+++ b/src/main/session/correlation.ts
@@ -25,7 +25,7 @@
  */
 
 import { readDurable, writeDurableSoon } from '../durable.js';
-import { listAllSessions, readRecentEvents } from './store.js';
+import { readEverySummary, readRecentEvents } from './store.js';
 
 export interface RequestCorrelation {
   requestId: string;
@@ -217,7 +217,12 @@ async function restoreRequestCorrelationsOnce(): Promise<void> {
   // is idempotent for the same conversation and still makes contradictions sticky.
   let sessions;
   try {
-    sessions = await listAllSessions();
+    // Every retained session, not the bounded list. This decides which conversation owns a
+    // request id, and `readAllSummaries()` behind `listAllSessions()` stops at
+    // MAX_SCANNED_SESSIONS and says so in its own doc comment: do not use it for identity.
+    // Past that cap it answers "no such session" for a session that exists, and the request
+    // is then reconciled against whatever else claims it.
+    sessions = await readEverySummary();
   } catch (error) {
     // A valid direct snapshot can be restored before the session store is initialized (some
     // tests and narrowly scoped consumers do exactly that). In the real app the store is ready

--- a/src/main/session/recorder.ts
+++ b/src/main/session/recorder.ts
@@ -46,7 +46,7 @@ import {
   endSession,
   findSessionByConversation,
   getSession,
-  listAllSessions,
+  readEverySummary,
   readAsset,
   readEvents,
   readRecentEvents,
@@ -866,7 +866,9 @@ export async function repairDeterministicAttribution(): Promise<{ sessions: numb
   let repairedSessions = 0;
   let repairedCalls = 0;
 
-  for (const summary of await listAllSessions()) {
+  // Every Unattributed session, not a bounded page: this sweep promises to repair all of
+  // them, and one it cannot see is one it silently leaves misattributed forever.
+  for (const summary of await readEverySummary()) {
     if (summary.conversationId !== null || summary.title !== 'Unattributed activity') continue;
     const events = await readEvents(summary.id);
     const scannedThroughSeq = events.reduce((highest, event) => Math.max(highest, event.seq), 0);

--- a/src/main/session/store.ts
+++ b/src/main/session/store.ts
@@ -1788,7 +1788,7 @@ async function readAllSummaries(): Promise<SessionSummary[]> {
  * folder after an arbitrary cap can resume the wrong work. Keep the expensive path explicit
  * and use it only where "every session" is part of the contract.
  */
-async function readEverySummary(): Promise<SessionSummary[]> {
+export async function readEverySummary(): Promise<SessionSummary[]> {
   const catalog = await ensureAttachmentCatalog();
   const summaries = new Map<string, SessionSummary>();
   for (const summary of catalog.summaries.values()) summaries.set(summary.id, summary);


### PR DESCRIPTION
`readAllSummaries()` documents what it must not be used for:

> Legacy/model-facing bounded list. Do not use this for correctness properties that promise to see every retained session; **identity**, latest-handoff recovery and retention use the uncapped process catalog instead.

`listAllSessions()` wraps it, and every one of its three callers is a property that sentence excludes.

| caller | what the cap does to it |
|---|---|
| `reconcileRequestCorrelations()` (new in #134) | decides which conversation owns a request id; past the cap an existing session answers "no such session" |
| `repairDeterministicAttribution()` | promises to repair every Unattributed session; one it cannot see stays misattributed, and the sweep is idempotent so no later run reaches it |
| `session_search` | reports `search_complete: true` and "No older recorded sessions remain" from `sessions.length` — telling the model the history is exhausted while older sessions exist |

All three now use `readEverySummary()`, the uncapped catalog that same comment points to. It is exported for this; nothing else changes.

For `session_search` it is also the cheaper path once the catalog is warm — the in-process catalog instead of a `readdir` plus a `readMeta` per folder.

### Verified

`npm run typecheck` clean. Full suite 3434 passed; the four failures are `renderer-usage` (locale-dependent number formatting) and one `mcp` shell test, which fail identically on unmodified `main` on this Windows machine and pass in CI.

### Why there is no new test

Reproducing the defect needs a store with more than `MAX_SCANNED_SESSIONS` session folders, which is not something to build in a unit test. The change is argued from the contract the code states about itself, and the three call sites are named in that contract.