### PR TITLE
Carry destinationLost across the relay it was being dropped in

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -2414,6 +2414,49 @@ function isChatGptUrl(value) {
 /** Serializes every ownership transition and owned side effect for one browser tab. */
 const tabOperationQueues = new Map();
 
+/**
+ * Which checkpoint fields may cross to the app, and what each one has to look like.
+ *
+ * Named in one list rather than eight hand-copied ternaries, because this body is rebuilt
+ * field by field and a field nobody remembered to list is dropped in silence with both ends
+ * of the feature looking correct. `destinationLost` did exactly that: content.js sends it and
+ * bridge.ts acts on it, so the page could prove a brief never left it and the app would have
+ * retired the lease and re-offered the brief at once — but the relay never carried the field,
+ * so that path could not run and the chat waited out the whole lease instead.
+ *
+ * Still an allowlist, not a passthrough: nothing reaches the app unless it is named here, and
+ * every field stays token-paired, because the field only says anything about the transaction
+ * the token names.
+ */
+const COMPACT_CHECKPOINT_FLAGS = [
+  'sourceAttempt',
+  'sourceDispatch',
+  'sourceLost',
+  'destinationAttempt',
+  'destinationDispatch',
+  'destinationLost'
+];
+const COMPACT_CHECKPOINT_TEXT = ['summary', 'sourceMessageId', 'destinationMessageId'];
+// Not a checkpoint of its own: it qualifies `sourceMessageId` by saying how far that exact
+// marked response has grown. Sent only alongside the field it describes, so a bare count can
+// never move a deadline by itself.
+const COMPACT_CHECKPOINT_COUNTS = { sourceProgress: 'sourceMessageId' };
+
+function compactCheckpointFields(message) {
+  if (!message || typeof message.token !== 'string') return {};
+  const fields = {};
+  for (const flag of COMPACT_CHECKPOINT_FLAGS) {
+    if (message[flag] === true) fields[flag] = true;
+  }
+  for (const name of COMPACT_CHECKPOINT_TEXT) {
+    if (typeof message[name] === 'string') fields[name] = message[name];
+  }
+  for (const [name, requires] of Object.entries(COMPACT_CHECKPOINT_COUNTS)) {
+    if (Number.isSafeInteger(message[name]) && typeof fields[requires] === 'string') fields[name] = message[name];
+  }
+  return Object.keys(fields).length > 0 ? { token: message.token, ...fields } : {};
+}
+
 function serializeTab(tab, operation) {
   if (!Number.isInteger(tab)) return operation();
   const prior = tabOperationQueues.get(tab) || Promise.resolve();
@@ -2824,31 +2867,7 @@ const HANDLERS = {
         // verbatim and only together: the app refuses a brief whose token does not name an
         // open continuation for this chat, which is what keeps some other tab's text from
         // ever becoming this session's handoff.
-        ...(typeof message.token === 'string' && typeof message.summary === 'string'
-          ? { token: message.token, summary: message.summary }
-          : {}),
-        ...(typeof message.token === 'string' && message.sourceAttempt === true
-          ? { token: message.token, sourceAttempt: true }
-          : {}),
-        ...(typeof message.token === 'string' && message.sourceLost === true
-          ? { token: message.token, sourceLost: true }
-          : {}),
-        ...(typeof message.token === 'string' && message.sourceDispatch === true
-          ? { token: message.token, sourceDispatch: true }
-          : {}),
-        ...(typeof message.token === 'string' && typeof message.sourceMessageId === 'string'
-          ? { token: message.token, sourceMessageId: message.sourceMessageId,
-              ...(Number.isSafeInteger(message.sourceProgress) ? { sourceProgress: message.sourceProgress } : {}) }
-          : {}),
-        ...(typeof message.token === 'string' && message.destinationAttempt === true
-          ? { token: message.token, destinationAttempt: true }
-          : {}),
-        ...(typeof message.token === 'string' && message.destinationDispatch === true
-          ? { token: message.token, destinationDispatch: true }
-          : {}),
-        ...(typeof message.token === 'string' && typeof message.destinationMessageId === 'string'
-          ? { token: message.token, destinationMessageId: message.destinationMessageId }
-          : {})
+        ...compactCheckpointFields(message)
       })
     });
     // Chat B, for this window. The app produced it inside this very request precisely so that

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1307,6 +1307,39 @@ describe('worker settings authority', () => {
     ]);
   });
 
+  it('carries destinationLost, and still refuses anything not on the checkpoint list', async () => {
+    const posted: Record<string, unknown>[] = [];
+    const fetch = vi.fn(async (input: string, init: Record<string, unknown> = {}) => {
+      const url = new URL(input);
+      if (url.pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
+      if (url.pathname === '/compact' && init.method === 'POST') {
+        posted.push(JSON.parse(String(init.body || '{}')));
+        return response(200, { ok: true });
+      }
+      return response(404, {});
+    });
+    const worker = loadWorker({ local: new FakeStorageArea(paired), session: new FakeStorageArea(), fetch,
+      tabsGet: async () => ({ id: 44, url: `https://chatgpt.com/c/${CHAT}` }) });
+    await worker.registerTab(44);
+    await worker.send({ type: 'bind', conversationId: CHAT }, 44);
+    const token = '0123456789abcdef0123456789abcdef';
+
+    // The page sends this and the app acts on it — it retires the lease and re-offers the brief
+    // to a fresh chat at once instead of waiting the lease out. The relay used to drop it.
+    await worker.send({ type: 'compact', conversationId: CHAT, token, destinationLost: true }, 44);
+    // A field nobody named must not ride along on a valid token.
+    await worker.send({ type: 'compact', conversationId: CHAT, token, sourceLost: true, invented: true }, 44);
+    // And a checkpoint without its token says nothing about any transaction.
+    await worker.send({ type: 'compact', conversationId: CHAT, destinationLost: true }, 44);
+
+    expect(posted).toHaveLength(3);
+    expect(posted[0]).toMatchObject({ conversationId: CHAT, token, destinationLost: true });
+    expect(posted[1]).toMatchObject({ conversationId: CHAT, token, sourceLost: true });
+    expect(posted[1]).not.toHaveProperty('invented');
+    expect(posted[2]).not.toHaveProperty('destinationLost');
+    expect(posted[2]).not.toHaveProperty('token');
+  });
+
   it.each(['new-chat', 'other-chat', 'pending-navigation'])('checks the current Chrome route for compaction after %s', async scenario => {
     const currentUrl = scenario === 'other-chat' ? 'https://chatgpt.com/c/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
       : `https://chatgpt.com/g/g-p-abcdef1234567890abcdef1234567890/c/${CHAT}`;


### PR DESCRIPTION
### The bug

`destinationLost` exists at both ends and nowhere in between:

| file | occurrences on `main` | |
|---|---|---|
| `extension/content.js` | 1 | the page **sends** it |
| `extension/background.js` | **0** | the relay **drops** it |
| `src/main/bridge.ts` | 1 | the app **acts** on it |

What the app would have done with it:

> The page armed the click and then proved the brief never left it. The lease belongs to that page and is retired with it, and the same brief is offered to a fresh chat at once — not after the quarter-hour the lease was measured for […]

That path cannot run today. The chat waits out the whole lease instead, and both ends look correct while it does.

### The change

The relay forwarded checkpoints as eight hand-copied ternaries, rebuilt field by field. `destinationLost` was simply never added to it, and that shape is one where the next field goes missing the same silent way.

Replaced with a named allowlist: a field is either listed or it is not carried, and adding one is a single line. It stays an allowlist rather than a passthrough, and every field stays token-paired — a checkpoint says something only about the transaction its token names, so a field arriving without one is still not forwarded.

Net effect on the file is about even: ~25 lines of list and helper for ~30 lines of ternaries.

### Verified

Fails before the change:

```
× carries destinationLost, and still refuses anything not on the checkpoint list
  AssertionError: expected { …(6) } to match object { …(3) }
```

Passes after. The test also pins the two properties the allowlist exists for: an unnamed field does not ride along on a valid token, and no checkpoint crosses without one.

`node --check` clean on the extension worker. Full suite 3435 passed; the four failures are `renderer-usage` (locale-dependent number formatting) and one `mcp` shell test, which fail identically on unmodified `main` on this Windows machine and pass in CI.