### PR TITLE
Add a browser tool: ChatGPT can drive a real web page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,12 +350,18 @@ jobs:
       - name: Package standalone extension
         run: |
           set -euo pipefail
-          (cd extension && zip -qr ../release/Chat-On-Steroids-Extension.zip . -x '*.map')
+          (cd extension && zip -qr ../release/Chat-On-Steroids-Extension.zip . -x '*.map' -x '*.d.ts')
           zip -q release/Chat-On-Steroids-Extension.zip LICENSE
           node -e "const m=require('./extension/manifest.json'),p=require('./package.json');if(m.version!==p.version)throw new Error('Extension '+m.version+' does not match app '+p.version)"
-          for required in manifest.json background.js chatgpt-dom.js content.js fiber.js overlay.css popup.html popup.css popup.js icons/icon16.png icons/icon32.png icons/icon48.png icons/icon128.png LICENSE; do
+          for required in manifest.json background.js browser-driver.js chatgpt-dom.js content.js fiber.js overlay.css popup.html popup.css popup.js icons/icon16.png icons/icon32.png icons/icon48.png icons/icon128.png LICENSE; do
             unzip -Z1 release/Chat-On-Steroids-Extension.zip | grep -Fxq "$required" || { echo "Extension zip missing $required" >&2; exit 1; }
           done
+          # And nothing that only exists for the build: a stray declaration file here means the
+          # published add-on ships something a browser cannot run.
+          if unzip -Z1 release/Chat-On-Steroids-Extension.zip | grep -q '\.d\.ts$'; then
+            echo "Extension zip carries TypeScript declarations" >&2
+            exit 1
+          fi
 
       - name: Create SHA-256 checksums
         run: |

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -37,6 +37,9 @@ extraResources:
     filter:
       - '**/*'
       - '!**/*.map'
+      # Type declarations describe the driver for this repository's own tooling. A browser
+      # has no use for them and a shipped extension should carry nothing it cannot run.
+      - '!**/*.d.ts'
 
 npmRebuild: false
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -20,6 +20,8 @@
  * record the app has not accepted yet.
  */
 
+import * as browserDriverModule from './browser-driver.js';
+
 const PORTS = [8765, 8766, 8767, 8768, 8769];
 const HELLO_TIMEOUT_MS = 1200;
 const REQUEST_TIMEOUT_MS = 10_000;
@@ -3090,8 +3092,98 @@ const HANDLERS = {
     // response itself was lost; the outbox is now the sole retry path.
     await forgetDeferredRevival(message.id);
     return result;
+  },
+
+  /**
+   * Browser control, which lives here because the worker is the only part of the extension
+   * allowed to hold a debugger session — the same reason it is the only part that holds the
+   * pairing token. A content script asks; it never drives.
+   *
+   * Loaded on first use rather than imported at the top. The worker is started for every
+   * ordinary observation and almost none of those touch a browser session, so the driver
+   * should not be on that path; and this file is also evaluated as a plain script by its own
+   * tests, where a static import is a parse error.
+   */
+  async browser_status() {
+    const driver = await browserControl();
+    return { ok: true, granted: await driver.hasBrowserPermissions(), ...(await driver.browserDriver.status()) };
+  },
+  async browser_attach(message) {
+    return browserResult(async (driver) => driver.browserDriver.attach(Number(message.tabId)), 'BROWSER_ATTACH_FAILED');
+  },
+  async browser_detach() {
+    const driver = await browserControl();
+    return { ok: true, ...(await driver.browserDriver.detach()) };
+  },
+  async browser_act(message) {
+    return browserResult(
+      async (driver) => ({ result: await driver.browserDriver.act(message.action) }),
+      'BROWSER_ACTION_FAILED'
+    );
+  },
+  /**
+   * Reports a browser action's outcome back to the app.
+   *
+   * Through the worker because the pairing token lives here and never in a content script —
+   * the same reason every other route the page needs is proxied rather than called directly.
+   */
+  async browser_result(message) {
+    await load();
+    try {
+      return await call('/browser/result', {
+        method: 'POST',
+        body: JSON.stringify({
+          conversationId: String(message.conversationId || ''),
+          id: String(message.id || ''),
+          ok: message.ok === true,
+          data: message.data,
+          error: message.error,
+          detail: message.detail
+        })
+      });
+    } catch (error) {
+      return { ok: false, error: 'bridge_unreachable', detail: String(error?.message ?? error) };
+    }
+  },
+  async browser_observe(message) {
+    return browserResult(
+      async (driver) => driver.browserDriver.observe({ includeScreenshot: message.includeScreenshot !== false }),
+      'BROWSER_OBSERVE_FAILED'
+    );
   }
 };
+
+/**
+ * The browser driver, loaded once and only when something actually asks for it.
+ *
+ * Statically imported, because a service worker may not do otherwise: dynamic `import()` is
+ * disallowed on ServiceWorkerGlobalScope by specification, and Chrome refuses it at runtime with
+ * exactly that message. It was dynamic here to keep the module off the hot path of ordinary
+ * observation and to let this file parse where a test evaluates it as a classic script — and
+ * that second reason quietly cost the whole feature: every browser_* message failed in a real
+ * browser while the tests, which never execute an import, stayed green. The test harness stubs
+ * the module now; the product does what the platform allows.
+ */
+let browserLifecycleInstalled = false;
+async function browserControl() {
+  if (!browserLifecycleInstalled) {
+    browserLifecycleInstalled = true;
+    // Registered on first use rather than at load: a session the browser tears down — a closed
+    // tab, Cancel on the debugging banner, DevTools opening — must not leave this worker
+    // believing it still owns one.
+    browserDriverModule.installBrowserDriverLifecycle();
+  }
+  return browserDriverModule;
+}
+
+async function browserResult(run, fallbackCode) {
+  try {
+    const driver = await browserControl();
+    return { ok: true, ...(await run(driver)) };
+  } catch (error) {
+    return { ok: false, error: error?.code ?? fallbackCode, detail: String(error?.message ?? error) };
+  }
+}
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   const handler = message && typeof message.type === 'string' ? HANDLERS[message.type] : null;
@@ -3580,6 +3672,10 @@ if (chrome.alarms && chrome.alarms.onAlarm && typeof chrome.alarms.onAlarm.addLi
       .then(() => drain())
       .then(() => drainCloses())
       .then(() => maintain())
+      // Catches a "Chat On Steroids" tab group left behind by a session this worker no longer
+      // remembers - the MV3 recycle case sweepStaleDrivenGroups exists for - even when nothing
+      // ever attaches again to trigger the other place it runs.
+      .then(() => browserDriverModule.sweepStaleDrivenGroups())
       .catch(() => undefined)
       .then(() => {
         // Re-armed here and nowhere else. Every other caller of scheduleRetry() finds the

--- a/extension/browser-driver.d.ts
+++ b/extension/browser-driver.d.ts
@@ -1,0 +1,99 @@
+/**
+ * The browser driver's contract.
+ *
+ * The extension ships as plain JavaScript because that is what a browser loads, but the app's
+ * tests and tooling are typed, and a driver that can click and type on any page is the last
+ * place to leave a shape implicit.
+ */
+
+export declare class BrowserDriverError extends Error {
+  code: string;
+}
+
+export declare const DRIVEN_GROUP_TITLE: string;
+export declare const REFUSED_HOSTS: string[];
+export declare const BROWSER_PERMISSIONS: { permissions: string[]; origins: string[] };
+export declare const COLLECT_SOURCE: string;
+export declare const MODIFIERS: Record<string, number>;
+
+/** Whether browser control refuses to attach to this page at all. */
+export declare function refusedUrl(url: unknown): boolean;
+
+/** False where the browser exposes no DevTools protocol to extensions. */
+export declare function browserControlSupported(): Promise<boolean>;
+export declare function hasBrowserPermissions(): Promise<boolean>;
+/** Must be called from a user gesture; Chrome refuses the prompt otherwise. */
+export declare function requestBrowserPermissions(): Promise<boolean>;
+
+export declare function cdpButton(name?: unknown): 'left' | 'right' | 'middle' | 'back' | 'forward';
+export declare function buttonMask(name?: unknown): number;
+export declare function keyDescriptor(name: string): {
+  key: string;
+  code?: string;
+  vk: number;
+  text?: string;
+};
+
+export interface BrowserSessionStatus {
+  attached: boolean;
+  tabId: number | null;
+  url: string | null;
+  title: string | null;
+  /** The driven-tab group, when one is held — the blue band a person sees above the tab. */
+  groupId?: number | null;
+}
+
+export interface BrowserElement {
+  /** Name this in a ref action; only the newest observation's refs are addressable. */
+  ref: string;
+  role: string;
+  name: string;
+  value: string;
+  disabled: boolean;
+  checked: string;
+  /** Centre of the element, in CSS pixels — the same space input and screenshots use. */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface BrowserObservation {
+  tabId: number;
+  url: string;
+  title: string;
+  viewport: { width: number; height: number };
+  scrollY: number;
+  scrollHeight: number;
+  elements: BrowserElement[];
+  /** Base64 PNG in which one pixel is one CSS pixel, or null when not requested. */
+  screenshot: { data: string; width: number; height: number } | null;
+}
+
+export type BrowserAction =
+  | { type: 'navigate'; url: string }
+  | { type: 'back' | 'forward' | 'reload' }
+  | { type: 'move'; x: number; y: number; modifiers?: string[] }
+  | { type: 'click' | 'double_click'; x: number; y: number; button?: string; modifiers?: string[] }
+  | { type: 'drag'; path: Array<{ x: number; y: number }>; button?: string; modifiers?: string[] }
+  | { type: 'scroll'; x: number; y: number; scroll_x?: number; scroll_y?: number; modifiers?: string[] }
+  | { type: 'type'; text: string }
+  | { type: 'keypress'; keys: string[]; modifiers?: string[] }
+  | { type: 'wait'; ms?: number }
+  | { type: 'click_ref'; ref: string; button?: string }
+  | { type: 'set_value'; ref: string; text: string };
+
+export declare const browserDriver: {
+  status(): Promise<BrowserSessionStatus>;
+  ensureAttached(openUrl?: string | null): Promise<void>;
+  assertPageStillAllowed(): Promise<void>;
+  attach(tabId: number): Promise<BrowserSessionStatus>;
+  detach(): Promise<BrowserSessionStatus>;
+  forget(tabId: number): void;
+  act(action: BrowserAction): Promise<Record<string, unknown>>;
+  /** Where a ref points now — refused rather than guessed when the element has gone. */
+  resolveRef(ref: string): Promise<{ x: number; y: number }>;
+  observe(options?: { includeScreenshot?: boolean }): Promise<BrowserObservation>;
+};
+
+export declare function installBrowserDriverLifecycle(): void;

--- a/extension/browser-driver.js
+++ b/extension/browser-driver.js
@@ -1,0 +1,2106 @@
+/**
+ * Browser control through the DevTools protocol.
+ *
+ * The Desktop driver already controls a browser: it moves the real pointer and posts real
+ * keystrokes at the operating-system level. What it cannot do is *see* a web page. Chromium
+ * keeps its renderer accessibility tree switched off until a real assistive client asks for
+ * it, so a UIA/AX walk of a browser window returns the toolbar, the tabs and one opaque pane
+ * where the page is. Measured against a full traversal of a live Chromium window: sixty-three
+ * elements, every one of them browser chrome, not a single node of page content.
+ *
+ * Inside a web page the Desktop driver is therefore reduced to pixels and guesswork, which is
+ * exactly where `click_ref` and `set_value` — the two things that make this product better
+ * than coordinate-poking — stop being available. This file closes that gap, and it is
+ * browser-level rather than OS-level, so it works the same on every platform and on a window
+ * that is not even in the foreground.
+ *
+ * ## Why the debugger permission
+ *
+ * Events a content script dispatches carry `isTrusted: false`. Real pages reject them for
+ * anything that matters: file pickers, drag and drop, and any framework that guards against
+ * synthetic input. A driver built that way works on simple pages and fails silently on the
+ * hard ones, which is worse than not having it at all.
+ *
+ * `chrome.debugger` is the only route to `isTrusted: true` from an extension. It costs a
+ * permanent, unmissable "…is debugging this browser" banner on every driven tab. That banner
+ * is not a wart to be minimised — it is the honest signal that something other than the
+ * person at the keyboard is driving. This module deliberately adds two more: driven tabs are
+ * collected into a visibly named tab group, and a pointer overlay shows where the model acts.
+ *
+ * ## The coordinate invariant
+ *
+ * One rule, chosen so that a whole class of bugs cannot exist: **one screenshot pixel is one
+ * CSS pixel is one input unit.** Screenshots are taken with an explicit clip at `scale: 1`
+ * over the CSS visual viewport, so a coordinate read off the returned image is already the
+ * coordinate `Input.dispatchMouseEvent` wants. There is no device-pixel-ratio arithmetic
+ * anywhere in this file, on any display, at any zoom level.
+ */
+
+/** Tab group title. Deliberately the product name: the user must recognise it instantly. */
+export const DRIVEN_GROUP_TITLE = 'Chat On Steroids';
+
+/**
+ * Pages this driver refuses to attach to, whatever it is asked.
+ *
+ * ChatGPT itself is first, for a reason worth stating plainly: the model asking for browser
+ * control is *in* a ChatGPT tab, and a driver able to attach there could drive its own
+ * conversation — send messages as the user, answer its own confirmations, or read another
+ * conversation the person has open in a second tab. That is the single most dangerous thing
+ * this capability could do, so it is refused at the lowest level rather than anywhere it
+ * could later be forgotten.
+ *
+ * The browser's own surfaces are refused because a debugger session there reaches settings,
+ * stored credentials and other extensions. `file:` is refused because a page that can be
+ * driven should not also be a filesystem reader.
+ */
+export const REFUSED_HOSTS = ['chatgpt.com', 'chat.openai.com'];
+
+/** The only two schemes a driven page may use. Everything else is refused by being absent. */
+const DRIVABLE_SCHEMES = ['http:', 'https:'];
+
+/**
+ * The modifier that means "select all" on this machine.
+ *
+ * CDP modifier bits are 1 Alt, 2 Ctrl, 4 Meta. This was hardcoded to Meta, which is Cmd on a Mac
+ * and the Windows key everywhere else — so off macOS nothing was selected, and set_value then
+ * inserted at the caret instead of replacing: a field holding "abc" became "abcxyz". Clearing
+ * was worse, because the lone Delete with no selection removed a single character forward.
+ */
+const SELECT_ALL_MODIFIER = /Mac/i.test(globalThis.navigator?.userAgent ?? '') ? 4 : 2;
+
+/** How long any single protocol command may take before the driver gives up on it. */
+const COMMAND_TIMEOUT_MS = 15_000;
+/** Navigation gets longer, but never unbounded. */
+const NAVIGATE_TIMEOUT_MS = 30_000;
+/**
+ * Two operations answer only once the renderer has composited, and get longer for it.
+ *
+ * `Page.captureScreenshot` replies when a frame is produced, and a wheel event is acknowledged
+ * after the compositor's input pipeline has taken it. Neither is a fixed cost: a tab that is
+ * not compositing — backgrounded, occluded, or simply idle with nothing animating — can take
+ * seconds, and both were measured taking longer than ten in a real browser run. Holding them
+ * to the ordinary command deadline turns "the page was quiet" into a failure, which is the
+ * opposite of what the caller asked about. Clicks and keystrokes are acknowledged directly and
+ * keep the ordinary deadline.
+ */
+const COMPOSITOR_TIMEOUT_MS = 30_000;
+/**
+ * How long a scroll may wait before the position is read instead.
+ *
+ * Scrolling is judged by whether the page moved, so waiting the full compositor budget buys
+ * nothing: two failed attempts cost a minute of a run in which nothing happened, measured.
+ */
+const SCROLL_TIMEOUT_MS = 5_000;
+/**
+ * How long a scroll's move-detection waits for the position to start changing, once a dispatch
+ * call has returned — acknowledged or timed out. Separate from SCROLL_TIMEOUT_MS: that budget
+ * belongs to the protocol round trip, this one to a page that is merely slow to apply what it
+ * already accepted.
+ */
+const SCROLL_ONSET_TIMEOUT_MS = 1_000;
+/** Upper bound on elements one observation returns, so a huge page cannot flood the model. */
+const MAX_ELEMENTS = 200;
+
+/**
+ * How long a link click is given to move the page before the answer says it did not.
+ *
+ * Long enough for an ordinary same-origin navigation to commit — the check is on the address
+ * changing, not on the load finishing — and short enough that it is not felt on a click that was
+ * never going to navigate. Only spent on a click that resolved to a real destination.
+ */
+const CLICK_NAVIGATION_MS = 1500;
+/**
+ * How long a drag holds the button down before moving, and hovers before letting go.
+ *
+ * The same two numbers both desktop drivers use, for the same reason: a press and a release in
+ * the same instant is a click, and neither an HTML5 drag nor a hover-armed drop target ever
+ * starts. Copied deliberately rather than re-derived, so all three drivers behave alike.
+ */
+const DRAG_PRESS_HOLD_MS = 90;
+const DRAG_DROP_DWELL_MS = 140;
+
+const pause = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export class BrowserDriverError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'BrowserDriverError';
+    this.code = code;
+  }
+}
+
+const fail = (code, message) => new BrowserDriverError(code, message);
+
+export function refusedUrl(url) {
+  const value = String(url ?? '').trim();
+  // An address that cannot be read is refused, not allowed. Chrome answers `tab.url` with
+  // undefined for any tab the extension has no access to, and a refusal that misses there would
+  // quietly stop applying to the tabs it must cover. A tab whose address is unknown is a tab
+  // that cannot be shown safe to drive, which is the same answer.
+  if (!value) return true;
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    // Not an address at all. Same reasoning as above.
+    return true;
+  }
+  // Everything but the ordinary web is refused by not being on this list, rather than by being
+  // on a list of what to reject. The rejection list was the bug: it matched `chrome:`, `file:`,
+  // `javascript:` and the rest by name, so any scheme nobody thought of — and any new one a
+  // browser adds — read as an ordinary page.
+  if (!DRIVABLE_SCHEMES.includes(parsed.protocol.toLowerCase())) return true;
+  // The host, parsed, not the start of the string.
+  //
+  // This was `/^https:\/\/chatgpt\.com/i`, and a string prefix is the wrong instrument for the
+  // most important rule in this file. `http://chatgpt.com/` did not match, and Chrome then
+  // redirects it to https with the session still attached; `https://user@chatgpt.com/` did not
+  // match either, because the userinfo sits where the host was expected. Meanwhile
+  // `https://sub.chatgpt.com/` was allowed and `https://chatgpt.com.example/` was refused —
+  // both backwards. Comparing the parsed host answers all four correctly at once.
+  const host = parsed.hostname.toLowerCase().replace(/\.$/, '');
+  return REFUSED_HOSTS.some((refused) => host === refused || host.endsWith(`.${refused}`));
+}
+
+/**
+ * The one tab this driver is attached to, or null.
+ *
+ * Deliberately one at a time. A driver holding several debugger sessions is a driver whose
+ * "stop" is ambiguous and whose banner no longer tells the user which tab is live.
+ */
+let session = null;
+
+/** Promise wrapper over the callback API, turning `lastError` into a typed failure. */
+function rawSend(tabId, method, params, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(fail('BROWSER_TIMEOUT', `${method} did not answer within ${timeoutMs} ms`));
+    }, timeoutMs);
+    const finish = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn(value);
+    };
+    try {
+      chrome.debugger.sendCommand({ tabId }, method, params, (result) => {
+        const error = chrome.runtime.lastError;
+        if (error) return finish(reject, fail('BROWSER_PROTOCOL_FAILED', `${method}: ${error.message}`));
+        finish(resolve, result ?? {});
+      });
+    } catch (error) {
+      finish(reject, fail('BROWSER_PROTOCOL_FAILED', `${method}: ${error?.message ?? String(error)}`));
+    }
+  });
+}
+
+function send(method, params = {}, timeoutMs = COMMAND_TIMEOUT_MS) {
+  if (!session) throw fail('BROWSER_NOT_ATTACHED', 'no tab is under browser control');
+  return rawSend(session.tabId, method, params, timeoutMs);
+}
+
+/**
+ * Collects a driven tab into one visibly named group.
+ *
+ * Purely an affordance for the person watching: the banner says *this tab* is being driven,
+ * the group says *these* are the tabs this session has touched. Failure is never fatal —
+ * losing the grouping must not cost the ability to stop — so it is attempted and forgotten.
+ */
+async function groupDrivenTab(tabId) {
+  try {
+    if (!chrome.tabs?.group || !chrome.tabGroups?.update) return null;
+    // A stray group from a session this worker no longer remembers (see sweepStaleDrivenGroups
+    // below) must not be left standing beside the one this call is about to create — that is
+    // exactly how two "Chat On Steroids" bands end up visible at once.
+    await sweepStaleDrivenGroups();
+    const groupId = await chrome.tabs.group({ tabIds: [tabId] });
+    await chrome.tabGroups.update(groupId, { title: DRIVEN_GROUP_TITLE, color: 'blue' });
+    return groupId;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Puts a released tab back where it was.
+ *
+ * The group is the visible answer to "is this tab being driven": a blue band labelled with the
+ * app's name, above the tab. It was created on attach and never removed, so every session left
+ * one behind — a tab still advertising that something is driving it when nothing is, and one
+ * more band in the tab strip for every run. The indicator that exists to be trusted was the one
+ * telling the untruth.
+ *
+ * Best effort by construction. Ungrouping needs a permission that is optional, the tab may have
+ * gone, and neither is a reason to fail letting go of it.
+ */
+async function ungroupDrivenTab(tabId, groupId) {
+  if (groupId === null || groupId === undefined) return;
+  try {
+    if (chrome.tabs?.ungroup) await chrome.tabs.ungroup(tabId);
+  } catch {
+    // The tab is gone, or grouping was never permitted. Either way there is nothing to undo.
+  }
+}
+
+/**
+ * Ungroups every "Chat On Steroids" band this worker is not currently using.
+ *
+ * `session` is the only record this module keeps of which group belongs to a live run, and it
+ * is plain memory — nothing survives an MV3 service worker being recycled, which Chrome does
+ * on its own after roughly thirty seconds of inactivity, restart or update entirely outside
+ * this driver's control. A restart mid-session, or between the last action and a person
+ * noticing the tab is still there, wipes `session` with no `detach` ever having run: the tab
+ * keeps its blue band with nothing left owning it, and it stays that way until something
+ * cleans it up, because nothing was going to run `ungroupDrivenTab` for a session this worker
+ * no longer remembers existed. This is that cleanup. It runs before every new group is created
+ * (so an orphan is never left standing beside a fresh one) and on the extension's own wake
+ * timer (so an orphan is still caught even if nothing ever attaches again). Never touches the
+ * tabs themselves — same as `detach`, only the grouping goes away, never the page.
+ */
+export async function sweepStaleDrivenGroups() {
+  if (!chrome.tabGroups?.query || !chrome.tabs?.query || !chrome.tabs?.ungroup) return;
+  let groups;
+  try {
+    groups = await chrome.tabGroups.query({ title: DRIVEN_GROUP_TITLE });
+  } catch {
+    return;
+  }
+  for (const group of groups) {
+    if (session && group.id === session.groupId) continue;
+    try {
+      const tabs = await chrome.tabs.query({ groupId: group.id });
+      const tabIds = tabs.map((tab) => tab.id).filter((id) => typeof id === 'number');
+      if (tabIds.length > 0) await chrome.tabs.ungroup(tabIds);
+    } catch {
+      // The group or its tabs may already be gone by the time this runs. Best effort, same as
+      // ungroupDrivenTab: there is nothing left to undo either way.
+    }
+  }
+}
+
+/**
+ * Makes the driven tab the one actually compositing, before an action whose correctness
+ * depends on it.
+ *
+ * A scroll gesture and a wheel event are both compositor work, and Chrome defers compositor
+ * work for a background tab rather than doing it immediately — a QA round measured this
+ * directly, with instrumentation: `visibilityState: hidden` turned a 388 ms, correctly-judged
+ * scroll into a 7275 ms timeout with the target's own `scrollLeft` still unmoved, and the
+ * instant the tab was activated afterward it jumped straight to *double* the requested
+ * distance — the gesture and its own wheel fallback, both delivered together the moment the
+ * tab could actually paint. The refusal that produces is honest about the instant it was
+ * measured and wrong a moment later, which is worse than either being right or explaining why.
+ *
+ * The same round measured a second, independent effect of the same cause: a link opened while
+ * its tab is backgrounded gets a new tab whose `openerTabId` names whichever tab actually *is*
+ * active — Chrome's own tab-creation attribution, not anything this driver controls — so
+ * `findCreatedTab`'s comparison against the driven tab's own id can never match. Widening its
+ * poll window would not have helped; the condition itself does not hold while backgrounded.
+ *
+ * `chrome.tabs.update({ active: true })` is tried first and alone, because the follow-up round
+ * that confirmed this fix also measured its cost: `chrome.windows.update({ focused: true })`
+ * does not just switch a Chrome tab, it switches the *macOS application* — measured directly,
+ * TextEdit frontmost to Chrome frontmost, 1191 ms. That takes real keystrokes away from
+ * whoever is typing, unlike the debugger banner, tab group and pointer overlay, none of which
+ * take anything from the person watching. `visibilityState` turns out to track only whether a
+ * tab is its *window's* active one and whether that window is open — not which macOS
+ * application is frontmost — so a later measurement found the ordinary "working in another
+ * app" case never needs to escalate at all: tab activation alone recovered visibility with
+ * TextEdit genuinely frontmost throughout. The one case that reliably does need it is a
+ * minimized Chrome window.
+ *
+ * `broughtToFront` reports whether that escalation was *attempted* without error — not whether
+ * `visibilityState` confirmed it within some poll afterward. Those used to be the same return
+ * value, and a minimized window's own un-minimize animation measured a reproducible 556–588 ms
+ * against a 300 ms poll, so the one case the field exists to name was exactly the case it
+ * reported wrong: the window came forward, the scroll worked, and `broughtToFront` still said
+ * `false`. The wait after escalating is now purely a courtesy — giving the caller's own action
+ * a real chance to see `visible` before proceeding — and is generous enough to usually see it,
+ * without being what the field means.
+ *
+ * Best-effort and bounded throughout: a tab that cannot be activated (closed mid-call, or a
+ * withdrawn permission) still gets to attempt the action rather than fail before it starts.
+ */
+async function ensureTabActive(tabId) {
+  const tab = await chrome.tabs.get(tabId).catch(() => null);
+  if (!tab) return { broughtToFront: false };
+
+  const waitVisible = async (ms) => {
+    const deadline = Date.now() + ms;
+    while (Date.now() < deadline) {
+      try {
+        const reply = await send('Runtime.evaluate', { expression: 'document.visibilityState', returnByValue: true });
+        if (reply?.result?.value === 'visible') return true;
+      } catch {
+        return false;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    return false;
+  };
+
+  try {
+    if (!tab.active) await chrome.tabs.update(tabId, { active: true });
+  } catch {
+    return { broughtToFront: false };
+  }
+  if (await waitVisible(300)) return { broughtToFront: false };
+
+  // The lighter fix was not enough — the window itself was not visible, which tab activation
+  // alone cannot reach. Pay the real cost only now that it is the thing missing.
+  //
+  // No windowId means no escalation is possible, not that one was tried and skipped — the
+  // earlier form fell through this case into the unconditional `return true` below, reporting
+  // a switch that never happened. The one thing broughtToFront exists to get right.
+  if (tab.windowId === undefined) return { broughtToFront: false };
+  try {
+    await chrome.windows.update(tab.windowId, { focused: true });
+  } catch {
+    return { broughtToFront: false };
+  }
+  // 900 ms, not 300: measured at 556-588 ms for a minimized window's own un-minimize animation
+  // on real hardware, so 300 reported this exact case wrong. This wait no longer decides
+  // broughtToFront — escalating without error already did — it only gives the action that
+  // follows a real chance to find the page visible before it runs.
+  await waitVisible(900);
+  return { broughtToFront: true };
+}
+
+/**
+ * A pointer the person can actually see.
+ *
+ * CDP input moves no real cursor, so without this the page reacts and nothing visibly causes
+ * it — the most unnerving way to watch a machine use your browser. The overlay lives in the
+ * page, so it also lands in screenshots for free and the model sees the same pointer the user
+ * does. It is `pointer-events: none` and must stay that way: an overlay that can swallow a
+ * click is an overlay that breaks the thing it illustrates.
+ */
+const POINTER_SOURCE = `(() => {
+  const ID = '__cos_pointer__';
+  let node = document.getElementById(ID);
+  if (!node) {
+    node = document.createElement('div');
+    node.id = ID;
+    node.setAttribute('aria-hidden', 'true');
+    node.style.cssText = [
+      'position:fixed', 'left:0', 'top:0', 'width:22px', 'height:22px',
+      'pointer-events:none', 'z-index:2147483647', 'margin:0', 'padding:0', 'border:0',
+      'transition:transform 90ms linear', 'will-change:transform'
+    ].join(';');
+    node.innerHTML =
+      '<svg width="22" height="22" viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">' +
+      '<path d="M4 2 L4 16 L8 12.5 L10.5 18 L13 17 L10.5 11.5 L16 11.5 Z" ' +
+      'fill="#fff" stroke="#111" stroke-width="1.5" stroke-linejoin="round"/></svg>';
+    (document.body || document.documentElement).appendChild(node);
+  }
+  return node;
+})()`;
+
+/**
+ * Where the overlay was last put, so it can be put back.
+ *
+ * The overlay lives in the document and a navigation replaces the document. It was drawn at
+ * attach and thereafter only by mouse actions, so navigate-then-look — the exact order the QA
+ * script asks for — found nothing, and the pointer the user watches vanished for every page
+ * change until something happened to move it.
+ */
+let pointerAt = { x: 0, y: 0, pressed: false };
+
+async function movePointer(x, y, pressed = false) {
+  pointerAt = { x, y, pressed };
+  try {
+    await send('Runtime.evaluate', {
+      expression:
+        `${POINTER_SOURCE}.style.transform = ` +
+        `'translate(${Math.round(x)}px, ${Math.round(y)}px) scale(${pressed ? 0.82 : 1})';`,
+      returnByValue: true
+    });
+  } catch {
+    // A page mid-navigation has no document to draw into. The action still stands; only its
+    // illustration is missing, and that is never a reason to fail the action.
+  }
+}
+
+/** Draws the overlay again wherever it last was, after a new document replaced it. */
+async function restorePointer() {
+  await movePointer(pointerAt.x, pointerAt.y, pointerAt.pressed);
+}
+
+async function removePointer() {
+  try {
+    await send('Runtime.evaluate', {
+      expression: "document.getElementById('__cos_pointer__')?.remove();",
+      returnByValue: true
+    });
+  } catch {
+    // Detaching anyway, and the overlay dies with the next navigation regardless.
+  }
+}
+
+/** The CSS visual viewport, which is the coordinate space every action in this file uses. */
+async function viewport() {
+  const metrics = await send('Page.getLayoutMetrics');
+  const visual = metrics.cssVisualViewport ?? metrics.visualViewport ?? {};
+  const layout = metrics.cssLayoutViewport ?? metrics.layoutViewport ?? {};
+  const width = Math.max(1, Math.round(visual.clientWidth ?? layout.clientWidth ?? 0));
+  const height = Math.max(1, Math.round(visual.clientHeight ?? layout.clientHeight ?? 0));
+  // Where the viewport sits in the document. Needed because a capture clip is given in document
+  // coordinates, not in viewport ones — see `screenshot`.
+  const x = Math.round(visual.pageX ?? layout.pageX ?? 0);
+  const y = Math.round(visual.pageY ?? layout.pageY ?? 0);
+  // The display's scale factor, from the two viewports the browser already reports: one measured
+  // in CSS pixels and one in device pixels. Derived rather than asked for, so it needs no script
+  // in the page and is right on a page that refuses to run any.
+  const devicePixels = Number(metrics.visualViewport?.clientWidth ?? 0);
+  const cssPixels = Number(visual.clientWidth ?? layout.clientWidth ?? 0);
+  const ratio = devicePixels > 0 && cssPixels > 0 ? devicePixels / cssPixels : 1;
+  return { width, height, x, y, ratio };
+}
+
+/**
+ * The size a PNG actually is, read from its header.
+ *
+ * Because the alternative is to report the size that was asked for, which is what this did, and
+ * an image that came back at twice the requested size was described as if it had not.
+ */
+function pngSize(base64) {
+  try {
+    const head = atob(String(base64).slice(0, 64));
+    if (head.slice(12, 16) !== 'IHDR') return null;
+    const at = (i) =>
+      (head.charCodeAt(i) << 24) | (head.charCodeAt(i + 1) << 16) |
+      (head.charCodeAt(i + 2) << 8) | head.charCodeAt(i + 3);
+    return { width: at(16), height: at(20) };
+  } catch {
+    return null;
+  }
+}
+
+/** CDP's mouse-button vocabulary, from the one this product uses everywhere else. */
+export function cdpButton(name) {
+  switch (String(name || 'left').toLowerCase()) {
+    case 'right': return 'right';
+    case 'middle': case 'wheel': return 'middle';
+    case 'back': return 'back';
+    case 'forward': return 'forward';
+    default: return 'left';
+  }
+}
+
+/** The bitmask CDP wants for "which buttons are currently held" during a drag. */
+export function buttonMask(name) {
+  switch (cdpButton(name)) {
+    case 'right': return 2;
+    case 'middle': return 4;
+    case 'back': return 8;
+    case 'forward': return 16;
+    default: return 1;
+  }
+}
+
+/**
+ * Key identity for `Input.dispatchKeyEvent`.
+ *
+ * A page listens for `key`, `code` and `keyCode`, and different pages listen for different
+ * ones, so all three are supplied. The names accepted here are the same names the Desktop
+ * driver accepts, including the DOM `Arrow*` spellings — one vocabulary across both drivers
+ * is worth more than either driver's private preference.
+ */
+const KEYS = {
+  enter: { key: 'Enter', code: 'Enter', vk: 13, text: '\r' },
+  return: { key: 'Enter', code: 'Enter', vk: 13, text: '\r' },
+  tab: { key: 'Tab', code: 'Tab', vk: 9, text: '\t' },
+  escape: { key: 'Escape', code: 'Escape', vk: 27 },
+  esc: { key: 'Escape', code: 'Escape', vk: 27 },
+  backspace: { key: 'Backspace', code: 'Backspace', vk: 8 },
+  delete: { key: 'Delete', code: 'Delete', vk: 46 },
+  space: { key: ' ', code: 'Space', vk: 32, text: ' ' },
+  home: { key: 'Home', code: 'Home', vk: 36 },
+  end: { key: 'End', code: 'End', vk: 35 },
+  pageup: { key: 'PageUp', code: 'PageUp', vk: 33 },
+  pagedown: { key: 'PageDown', code: 'PageDown', vk: 34 },
+  up: { key: 'ArrowUp', code: 'ArrowUp', vk: 38 },
+  down: { key: 'ArrowDown', code: 'ArrowDown', vk: 40 },
+  left: { key: 'ArrowLeft', code: 'ArrowLeft', vk: 37 },
+  right: { key: 'ArrowRight', code: 'ArrowRight', vk: 39 },
+  arrowup: { key: 'ArrowUp', code: 'ArrowUp', vk: 38 },
+  arrowdown: { key: 'ArrowDown', code: 'ArrowDown', vk: 40 },
+  arrowleft: { key: 'ArrowLeft', code: 'ArrowLeft', vk: 37 },
+  arrowright: { key: 'ArrowRight', code: 'ArrowRight', vk: 39 }
+};
+
+/** Modifier bits CDP expects: Alt 1, Control 2, Meta 4, Shift 8. */
+export const MODIFIERS = {
+  alt: 1, option: 1,
+  control: 2, ctrl: 2,
+  meta: 4, cmd: 4, command: 4, super: 4, win: 4,
+  shift: 8
+};
+
+export function keyDescriptor(name) {
+  const lower = String(name || '').toLowerCase();
+  if (KEYS[lower]) return KEYS[lower];
+  if (/^f([1-9]|1[0-9]|2[0-4])$/.test(lower)) {
+    const number = Number(lower.slice(1));
+    return { key: `F${number}`, code: `F${number}`, vk: 111 + number };
+  }
+  if ([...name].length === 1) {
+    const character = name;
+    const upper = character.toUpperCase();
+    const code = /[a-z]/i.test(character)
+      ? `Key${upper}`
+      : /[0-9]/.test(character)
+        ? `Digit${character}`
+        : undefined;
+    return { key: character, code, vk: upper.charCodeAt(0), text: character };
+  }
+  throw fail('BAD_KEY', `unknown key ${name}`);
+}
+
+/**
+ * Reads the page's interactive elements, in an isolated world.
+ *
+ * Deliberately not `Accessibility.getFullAXTree`: that returns nodes without geometry, so
+ * every one of them would need a second round trip to become clickable, and a page of any
+ * size turns into hundreds of protocol calls. One evaluation returns role, accessible name,
+ * state and rectangle together — and the rectangle is already in the coordinate space the
+ * input methods use.
+ *
+ * The isolated world matters. Evaluated in the page's own world, a hostile or merely
+ * over-clever page could shadow `querySelectorAll` or `getBoundingClientRect` and hand back a
+ * description of a page that does not exist, which the model would then act on.
+ */
+export const COLLECT_SOURCE = `(() => {
+  const SELECTOR = [
+    'a[href]', 'button', 'input:not([type=hidden])', 'select', 'textarea',
+    '[role=button]', '[role=link]', '[role=checkbox]', '[role=radio]', '[role=tab]',
+    '[role=menuitem]', '[role=option]', '[role=switch]', '[role=textbox]',
+    '[role=combobox]', '[role=searchbox]', '[contenteditable=""]', '[contenteditable=true]'
+  ].join(',');
+  const seen = [];
+  /**
+   * A path that finds this element again later.
+   *
+   * Coordinates go stale the moment the page scrolls or reflows, and a click on a stale
+   * coordinate does not fail — it hits whatever moved into that spot, which is the worst
+   * possible outcome. Re-resolving from the document at action time turns that into an honest
+   * refusal instead. An id is used when the page provides one; otherwise a child-index chain,
+   * which is stable enough for the moments between an observation and the action on it.
+   */
+  const pathOf = (el) => {
+    if (el.id && document.querySelectorAll('#' + CSS.escape(el.id)).length === 1) {
+      return '#' + CSS.escape(el.id);
+    }
+    const parts = [];
+    let node = el;
+    while (node && node.nodeType === 1 && node !== document.documentElement && parts.length < 24) {
+      const parent = node.parentElement;
+      if (!parent) break;
+      const index = Array.prototype.indexOf.call(parent.children, node) + 1;
+      parts.unshift(node.tagName.toLowerCase() + ':nth-child(' + index + ')');
+      node = parent;
+    }
+    return parts.length > 0 ? 'html > body ' + parts.slice(1).map((p) => '> ' + p).join(' ') : '';
+  };
+  const name = (el) => {
+    const label = el.getAttribute('aria-label');
+    if (label) return label.trim();
+    const labelledBy = el.getAttribute('aria-labelledby');
+    if (labelledBy) {
+      const parts = labelledBy.split(/\\s+/)
+        .map((id) => document.getElementById(id)?.textContent ?? '')
+        .join(' ').trim();
+      if (parts) return parts;
+    }
+    if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
+      const own = el.labels && el.labels[0] ? el.labels[0].textContent : '';
+      const text = (own || el.placeholder || el.getAttribute('title') || el.name || '').trim();
+      if (text) return text;
+    }
+    if (el.tagName === 'IMG') return (el.alt || '').trim();
+    const alt = el.querySelector('img[alt]')?.alt;
+    const text = (el.innerText || el.textContent || '').replace(/\\s+/g, ' ').trim();
+    return (text || alt || el.getAttribute('title') || '').trim();
+  };
+  const role = (el) => {
+    const explicit = el.getAttribute('role');
+    if (explicit) return explicit;
+    const tag = el.tagName.toLowerCase();
+    if (tag === 'a') return 'link';
+    if (tag === 'button') return 'button';
+    if (tag === 'select') return 'combobox';
+    if (tag === 'textarea') return 'textbox';
+    if (tag === 'input') {
+      const type = (el.getAttribute('type') || 'text').toLowerCase();
+      if (type === 'checkbox' || type === 'radio' || type === 'range') return type;
+      if (type === 'submit' || type === 'button' || type === 'reset') return 'button';
+      return 'textbox';
+    }
+    return 'generic';
+  };
+  /**
+   * Elements the page itself styles on :hover, which SELECTOR cannot describe.
+   *
+   * move_ref exists for menus and captions that appear under the pointer, and on the page that
+   * is the canonical example of exactly that — three avatars whose captions are revealed by
+   * ".figure:hover .figcaption" — it had nothing to aim at. The wrapper is a plain div with no
+   * role and no href, the caption inside it is display:none until hovered and so is skipped as
+   * unreachable, and the only ref on the whole page was an unrelated footer link. The feature
+   * was unusable on its own headline case.
+   *
+   * Read from the page's own stylesheets rather than by guessing at tag names. Adding, say,
+   * every img would flood the ref list on an image-heavy page and push real controls past
+   * MAX_ELEMENTS, which breaks pages that work today to fix one that does not. A :hover rule is
+   * the page declaring the element reacts to a pointer, so this only ever exposes what some
+   * author deliberately made hoverable, and pages with no such rule gain nothing.
+   *
+   * Cross-origin sheets throw on .cssRules and are skipped; that is a real gap, not a silent
+   * one — such a page simply keeps the refs it has today. Both the rule walk and the number of
+   * targets are bounded, because a stylesheet is page-controlled input.
+   */
+  const HOVER_TARGET_LIMIT = 100;
+  const hoverTargets = () => {
+    const found = new Set();
+    let sheets = [];
+    try { sheets = Array.from(document.styleSheets); } catch (e) { return found; }
+    let budget = 8000;
+    const walk = (rules) => {
+      for (const rule of rules) {
+        if (budget-- <= 0 || found.size >= HOVER_TARGET_LIMIT) return;
+        const sel = rule.selectorText;
+        if (sel && sel.indexOf(':hover') !== -1) {
+          for (const one of sel.split(',')) {
+            const idx = one.indexOf(':hover');
+            if (idx === -1) continue;
+            // The element the rule hangs off, not what it reveals: ".figure:hover .figcaption"
+            // is a statement about .figure. What it reveals is display:none until then, so it
+            // cannot be the thing a pointer is sent to.
+            const base = one.slice(0, idx).trim();
+            if (!base || base === '*') continue;
+            try {
+              for (const el of document.querySelectorAll(base)) {
+                found.add(el);
+                if (found.size >= HOVER_TARGET_LIMIT) return;
+              }
+            } catch (e) { /* a selector this browser will not parse is not a target */ }
+          }
+        }
+        // After selectorText, never instead of it: a nested style rule carries both.
+        if (rule.cssRules) walk(rule.cssRules);
+      }
+    };
+    for (const sheet of sheets) {
+      let rules = null;
+      try { rules = sheet.cssRules; } catch (e) { continue; }
+      if (rules) walk(rules);
+    }
+    return found;
+  };
+  const inDocumentOrder = (a, b) => {
+    const rel = a.compareDocumentPosition(b);
+    if (rel & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+    if (rel & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+    return 0;
+  };
+  const hovers = hoverTargets();
+  const interactive = Array.from(document.querySelectorAll(SELECTOR));
+  const already = new Set(interactive);
+  const extra = [];
+  for (const el of hovers) if (!already.has(el)) extra.push(el);
+  extra.sort(inDocumentOrder);
+  // Interactive elements first, and never displaced.
+  //
+  // A hover target is an addition to the surface; it must not cost a button. Rules like
+  // "tr:hover" and "li:hover" are ordinary on tables and menus, so a dashboard can easily
+  // declare a hundred of them, and a single list merged in document order would spend the
+  // MAX_ELEMENTS budget on rows and truncate away the controls further down the page — breaking
+  // pages that work today in order to fix one that did not. Filling in two passes means the cut
+  // always falls on hover targets first, and the output is put back into document order
+  // afterwards so the caller still reads the page from the top.
+  const candidates = interactive.concat(extra);
+  for (const el of candidates) {
+    if (seen.length >= ${MAX_ELEMENTS}) break;
+    const rect = el.getBoundingClientRect();
+    // Off-screen and zero-area elements are not things a pointer can reach, and reporting
+    // them invites a click at a coordinate that addresses something else entirely.
+    if (rect.width < 1 || rect.height < 1) continue;
+    if (rect.bottom <= 0 || rect.right <= 0) continue;
+    if (rect.top >= innerHeight || rect.left >= innerWidth) continue;
+    const style = getComputedStyle(el);
+    if (style.visibility === 'hidden' || style.display === 'none' || Number(style.opacity) === 0) continue;
+    if (el.getAttribute('aria-hidden') === 'true') continue;
+    // A hover wrapper's whole point is that its text is hidden until hovered, so name(), which
+    // reads innerText, finds nothing on exactly the elements this exists for. textContent sees
+    // through display:none and gives "name: user1 View profile" — the caption the hover is about,
+    // which is the most useful thing this ref could be called. Only as a fallback, and only for
+    // these: for anything else an empty name is the honest answer.
+    let label = name(el).slice(0, 160);
+    if (!label && hovers.has(el)) {
+      label = (el.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 160);
+    }
+    seen.push({
+      el,
+      path: pathOf(el),
+      role: role(el),
+      name: label,
+      value: 'value' in el && typeof el.value === 'string' ? String(el.value).slice(0, 160) : '',
+      disabled: Boolean(el.disabled || el.getAttribute('aria-disabled') === 'true'),
+      // Only for controls that have a checked state at all.
+      //
+      // The checked property is a boolean on every input element, so a text field, a search box
+      // and a submit button all reported false -- and the renderer, reading it as "is there
+      // something to say", printed checked=false beside every one of them. On a login or settings
+      // page that is noise on nearly every line, and it drowns the one signal it exists for: a
+      // checkbox that is already ticked. aria-checked comes first because a div with a role is a
+      // checkbox too, and it carries "mixed", which a boolean cannot.
+      //
+      // No backticks in this comment: everything here is stringified into the page, and a
+      // backtick ends the template literal that carries it.
+      checked:
+        el.getAttribute('aria-checked') ??
+        (/^(checkbox|radio)$/i.test(el.getAttribute('type') ?? '') ? String(el.checked) : ''),
+      x: Math.round(rect.left + rect.width / 2),
+      y: Math.round(rect.top + rect.height / 2),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height)
+    });
+  }
+  // Back into document order for the caller, after the two-pass fill above chose *which*
+  // elements survive the budget. The element is carried only for this sort and dropped here.
+  seen.sort((a, b) => inDocumentOrder(a.el, b.el));
+  return JSON.stringify({
+    url: location.href,
+    title: document.title,
+    scrollY: Math.round(scrollY),
+    scrollHeight: Math.round(document.documentElement.scrollHeight),
+    elements: seen.map((row) => { const copy = Object.assign({}, row); delete copy.el; return copy; })
+  });
+})()`;
+
+/** Frames one observation will look into, and how deep. A frame bomb is a real page shape. */
+const MAX_FRAMES = 12;
+const MAX_FRAME_DEPTH = 4;
+
+async function isolatedContext(frameId) {
+  const { executionContextId } = await send('Page.createIsolatedWorld', {
+    frameId,
+    worldName: 'chat-on-steroids',
+    grantUniveralAccess: false
+  });
+  return executionContextId;
+}
+
+async function mainFrameId() {
+  const { frameTree } = await send('Page.getFrameTree');
+  const frameId = frameTree?.frame?.id;
+  if (!frameId) throw fail('BROWSER_PROTOCOL_FAILED', 'the page reported no main frame');
+  return frameId;
+}
+
+/** Evaluates the collector inside one frame, in a world the page cannot see or shadow. */
+async function readFrame(frameId) {
+  const contextId = await isolatedContext(frameId);
+  const { result, exceptionDetails } = await send('Runtime.evaluate', {
+    expression: COLLECT_SOURCE,
+    contextId,
+    returnByValue: true,
+    awaitPromise: false
+  });
+  if (exceptionDetails) return null;
+  try {
+    return JSON.parse(String(result?.value ?? '{}'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Where a child frame sits in the page above it.
+ *
+ * An element's rectangle is relative to its own frame, so without this every coordinate
+ * inside an iframe would be wrong by the iframe's position — and wrong coordinates do not
+ * fail, they click somewhere else.
+ */
+async function frameOffset(frameId) {
+  try {
+    const { backendNodeId } = await send('DOM.getFrameOwner', { frameId });
+    if (!backendNodeId) return null;
+    const { model } = await send('DOM.getBoxModel', { backendNodeId });
+    const quad = model?.content;
+    if (!Array.isArray(quad) || quad.length < 2) return null;
+    return { x: quad[0], y: quad[1] };
+  } catch {
+    // A frame that closed between the tree walk and this call. Its elements are dropped
+    // rather than reported at an offset nobody can vouch for.
+    return null;
+  }
+}
+
+/**
+ * Every element on the page, including the ones inside iframes.
+ *
+ * Consent dialogs, payment forms, embedded editors and most login widgets are iframes. Reading
+ * only the main frame reported those pages as having nothing to interact with, which the model
+ * cannot tell apart from a page that genuinely has nothing.
+ *
+ * Each element keeps the frame it came from, because a ref has to be re-resolved in the frame
+ * that owns it, and carries coordinates already translated into the top-level page's space so
+ * that clicking one needs no further arithmetic.
+ */
+async function collectElements(generation) {
+  const root = await mainFrameId();
+  const { frameTree } = await send('Page.getFrameTree');
+
+  const frames = [];
+  const walk = (node, depth, offset) => {
+    if (!node?.frame?.id || frames.length >= MAX_FRAMES) return;
+    frames.push({ id: node.frame.id, depth, offset });
+    if (depth >= MAX_FRAME_DEPTH) return;
+    for (const child of node.childFrames ?? []) walk(child, depth + 1, null);
+  };
+  walk(frameTree, 0, { x: 0, y: 0 });
+
+  const page = (await readFrame(root)) ?? { elements: [] };
+  const elements = [];
+  let index = 0;
+  const take = (list, frameId, offset) => {
+    for (const element of list ?? []) {
+      if (elements.length >= MAX_ELEMENTS) return;
+      elements.push({
+        ...element,
+        // Stamped with the observation that minted it, not just a recycled per-call index. Every
+        // observe() starts index back at 0, so a bare "e4" from one observation and "e4" from the
+        // next name two unrelated elements — and a caller holding the first one after the second
+        // has run gets a silent, successful click on whatever the label now happens to match. QA
+        // caught exactly that: a stale first-observation ref was reused by a later observation and
+        // activated a different control instead of failing. The generation makes that collision
+        // impossible instead of merely unlikely.
+        ref: 'g' + generation + '_e' + index++,
+        frameId,
+        x: Math.round(element.x + offset.x),
+        y: Math.round(element.y + offset.y)
+      });
+    }
+  };
+  take(page.elements, root, { x: 0, y: 0 });
+
+  for (const frame of frames) {
+    if (frame.id === root) continue;
+    if (elements.length >= MAX_ELEMENTS) break;
+    const offset = await frameOffset(frame.id);
+    if (!offset) continue;
+    const inner = await readFrame(frame.id);
+    if (!inner) continue;
+    take(inner.elements, frame.id, offset);
+  }
+
+  return { ...page, elements };
+}
+
+/**
+ * A screenshot of what is on screen, in which one pixel is one CSS pixel.
+ *
+ * The clip carries two facts, and both were learned the hard way.
+ *
+ * `scale: 1` is why the clip exists at all: without it the image comes back in device pixels and
+ * every coordinate the model reads off it is wrong by the display's scale factor, on exactly the
+ * high-DPI machines people actually use.
+ *
+ * The origin is why this went wrong for months. A capture clip is given in **document**
+ * coordinates, not viewport ones, and this asked for `0,0` — the top of the document. On any
+ * scrolled page that is not what is on screen: the requested region has mostly never been
+ * rasterised, so it comes back blank, with the sliver that does overlap the viewport stranded far
+ * down the image. Two QA runs reported it as "the screenshot after scrolling is wrong"; it was
+ * every screenshot of a scrolled page, whoever scrolled it and however long ago.
+ *
+ * So the clip starts where the viewport starts. It is what Chrome's own tooling does — Puppeteer
+ * adds the layout viewport's `pageX`/`pageY` to every clip it sends, for this reason.
+ *
+ * And the scale is `1 / ratio`, not `1`. A clip's scale multiplies the display's own scale factor
+ * rather than replacing it, so `scale: 1` on a Retina display returned an image at twice the size
+ * it claimed — and the claim was the requested size, never the picture's, so nothing noticed for
+ * as long as this has existed. Every coordinate a model read off one of those images was out by
+ * a factor of two on every Mac made in the last decade. The size reported now comes from the
+ * PNG's own header.
+ */
+async function screenshot() {
+  const { width, height, x, y, ratio } = await viewport();
+  const { data } = await send('Page.captureScreenshot', {
+    format: 'png',
+    captureBeyondViewport: false,
+    clip: { x, y, width, height, scale: 1 / (ratio || 1) }
+  }, COMPOSITOR_TIMEOUT_MS);
+  const actual = pngSize(data);
+  return { data, width: actual?.width ?? width, height: actual?.height ?? height };
+}
+
+async function currentTab(tabId) {
+  const tab = await chrome.tabs.get(tabId);
+  if (!tab) throw fail('BROWSER_TAB_GONE', `tab ${tabId} no longer exists`);
+  return tab;
+}
+
+/**
+ * The permissions browser control needs, which the extension deliberately does not ship with.
+ *
+ * `debugger` and `<all_urls>` together are the most far-reaching pair an extension can hold —
+ * read and write on every page, plus trusted input. Requiring them at install time would mean
+ * every existing user is re-prompted on update and left disabled until they accept a
+ * capability most of them will never switch on. As optional permissions they are requested
+ * once, from a real click in the popup, by the person who actually wants the feature.
+ */
+/**
+ * What is actually requested and revoked at runtime.
+ *
+ * `debugger` is not here, and cannot be: Chrome refuses it in optional_permissions, dropping the
+ * entry at manifest load so a later request answers "Only permissions specified in the manifest
+ * may be requested" — measured against Chrome 152. One unavailable entry failed the whole
+ * request, which is why the popup switch could never stay on. It is a required permission now.
+ *
+ * Site and tab access remain optional, and they are what decides whether this extension can
+ * read a page at all, so the opt-in still means something.
+ */
+export const BROWSER_PERMISSIONS = { permissions: ['tabs', 'tabGroups'], origins: ['<all_urls>'] };
+
+/** Held from install, not requestable. Checked, never requested and never removed. */
+/**
+ * A short digest of this file, so an answer can say which driver produced it.
+ *
+ * Installing a new build rewrites the extension folder, but Chrome keeps running the copy it
+ * already loaded until someone reloads the extension by hand. A test run then measures the old
+ * driver while reading the new source, and reports a fix as broken — which has already cost a
+ * round. Hashing the running source turns that into something visible: two runs quoting the same
+ * stamp were the same code, whatever the release notes say.
+ */
+let driverStamp = null;
+async function stamp() {
+  if (driverStamp) return driverStamp;
+  try {
+    const source = await (await fetch(chrome.runtime.getURL('browser-driver.js'))).arrayBuffer();
+    const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', source)).slice(0, 6);
+    driverStamp = [...digest].map((b) => b.toString(16).padStart(2, '0')).join('');
+  } catch {
+    driverStamp = 'unreadable';
+  }
+  return driverStamp;
+}
+const REQUIRED_BROWSER_PERMISSIONS = { permissions: ['debugger'] };
+
+/**
+ * One call shape, whichever the browser answers with.
+ *
+ * `permissions.*` answers a callback in the classic API and returns a promise in the MV3 one,
+ * and which you get depends on the browser build rather than on anything visible here. Waiting
+ * only for the callback hangs forever against the promise form, and a permission check that
+ * hangs is indistinguishable from one that denied. Accepting either costs three lines.
+ */
+function askPermissions(method) {
+  return new Promise((resolve) => {
+    const runtime = globalThis.browser ?? globalThis.chrome;
+    const api = runtime?.permissions;
+    if (!api?.[method]) return resolve(false);
+    try {
+      const returned = api[method](BROWSER_PERMISSIONS, (granted) => {
+        void runtime?.runtime?.lastError;
+        resolve(Boolean(granted));
+      });
+      if (returned && typeof returned.then === 'function') {
+        returned.then((granted) => resolve(Boolean(granted)), () => resolve(false));
+      }
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+/**
+ * Whether this browser can do any of this at all.
+ *
+ * Browser control needs the DevTools protocol. Where an extension cannot reach it — a browser
+ * that never implemented it, or a build where policy has taken it away — this is not a missing
+ * permission but a missing capability, and saying so plainly is the difference between a
+ * feature someone can decide not to use and a switch that silently does nothing.
+ *
+ * Deliberately not a `chrome.debugger` presence check. That object does not exist until the
+ * optional permission is granted, so testing for it would hide the very switch that grants
+ * it — the feature would be permanently unreachable on exactly the browsers that support it.
+ * Proven in a real Edge run, where the popup reported no debugger API at all.
+ */
+export function browserControlSupported() {
+  return new Promise((resolve) => {
+    const runtime = globalThis.browser ?? globalThis.chrome;
+    const api = runtime?.permissions;
+    if (!api?.contains) return resolve(false);
+    // Asking whether the permission is *held* is not the question — it will not be, before it
+    // is granted. Asking whether the browser recognises the name is: one that has never heard
+    // of it rejects the call outright, while one that simply has not granted it answers false.
+    const done = (value) => resolve(value === true || value === false);
+    try {
+      const returned = api.contains({ permissions: ['debugger'] }, (held) => {
+        // A browser that does not know the permission reports it here rather than throwing.
+        if (runtime?.runtime?.lastError) return resolve(false);
+        done(held);
+      });
+      if (returned && typeof returned.then === 'function') returned.then(done, () => resolve(false));
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+export async function hasBrowserPermissions() {
+  if (!(await browserControlSupported())) return false;
+  // Both halves, because they are granted by different mechanisms: debugger at install, the
+  // rest from the popup. Holding only one is not browser control.
+  if (!(await containsRequired())) return false;
+  return askPermissions('contains');
+}
+
+/** Whether the install-time debugger permission is actually present. */
+function containsRequired() {
+  return new Promise((resolve) => {
+    const runtime = globalThis.browser ?? globalThis.chrome;
+    const api = runtime?.permissions;
+    if (!api?.contains) return resolve(false);
+    try {
+      const returned = api.contains(REQUIRED_BROWSER_PERMISSIONS, (held) => {
+        if (runtime?.runtime?.lastError) return resolve(false);
+        resolve(held === true);
+      });
+      if (returned && typeof returned.then === 'function') {
+        returned.then((held) => resolve(held === true), () => resolve(false));
+      }
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+/** Must be called from a user gesture; the browser refuses the prompt otherwise. */
+export function requestBrowserPermissions() {
+  return askPermissions('request');
+}
+
+/** Where the page is scrolled to, or null when it cannot be read. */
+/**
+ * Waits until the page has stopped moving and painted what it moved to.
+ *
+ * A scroll gesture animates. The command returns as soon as it is accepted, so a screenshot taken
+ * straight afterwards catches the page mid-flight: a run got an entirely white picture of a page
+ * that had plainly scrolled, and on a simpler page the newly exposed strip was blank while the
+ * old content still sat at its old height. The scroll had worked; the evidence of it had not.
+ *
+ * That is the failure this whole layer exists to prevent — an answer that says `ok` beside a
+ * picture that shows something else — so scrolling waits for the position to settle and then for
+ * two animation frames, which is the browser's own promise that a paint has happened.
+ */
+async function settleAfterScroll(send, x, y) {
+  let last = null;
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    const now = await readScrollPosition(send, x, y);
+    if (now !== null && last !== null && now.x === last.x && now.y === last.y) break;
+    last = now;
+    await new Promise((resolve) => setTimeout(resolve, 40));
+  }
+  try {
+    await send('Runtime.evaluate', {
+      expression:
+        'new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve(1))))',
+      awaitPromise: true,
+      returnByValue: true
+    }, SCROLL_TIMEOUT_MS);
+  } catch {
+    // A page that will not run script still scrolled; the wait above is the part that matters.
+  }
+}
+
+/**
+ * Whether a click just opened a new ordinary tab — `target="_blank"`, `window.open`, a form
+ * posting to a new tab.
+ *
+ * Before this, nothing in a click's answer said so: the driver stayed attached to the tab it
+ * was already on, status kept naming that same tab, and a caller had no way to learn a second
+ * tab now existed short of separately listing tabs and guessing which one was new. QA reached
+ * for exactly that guess and found nothing to guess from.
+ *
+ * Chrome creates the new tab a beat after the input event that triggered it completes, so this
+ * polls briefly rather than checking once and calling it settled.
+ */
+async function findCreatedTab(openerTabId, before) {
+  const deadline = Date.now() + 200;
+  for (;;) {
+    let tabs = [];
+    try {
+      // `openerTabId` is a property Chrome reports on a returned Tab, not a filter
+      // `tabs.query` accepts — passing it as query criteria throws ACTION_REFUSED
+      // ("Unexpected property"). Query everything and filter here instead.
+      tabs = await chrome.tabs.query({});
+    } catch {
+      return null;
+    }
+    const created = tabs.find(
+      (tab) => tab?.openerTabId === openerTabId && Number.isSafeInteger(tab?.id) && !before.has(tab.id)
+    );
+    if (created) {
+      return { tabId: created.id, url: created.url || created.pendingUrl || null, title: created.title || null };
+    }
+    if (Date.now() >= deadline) return null;
+    await new Promise((resolve) => setTimeout(resolve, 40));
+  }
+}
+
+/**
+ * Whether the page has moved from `before` — worth a short wait, not one look.
+ *
+ * A dispatch call timing out at SCROLL_TIMEOUT_MS says nothing about the scroll itself: QA saw
+ * horizontal scrolling reported as `BROWSER_SCROLL_FAILED` — neither the gesture nor the wheel
+ * fallback acknowledged in time — while a screenshot taken moments later showed the page had
+ * moved anyway. Reading the position exactly once, at the instant a timed-out dispatch call
+ * returns, catches the scroll mid-flight and calls it failed. This polls for the onset of
+ * movement the same way settleAfterScroll below polls for its end, so a scroll that lands a
+ * little after its dispatch call is still seen landing.
+ */
+async function waitForScrollOnset(send, before, timeoutMs, x, y) {
+  const deadline = Date.now() + timeoutMs;
+  let last = before;
+  for (;;) {
+    const now = await readScrollPosition(send, x, y);
+    if (now !== null) {
+      last = now;
+      if (before === null || now.x !== before.x || now.y !== before.y) return now;
+    }
+    if (Date.now() >= deadline) return last;
+    await new Promise((resolve) => setTimeout(resolve, 40));
+  }
+}
+
+/**
+ * The position a scroll at `(x, y)` is actually judged by — the element under that point that
+ * can scroll, not always the window.
+ *
+ * `Input.synthesizeScrollGesture` and a wheel event both scroll whatever the compositor finds
+ * under the pointer, the same way a real wheel does: a small nested strip with its own
+ * `overflow: auto` takes the gesture and never touches `window.scrollX`/`scrollY` at all. Reading
+ * only those two, as this used to, made a real, visible scroll of that strip indistinguishable
+ * from nothing happening — QA's fixture moved WIDE 1/2 → 2/3 → 3/4 on screen while every check
+ * here kept reporting `BROWSER_SCROLL_FAILED`. `elementFromPoint` finds the same element the
+ * gesture would have hit and walks up to the nearest one that can actually scroll in either
+ * axis; only when none exists — the ordinary case, an element-less point or the page itself —
+ * does this fall back to the window, which is the only thing a plain page scroll ever moves.
+ */
+function scrollTargetExpression(x, y) {
+  return (
+    '(() => {' +
+    `const px = ${Math.round(x)}, py = ${Math.round(y)};` +
+    'let el = document.elementFromPoint(px, py);' +
+    'while (el && el !== document.documentElement && el !== document.body) {' +
+    'const style = getComputedStyle(el);' +
+    'const canX = el.scrollWidth > el.clientWidth && /(auto|scroll)/.test(style.overflowX);' +
+    'const canY = el.scrollHeight > el.clientHeight && /(auto|scroll)/.test(style.overflowY);' +
+    'if (canX || canY) return { x: Math.round(el.scrollLeft), y: Math.round(el.scrollTop) };' +
+    'el = el.parentElement;' +
+    '}' +
+    'return { x: Math.round(scrollX), y: Math.round(scrollY) };' +
+    '})()'
+  );
+}
+
+async function readScrollPosition(send, x, y) {
+  try {
+    const reply = await send('Runtime.evaluate', {
+      expression: scrollTargetExpression(x, y),
+      returnByValue: true
+    });
+    const value = reply?.result?.value;
+    return value && typeof value.x === 'number' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export const browserDriver = {
+  /** What is under control right now, for the popup, the app and the stop button. */
+  /**
+   * Where the driver is now, not where it started.
+   *
+   * The address and title were captured when the tab was taken and never updated, so after any
+   * navigation — the driver's own, or the person clicking a link — status answered with the page
+   * the run began on. status is precisely what a caller uses to confirm where it is, so a stale
+   * answer is worse than no answer: it reads as confirmation.
+   *
+   * A tab that cannot be read leaves the last known values in place, which beats answering
+   * nothing about a session that is genuinely still attached.
+   */
+  async status() {
+    if (!session) return { attached: false, tabId: null, url: null, title: null, build: await stamp() };
+    try {
+      const tab = await chrome.tabs.get(session.tabId);
+      session.url = tab?.url || tab?.pendingUrl || session.url;
+      session.title = tab?.title || session.title;
+    } catch {
+      // Keep what we knew.
+    }
+    // The group rides along because it is the visible claim: a blue band above the tab saying
+    // something is driving it. Reporting it makes that claim checkable by whoever is driving,
+    // instead of only by a person looking at the tab strip.
+    return {
+      attached: true,
+      tabId: session.tabId,
+      url: session.url,
+      title: session.title,
+      groupId: session.groupId ?? null,
+      build: await stamp()
+    };
+  },
+
+  async attach(tabId) {
+    if (session && session.tabId === tabId) return this.status();
+    if (session) await this.detach();
+
+    if (!(await browserControlSupported())) {
+      throw fail(
+        'BROWSER_UNSUPPORTED',
+        'this browser exposes no DevTools protocol to extensions, so a web page cannot be driven ' +
+          'from it. Desktop control still works and can operate the browser window itself.'
+      );
+    }
+    if (!(await hasBrowserPermissions())) {
+      throw fail(
+        'BROWSER_PERMISSION_REQUIRED',
+        'browser control is off. Open the Chat On Steroids extension popup and turn it on; ' +
+          'the browser asks for site and tab access there. If the switch will not stay on, the ' +
+          'popup now says why underneath it.'
+      );
+    }
+
+    const tab = await currentTab(tabId);
+    // A tab still loading reports its destination as pendingUrl and its url as empty, which a
+    // tab this driver just opened always is. Judging only `url` would refuse the page we were
+    // asked for, at the moment we asked for it.
+    const address = tab.url || tab.pendingUrl || '';
+    if (!address) {
+      throw fail(
+        'BROWSER_URL_UNKNOWN',
+        `the address of tab ${tabId} cannot be read, so it cannot be shown safe to drive. Turn ` +
+          'browser control off and on again in the extension popup and accept the tab access it asks for.'
+      );
+    }
+    if (refusedUrl(address)) {
+      throw fail('BROWSER_URL_REFUSED', `browser control refuses ${address}`);
+    }
+
+    await new Promise((resolve, reject) => {
+      chrome.debugger.attach({ tabId }, '1.3', () => {
+        const error = chrome.runtime.lastError;
+        if (error) return reject(fail('BROWSER_ATTACH_FAILED', error.message));
+        resolve();
+      });
+    });
+
+    session = { tabId, url: tab.url ?? '', title: tab.title ?? '', groupId: null, refGeneration: 0 };
+    try {
+      await send('Page.enable');
+      await send('Runtime.enable');
+      await send('DOM.enable');
+      session.groupId = await groupDrivenTab(tabId);
+      await movePointer(0, 0);
+    } catch (error) {
+      await this.detach();
+      throw error;
+    }
+    return this.status();
+  },
+
+  /** Always safe to call, always leaves the tab as the user's own again. */
+  async detach() {
+    if (!session) return { attached: false, tabId: null, url: null, title: null, build: await stamp() };
+    const { tabId, groupId } = session;
+    await removePointer();
+    await ungroupDrivenTab(tabId, groupId);
+    try {
+      await new Promise((resolve) => chrome.debugger.detach({ tabId }, () => {
+        void chrome.runtime.lastError;
+        resolve();
+      }));
+    } catch {
+      // The tab may already be gone, which is the state we were heading for anyway.
+    }
+    const released = { tabId, url: session.url, title: session.title };
+    session = null;
+    // Say what was let go of. "No tab is under control" is the state afterwards and it is true,
+    // but as the answer to detach it reads as though there had been nothing to detach — which is
+    // the one thing it cannot distinguish. Naming the tab makes the effect legible.
+    // The build belongs on both branches. It was on the one that had nothing to let go of and
+    // not on the one that did, so every successful detach printed "driver build unreported" —
+    // the exact string the QA instructions call a finding. A false alarm in the answer that is
+    // supposed to settle which driver ran is worse than no answer at all.
+    return { attached: false, tabId: null, url: null, title: null, released, build: await stamp() };
+  },
+
+  /**
+   * Called when the browser tears the session down underneath us.
+   *
+   * Also reached when a person presses Cancel on Chrome's debugging banner, and the tab then
+   * outlives the session — so the group has to go here too, not only in detach.
+   */
+  forget(tabId) {
+    if (!session || session.tabId !== tabId) return;
+    const { groupId } = session;
+    session = null;
+    void ungroupDrivenTab(tabId, groupId);
+  },
+
+  /**
+   * Where a ref points *now*, not where it pointed when it was observed.
+   *
+   * A coordinate from an earlier observation does not fail when the page has scrolled or
+   * reflowed — it hits whatever moved into that spot, which is worse than any error. So a ref
+   * is re-resolved from the document immediately before it is used, and an element that is
+   * gone, hidden or off-screen produces a refusal instead of a click somewhere else.
+   */
+  async resolveRef(ref) {
+    const entry = session?.refs?.get(String(ref));
+    if (!entry) {
+      throw fail('BROWSER_BAD_REF', `${ref} is not from the most recent observation of this page`);
+    }
+    const { path, frameId } = entry;
+    // Resolved in the frame that owns it. A path from inside an iframe means nothing in the
+    // document above it, and could match something entirely different there.
+    //
+    // A ref whose frame was an iframe survives navigation of the *page* in the map (it is only
+    // replaced by the next observe()), but the frame itself can be gone by then — the top
+    // document navigated, or the iframe was removed. Asking CDP for that frame's isolated world
+    // then fails at the protocol level ("No frame for given id found"), which used to escape as
+    // a raw BROWSER_PROTOCOL_FAILED. That is exactly the case this method exists to turn into a
+    // clean refusal: the ref is stale, not the protocol.
+    let contextId;
+    try {
+      contextId = await isolatedContext(frameId);
+    } catch {
+      throw fail('BROWSER_BAD_REF', `${ref} belonged to a frame that no longer exists on this page`);
+    }
+    const offset = (await frameOffset(frameId)) ?? { x: 0, y: 0 };
+    const { result, exceptionDetails } = await send('Runtime.evaluate', {
+      expression: `(() => {
+        const el = document.querySelector(${JSON.stringify(path)});
+        if (!el) return JSON.stringify({ found: false });
+        const r = el.getBoundingClientRect();
+        const s = getComputedStyle(el);
+        const usable = r.width >= 1 && r.height >= 1 && r.bottom > 0 && r.right > 0 &&
+          r.top < innerHeight && r.left < innerWidth &&
+          s.visibility !== 'hidden' && s.display !== 'none' && Number(s.opacity) !== 0;
+        const x = Math.round(r.left + r.width / 2);
+        const y = Math.round(r.top + r.height / 2);
+        // What is actually at that point. A ref resolves to fresh coordinates, but coordinates are
+        // not the element: a page can lay something over it, and the click then lands on the cover
+        // while every part of the call still succeeds.
+        const at = document.elementFromPoint(x, y);
+        const hit = at
+          ? at.tagName.toLowerCase() + (at.id ? '#' + at.id : '')
+          : null;
+        const covered = Boolean(at) && at !== el && !el.contains(at) && !at.contains(el);
+        // The destination this click is expected to reach, when there is one to be sure of.
+        //
+        // Only a link that opens in this tab, addresses an ordinary page, and points somewhere
+        // other than where we already are. Anything else — a fragment, a new tab, a script
+        // handler — has no outcome that can be checked by watching the address, and guessing at
+        // one would file a "nothing happened" report against a click that worked perfectly.
+        // Top document only. The address watched after the click is the page's, and a link inside
+        // an iframe moves the frame while the page stays exactly where it was — so checking one
+        // against the other would report a working click as having reached nothing, which is
+        // worse than saying nothing. The top/self test is a reference comparison and is safe
+        // across origins. (No backticks in here: this whole source is a template literal.)
+        const anchor = window.top === window.self && el.closest ? el.closest('a[href]') : null;
+        let expect = '';
+        if (anchor && !anchor.target) {
+          const href = anchor.href;
+          if (/^https?:/i.test(href) && href.split('#')[0] !== location.href.split('#')[0]) expect = href;
+        }
+        return JSON.stringify({ found: true, usable, x, y, hit, covered, tag: el.tagName.toLowerCase(), expect });
+      })()`,
+      contextId,
+      returnByValue: true
+    });
+    if (exceptionDetails) throw fail('BROWSER_BAD_REF', `${ref} could not be resolved on this page`);
+    const found = JSON.parse(String(result?.value ?? '{}'));
+    if (!found.found) throw fail('BROWSER_BAD_REF', `${ref} is no longer on this page`);
+    if (!found.usable) throw fail('BROWSER_BAD_REF', `${ref} is on the page but not visible or reachable`);
+    // Back into the top-level page's coordinates, which is the space input events use.
+    //
+    // `tag`, `path` and `contextId` come back too, for the actions that cannot be expressed as a
+    // point. A native <select> is the case that forced it: its dropdown is painted by the browser
+    // process, so no synthetic event aimed at any coordinate can pick an option. See set_value.
+    return {
+      x: Math.round(found.x + offset.x),
+      y: Math.round(found.y + offset.y),
+      hit: found.hit ?? null,
+      covered: Boolean(found.covered),
+      tag: String(found.tag ?? ''),
+      expect: String(found.expect ?? ''),
+      path,
+      contextId
+    };
+  },
+
+  /**
+   * Attaches to the tab a person would mean by "the browser", if nothing is attached yet.
+   *
+   * Making the model ask for this first was bookkeeping it should not have to carry, and one
+   * more thing to get wrong. The newest ordinary tab is the one being worked in; ChatGPT's own
+   * tabs and browser surfaces are skipped by the same refusal list that governs an explicit
+   * attach, so this cannot reach anywhere an explicit attach could not.
+   */
+  async ensureAttached(openUrl = null) {
+    if (session) return;
+    let tabs = [];
+    try {
+      tabs = await chrome.tabs.query({});
+    } catch {
+      throw fail('BROWSER_PERMISSION_REQUIRED', 'browser control is off; turn it on in the extension popup');
+    }
+    const usable = tabs.filter((tab) => Number.isSafeInteger(tab?.id));
+    const candidate = usable
+      .filter((tab) => !refusedUrl(tab.url || tab.pendingUrl))
+      .sort((left, right) => (right.lastAccessed ?? 0) - (left.lastAccessed ?? 0))[0];
+    if (candidate) {
+      await this.attach(candidate.id);
+      // Judged again, by what the tab holds rather than by what it was asked for.
+      //
+      // The filter above reads `tab.url`, which for a page that failed to load is still the
+      // address that was requested — so a tab showing Chrome's error page looks like an ordinary
+      // site and is picked. QA met this straight after a detach: the next observe silently
+      // re-attached and returned `chrome-error://chromewebdata/` as the page, with no refusal
+      // anywhere. attach() cannot answer this either, for the same reason; only the frame tree
+      // can, and only once attached.
+      //
+      // Not when the caller brought an address, though. `navigate` is about to replace the
+      // document, so what the tab holds right now is not what it will be driven on — and
+      // refusing here would be a trap rather than a guard: the failed tab stays open, every
+      // later `navigate` auto-picks it, is refused, and detaches again, so the one action that
+      // would fix the situation is the one action that can never run. That is the dead end the
+      // comment below already names, arrived at from the other side.
+      if (!openUrl) await this.assertPageStillAllowed();
+      return;
+    }
+    // "No page is open" and "no page whose address I may read" are different problems with
+    // different fixes, and only the second one is the user's to solve. Chrome answers `tab.url`
+    // with undefined wherever the extension has no access, and those tabs are refused rather
+    // than driven — correct, but saying nothing is open when the browser is full of pages sends
+    // someone to open one more, which changes nothing.
+    if (usable.length > 0 && usable.every((tab) => !(tab.url || tab.pendingUrl))) {
+      throw fail(
+        'BROWSER_PERMISSION_REQUIRED',
+        `${usable.length} tab(s) are open but none of their addresses can be read, so none can be ` +
+          'shown safe to drive. Open the Chat On Steroids extension popup, turn browser control ' +
+          'off and on again, and accept the site access it asks for.'
+      );
+    }
+    // Nothing to take. If the caller brought an address — navigate is the only action that
+    // does — open it, because the alternative is the dead end QA walked into twice: "open the
+    // page first" is not an instruction a model can follow when no action opens a page. The
+    // address has already passed the refusal list in `act`, so this cannot open anywhere an
+    // explicit attach could not reach.
+    if (!openUrl) {
+      throw fail(
+        'BROWSER_NO_TAB',
+        'no ordinary web page is open to drive, and no address was given to open one. ' +
+          'Use navigate, which opens a page when none is open; ChatGPT tabs are never driven.'
+      );
+    }
+    const opened = await chrome.tabs.create({ url: openUrl, active: true });
+    if (!Number.isSafeInteger(opened?.id)) {
+      throw fail('BROWSER_NO_TAB', `the browser did not open ${openUrl}`);
+    }
+    await this.attach(opened.id);
+  },
+
+  /**
+   * Refuses to keep driving a page the driver would never have taken.
+   *
+   * The refusal list guarded two doors: attach, and navigate. A click is the third. Follow a
+   * link and the tab lands wherever it points with the debugger session still on it, so the one
+   * refusal this list exists for — the model must not reach the ChatGPT tab it is speaking
+   * from — could be walked around by clicking a link to it. The comment on that list says it is
+   * refused at the lowest level "rather than anywhere it could later be forgotten"; this is
+   * where it had been forgotten. Proven by clicking one, in Chrome, before it was written.
+   *
+   * The address comes from the protocol rather than from `chrome.tabs`, because the protocol
+   * answers whether or not the extension holds permission to read that tab's URL — and a check
+   * that goes blank exactly when permissions are thin is the failure this same list already had.
+   *
+   * Only pages the driver has been holding are checked. A tab attached moments ago was already
+   * judged by `attach`, and a tab this driver just opened passes through about:blank on its way
+   * to the page it was asked for, which is refused and would detach it on arrival.
+   */
+  /**
+   * The address the tab is really showing.
+   *
+   * Three surfaces answer this and two of them lie about a page that failed to load. Measured
+   * against a dead port: `chrome.tabs` reports the requested `http://127.0.0.1:1/`,
+   * `Page.getNavigationHistory` reports the same, and only `Page.getFrameTree` reports what the
+   * tab actually holds — `chrome-error://chromewebdata/`, carrying the address that failed
+   * alongside it as `unreachableUrl`. The isolated world agrees with the frame tree, which is why
+   * observe could describe a Chrome error page as though it were the site: every check upstream
+   * had asked one of the two surfaces that still name the site.
+   */
+  async currentPageUrl() {
+    try {
+      const { frameTree } = await send('Page.getFrameTree');
+      const frame = frameTree?.frame;
+      const url = String(frame?.url ?? '');
+      if (url) return { url, unreachable: String(frame?.unreachableUrl ?? '') };
+    } catch { /* fall back to history below */ }
+    try {
+      const history = await send('Page.getNavigationHistory');
+      return { url: String(history?.entries?.[history.currentIndex]?.url ?? ''), unreachable: '' };
+    } catch {
+      // Unreadable through the protocol means the session is already in trouble; onDetach and
+      // tabs.onRemoved cover a tab that has gone, and the next action will fail on its own.
+      return { url: '', unreachable: '' };
+    }
+  },
+
+  /**
+   * Whether the address left `from` within the budget.
+   *
+   * Polled rather than driven off `Page.frameNavigated`, because the answer is wanted for a click
+   * that may well produce no navigation at all — that is the case being measured — and an event
+   * that never arrives cannot be distinguished from one that is merely late without a timer
+   * anyway. Polling the frame tree says both things with one instrument.
+   */
+  async waitForUrlChange(from, budgetMs) {
+    const until = Date.now() + budgetMs;
+    for (;;) {
+      const { url } = await this.currentPageUrl();
+      if (url && url !== from) return true;
+      if (Date.now() >= until) return false;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  },
+
+  async assertPageStillAllowed() {
+    if (!session) return;
+    const { url: address, unreachable } = await this.currentPageUrl();
+    if (!address || !refusedUrl(address)) return;
+    await this.detach().catch(() => {});
+    // A page that failed to load is not a page that "moved" somewhere, and saying so sends the
+    // caller looking for a redirect that never happened. The address it could not reach is the
+    // one thing worth naming, because retrying or fixing it is the only way forward.
+    if (unreachable) {
+      throw fail(
+        'BROWSER_URL_REFUSED',
+        `the tab is showing Chrome's error page because ${unreachable} could not be loaded, so there ` +
+          'is no page to drive. The tab has been let go of.'
+      );
+    }
+    throw fail(
+      'BROWSER_URL_REFUSED',
+      `the page moved to ${address}, which browser control refuses. The tab has been let go of.`
+    );
+  },
+
+  async act(action) {
+    // Whether the page could have moved under us: a session that predates this call has had the
+    // chance, one established by the line below has not.
+    const held = Boolean(session);
+    const type = String(action?.type ?? '');
+    // navigate is the one action that carries its own destination, so it is the one action that
+    // can start from nothing. Its address is judged here, before a tab exists, so that a refused
+    // one never becomes a reason to open a tab and a refusal reads the same whether or not the
+    // browser happened to have a page open.
+    if (type === 'navigate') {
+      const target = String(action.url ?? '');
+      if (refusedUrl(target)) throw fail('BROWSER_URL_REFUSED', `browser control refuses ${target}`);
+      if (!/^https?:\/\//i.test(target)) throw fail('BAD_REQUEST', 'navigate needs an http(s) URL');
+      await this.ensureAttached(target);
+    } else {
+      await this.ensureAttached();
+    }
+    if (held) await this.assertPageStillAllowed();
+    const button = cdpButton(action?.button);
+    const modifiers = (action?.modifiers ?? []).reduce(
+      (bits, name) => bits | (MODIFIERS[String(name).toLowerCase()] ?? 0),
+      0
+    );
+
+    switch (type) {
+      case 'navigate': {
+        // Already validated above, where it had to be.
+        const url = String(action.url ?? '');
+        await send('Page.navigate', { url }, NAVIGATE_TIMEOUT_MS);
+        await restorePointer();
+        // Where it landed, not where it was aimed. A redirect can end on a refused page, and an
+        // action that only judges its argument cannot see that.
+        await this.assertPageStillAllowed();
+        return { navigated: url };
+      }
+      case 'back':
+      case 'forward': {
+        const history = await send('Page.getNavigationHistory');
+        const index = history.currentIndex + (type === 'back' ? -1 : 1);
+        const entry = history.entries?.[index];
+        if (!entry) throw fail('BROWSER_NO_HISTORY', `there is nothing to go ${type} to`);
+        // The destination is known before moving, so a refused one is refused before it is
+        // reached rather than after. History is the one navigation that can say this in advance.
+        if (refusedUrl(entry.url)) {
+          throw fail('BROWSER_URL_REFUSED', `browser control refuses ${entry.url}`);
+        }
+        await send('Page.navigateToHistoryEntry', { entryId: entry.id }, NAVIGATE_TIMEOUT_MS);
+        await restorePointer();
+        await this.assertPageStillAllowed();
+        return { navigated: entry.url };
+      }
+      case 'reload':
+        await send('Page.reload', {}, NAVIGATE_TIMEOUT_MS);
+        await restorePointer();
+        await this.assertPageStillAllowed();
+        return { reloaded: true };
+
+      case 'click_ref': {
+        /*
+         * Say what the click actually landed on.
+         *
+         * A QA run clicked a freshly observed link, got `ok`, and the page did not move — twice,
+         * a second apart. Everything in the call had succeeded: the ref resolved, the element was
+         * visible, the click was trusted. Nothing in the answer could distinguish that from a link
+         * that simply does not navigate. So the answer now carries what was under the point, and
+         * says plainly when something else is covering it.
+         */
+        const at = await this.resolveRef(action.ref);
+        const before = at.expect ? (await this.currentPageUrl()).url : '';
+        const clicked = await this.act({ ...action, type: 'click', x: at.x, y: at.y });
+        const answer = { ...clicked, hit: at.hit, covered: at.covered };
+        /*
+         * A link click is checked against the one thing it promised to do.
+         *
+         * `hit` and `covered` were the previous answer to "the click succeeded and the page did
+         * not move", and both are blind to the case that keeps producing it. They are computed by
+         * the renderer, so they can only see what the *page* draws. A browser-native dialog — the
+         * password-manager leak prompt, a permission bubble — is painted by the browser process
+         * over the web contents and suspends input to it. `elementFromPoint` cannot see it, so
+         * `covered` is honestly false, the click is dispatched and reported trusted, and it
+         * reaches nothing.
+         *
+         * Measured twice by QA on the-internet's Logout button, the second time with the cause
+         * visible: `hit=i covered=false`, the URL unchanged, and a foreground Chrome dialog
+         * headed "Passwort ändern" over the page. No CDP event announces such a dialog, so it
+         * cannot be detected — but its effect can. The click still happened and is still reported
+         * as such; what is added is whether the page went where the link pointed.
+         */
+        // `before` must be known for the comparison to mean anything. If the address could not be
+        // read at all, every later reading differs from it and the click would be reported as
+        // having navigated — turning this check into the very thing it exists to catch. An
+        // unreadable address says the session is already in trouble; say nothing rather than
+        // something false.
+        if (at.expect && before) {
+          const settled = await this.waitForUrlChange(before, CLICK_NAVIGATION_MS);
+          answer.navigated = settled;
+          if (!settled) {
+            answer.expected = at.expect;
+            // Under 200 characters, deliberately. The MCP layer renders a driver answer by
+            // printing every field it finds — which is what lets a new field like this one arrive
+            // there without being enumerated — and truncates any value past 200 with an ellipsis.
+            // The first draft ran to 315 and lost its whole second half at exactly that cut: the
+            // caller was told a click had been swallowed and not what to do about it, which is the
+            // half worth having. `expected` already carries the address, so this does not repeat
+            // it. Measured through renderBrowserAction rather than estimated — see its test.
+            answer.note =
+              'delivered, but the page did not go there. A Chrome password or permission dialog in ' +
+              'front of the tab can swallow a click invisibly. Check the screen, or use navigate ' +
+              'to reach the address directly.';
+          }
+        }
+        return answer;
+      }
+      case 'move_ref': {
+        /*
+         * Point at a control without pressing anything.
+         *
+         * Two independent QA runs named this as the one action genuinely missing: menus that open
+         * on hover, tooltips, and anything that reveals its controls only under the pointer were
+         * unreachable, because the only way to a named element was a click — which commits to the
+         * thing the hover was meant to inspect first. Coordinates could not stand in: what a hover
+         * reveals is usually laid out relative to the element, so the point has to be resolved from
+         * the ref at the moment of the move, not read off an older screenshot.
+         */
+        const at = await this.resolveRef(action.ref);
+        const moved = await this.act({ type: 'move', x: at.x, y: at.y });
+        return { ...moved, hit: at.hit, covered: at.covered };
+      }
+      case 'set_value': {
+        const at = await this.resolveRef(action.ref);
+        /**
+         * A native <select> is not a text field and cannot be driven as one.
+         *
+         * Chrome paints its dropdown in the browser process, above the page and outside the
+         * renderer entirely, so no CDP input event aimed at any coordinate reaches an option.
+         * The typing path below is therefore not merely wrong here, it is unobservable: the click
+         * opens a popup the driver cannot see, insertText goes nowhere, and every call still
+         * reports success. QA spent a step on exactly that — click_ref, keyboard, set_value and
+         * typing in turn, no tool error from any of them, and every read-back still showing
+         * "Please select an option".
+         *
+         * Selecting the option and firing input+change is what the page would observe from a real
+         * selection, and is the only route that exists from out here.
+         */
+        if (at.tag === 'select') {
+          const { result: picked, exceptionDetails: pickFailed } = await send('Runtime.evaluate', {
+            expression: `(() => {
+              const el = document.querySelector(${JSON.stringify(at.path)});
+              if (!el || el.tagName !== 'SELECT') return JSON.stringify({ ok: false, reason: 'gone' });
+              if (el.disabled) return JSON.stringify({ ok: false, reason: 'disabled' });
+              const want = ${JSON.stringify(String(action.text ?? ''))};
+              const norm = (s) => String(s == null ? '' : s).trim().toLowerCase();
+              const options = Array.from(el.options);
+              const label = (o) => (o.label || o.textContent || '');
+              // Exact value first, so a page whose values differ from its labels stays drivable
+              // by the value it actually submits; then either spelling, case and space forgiven.
+              const pick =
+                options.find((o) => o.value === want) ||
+                options.find((o) => norm(o.value) === norm(want)) ||
+                options.find((o) => norm(label(o)) === norm(want));
+              if (!pick) {
+                return JSON.stringify({
+                  ok: false, reason: 'no-option',
+                  options: options.filter((o) => !o.disabled).map((o) => label(o).trim()).slice(0, 20)
+                });
+              }
+              if (pick.disabled) return JSON.stringify({ ok: false, reason: 'option-disabled' });
+              el.focus();
+              el.selectedIndex = pick.index;
+              // Both, in this order, and bubbling: 'input' is what a framework binding listens
+              // for and 'change' is what plain pages listen for. A selection that fired neither
+              // would leave the page's own state behind the control the user can see.
+              el.dispatchEvent(new Event('input', { bubbles: true }));
+              el.dispatchEvent(new Event('change', { bubbles: true }));
+              return JSON.stringify({ ok: true, value: el.value, label: label(pick).trim() });
+            })()`,
+            contextId: at.contextId,
+            returnByValue: true
+          });
+          if (pickFailed) throw fail('BROWSER_BAD_REF', `${action.ref} could not be set on this page`);
+          const outcome = JSON.parse(String(picked?.value ?? '{}'));
+          if (outcome.reason === 'gone') throw fail('BROWSER_BAD_REF', `${action.ref} is no longer on this page`);
+          if (outcome.reason === 'disabled') throw fail('BROWSER_ACTION_REFUSED', `${action.ref} is disabled`);
+          if (outcome.reason === 'option-disabled') {
+            throw fail('BROWSER_ACTION_REFUSED', `that option of ${action.ref} is disabled`);
+          }
+          if (outcome.reason === 'no-option') {
+            // Naming the choices costs one line and saves the round trip that guessing would take.
+            const offered = (outcome.options ?? []).filter(Boolean).join(', ');
+            throw fail(
+              'BROWSER_ACTION_REFUSED',
+              `${action.ref} has no option matching that text${offered ? `. Options: ${offered}` : ''}`
+            );
+          }
+          if (outcome.ok !== true) throw fail('BROWSER_BAD_REF', `${action.ref} could not be set on this page`);
+          return { set: action.ref, value: outcome.value, selected: outcome.label };
+        }
+        // Focus by clicking where the control actually is, select everything, then insert.
+        // Writing `value` directly through the DOM skips the input events a page listens for,
+        // so a framework-backed field would look changed and behave as if it never was.
+        await this.act({ type: 'click', x: at.x, y: at.y });
+        // `commands` rather than a modifier, because a modifier only describes the keystroke and
+        // leaves the browser to decide what it means. QA measured what that costs: set_value on
+        // a field holding "OLD TEXT" produced "OLD TEXTONLY NEW" — nothing was selected, so the
+        // insert appended. This names the editing command outright, which is platform-independent
+        // and does not depend on Cmd versus Ctrl being interpreted the way the page expects.
+        await send('Input.dispatchKeyEvent', {
+          type: 'rawKeyDown', modifiers: SELECT_ALL_MODIFIER, key: 'a', code: 'KeyA',
+          windowsVirtualKeyCode: 65, commands: ['selectAll']
+        });
+        await send('Input.dispatchKeyEvent', {
+          type: 'keyUp', modifiers: SELECT_ALL_MODIFIER, key: 'a', code: 'KeyA', windowsVirtualKeyCode: 65
+        });
+        const text = String(action.text ?? '');
+        // insertText with empty text is a no-op, so an intentional clear needs a real delete.
+        // With the whole value selected, one delete removes it — and QA found an empty set_value
+        // reporting ok while the field kept its contents, which is the same missing selection.
+        if (text) await send('Input.insertText', { text });
+        else {
+          await send('Input.dispatchKeyEvent', { type: 'rawKeyDown', key: 'Delete', code: 'Delete', windowsVirtualKeyCode: 46 });
+          await send('Input.dispatchKeyEvent', { type: 'keyUp', key: 'Delete', code: 'Delete', windowsVirtualKeyCode: 46 });
+        }
+        return { set: action.ref, length: text.length };
+      }
+
+      case 'move':
+        await movePointer(action.x, action.y);
+        await send('Input.dispatchMouseEvent', {
+          type: 'mouseMoved', x: action.x, y: action.y, modifiers
+        });
+        return { moved: { x: action.x, y: action.y } };
+
+      case 'click':
+      case 'double_click': {
+        const clickCount = type === 'double_click' ? 2 : 1;
+        const openerTabId = session.tabId;
+        // A click that opens a tab is attributed by Chrome to whichever tab is active, not to
+        // this one — see ensureTabActive's own comment. Without this, createdTab correlation
+        // silently fails whenever the driven tab sits behind the conversation tab, which is the
+        // ordinary case rather than the exception.
+        const { broughtToFront } = await ensureTabActive(session.tabId);
+        const beforeTabs = new Set(
+          (await chrome.tabs.query({}).catch(() => [])).map((tab) => tab.id)
+        );
+        await movePointer(action.x, action.y);
+        await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x: action.x, y: action.y, modifiers });
+        for (let press = 1; press <= clickCount; press++) {
+          await movePointer(action.x, action.y, true);
+          await send('Input.dispatchMouseEvent', {
+            type: 'mousePressed', x: action.x, y: action.y, button, buttons: buttonMask(action.button),
+            clickCount: press, modifiers
+          });
+          await send('Input.dispatchMouseEvent', {
+            type: 'mouseReleased', x: action.x, y: action.y, button, buttons: 0,
+            clickCount: press, modifiers
+          });
+          await movePointer(action.x, action.y);
+        }
+        const createdTab = await findCreatedTab(openerTabId, beforeTabs);
+        return {
+          clicked: { x: action.x, y: action.y, button, clickCount },
+          ...(createdTab ? { createdTab } : {}),
+          ...(broughtToFront ? { broughtToFront } : {})
+        };
+      }
+
+      case 'drag': {
+        const path = Array.isArray(action.path) ? action.path : [];
+        if (path.length < 2) throw fail('BAD_REQUEST', 'drag needs at least two points');
+        const mask = buttonMask(action.button);
+        // A drag presses, moves and releases through the same Input.dispatchMouseEvent calls
+        // click does, and a backgrounded tab defers all of them the same way — see
+        // ensureTabActive's own comment. Missing here, a drag over a backgrounded tab would
+        // fail exactly how scroll and click used to: silently, with no escalation available.
+        const { broughtToFront } = await ensureTabActive(session.tabId);
+        await movePointer(path[0].x, path[0].y, true);
+        await send('Input.dispatchMouseEvent', { type: 'mouseMoved', x: path[0].x, y: path[0].y, modifiers });
+        await send('Input.dispatchMouseEvent', {
+          type: 'mousePressed', x: path[0].x, y: path[0].y, button, buttons: mask, clickCount: 1, modifiers
+        });
+        // Held before moving, and dwelt on before releasing. Both desktop drivers learned this
+        // the hard way and carry the same two numbers; this one still teleported press to
+        // release, so an HTML5 drag never started and a drop target that arms on hover never
+        // armed. A drag that presses and lets go in the same instant is a click with waypoints.
+        await pause(DRAG_PRESS_HOLD_MS);
+        for (const point of path.slice(1)) {
+          await movePointer(point.x, point.y, true);
+          await send('Input.dispatchMouseEvent', {
+            type: 'mouseMoved', x: point.x, y: point.y, button, buttons: mask, modifiers
+          });
+        }
+        const last = path[path.length - 1];
+        await pause(DRAG_DROP_DWELL_MS);
+        await send('Input.dispatchMouseEvent', {
+          type: 'mouseReleased', x: last.x, y: last.y, button, buttons: 0, clickCount: 1, modifiers
+        });
+        await movePointer(last.x, last.y);
+        return { dragged: path.length, ...(broughtToFront ? { broughtToFront } : {}) };
+      }
+
+      case 'scroll': {
+        const x = Number(action.x ?? 0);
+        const y = Number(action.y ?? 0);
+        // A background tab defers the compositor work a scroll gesture and a wheel event both
+        // need — see ensureTabActive's own comment for the measurement. Without this, a scroll
+        // over a backgrounded tab times out and reports moved: false for a scroll that lands a
+        // few seconds later, doubled, the instant something brings the tab back.
+        const { broughtToFront } = await ensureTabActive(session.tabId);
+        await movePointer(x, y);
+        /*
+         * Sent, then judged by whether the page moved — not by whether the protocol answered.
+         *
+         * A wheel event is acknowledged only once the compositor has taken it, and it sometimes
+         * never is: QA hit `Input.dispatchMouseEvent did not answer within 30000 ms` twice in a
+         * real browser on a real page, so scrolling reported failure for an action that was
+         * delivered. Headless never acknowledges one at all. The acknowledgement is a property
+         * of the compositor, not of the scroll.
+         *
+         * So: read the position, send, and look again. A page that moved scrolled, whatever the
+         * protocol said. A page that did not move and did not answer is reported as a timeout,
+         * because then nothing is known.
+         */
+        const dx = Number(action.scroll_x ?? 0);
+        const dy = Number(action.scroll_y ?? 0);
+        const before = await readScrollPosition(send, x, y);
+        const moveFrom = (position) =>
+          position !== null && before !== null && (position.x !== before.x || position.y !== before.y);
+
+        /*
+         * The gesture first, because the event does not work.
+         *
+         * `Input.dispatchMouseEvent` with `type: 'mouseWheel'` is accepted by Chrome 152 and then
+         * does nothing at all — measured on a Mac with a visible browser, at the viewport corner
+         * and at its centre: never acknowledged, never any movement, while `scrollBy` in the same
+         * page moved it 300 pixels. A run through the app saw the same thing, so this was broken
+         * for anyone using it and not merely unverifiable on a build machine.
+         *
+         * `Input.synthesizeScrollGesture` is the protocol's own scrolling primitive: it drives the
+         * compositor rather than posting an event into it, and with `gestureSourceType: 'mouse'`
+         * the page still sees real wheel events.
+         *
+         * Its sign convention is the opposite of the DOM's — `yDistance` is positive to scroll
+         * *up*, while a positive `deltaY` scrolls down — so it is negated here to keep the
+         * caller's convention the DOM one. Getting a scroll sign wrong by reasoning about the
+         * wrong API is exactly how every page once scrolled backwards, so the direction is
+         * asserted against a real browser in `verify:browser` rather than argued about here.
+         */
+        let acknowledged = true;
+        try {
+          await send('Input.synthesizeScrollGesture', {
+            x, y, xDistance: -dx, yDistance: -dy, gestureSourceType: 'mouse'
+          }, SCROLL_TIMEOUT_MS);
+        } catch (error) {
+          if (error?.code !== 'BROWSER_TIMEOUT') throw error;
+          acknowledged = false;
+        }
+        let after = await waitForScrollOnset(send, before, SCROLL_ONSET_TIMEOUT_MS, x, y);
+        if (!moveFrom(after)) {
+          // The wheel event as a fallback: it is what worked before Chrome stopped acting on it,
+          // and a browser that ignores the gesture instead is not one this code has met.
+          try {
+            await send('Input.dispatchMouseEvent', {
+              type: 'mouseWheel', x, y, modifiers, deltaX: dx, deltaY: dy
+            }, SCROLL_TIMEOUT_MS);
+            acknowledged = true;
+          } catch (error) {
+            if (error?.code !== 'BROWSER_TIMEOUT') throw error;
+            acknowledged = false;
+          }
+          after = await waitForScrollOnset(send, before, SCROLL_ONSET_TIMEOUT_MS, x, y);
+        }
+        if (moveFrom(after)) {
+          await settleAfterScroll(send, x, y);
+          after = await readScrollPosition(send, x, y);
+        }
+        const moved = moveFrom(after);
+        // Not moving is not the same as not working. A page already at its end does not move, and
+        // refusing that would be wrong. What is worth refusing is knowing nothing at all: nothing
+        // acknowledged and nothing moved means the scroll may as well not have been sent.
+        if (!acknowledged && !moved) {
+          throw fail(
+            'BROWSER_SCROLL_FAILED',
+            `neither a scroll gesture nor a wheel event was taken at ${x},${y}, and the page did ` +
+              'not move. Scroll over the element that actually scrolls, or observe first to see ' +
+              'where the page is.'
+          );
+        }
+        return { scrolled: { x, y }, moved, acknowledged, ...(broughtToFront ? { broughtToFront } : {}) };
+      }
+
+      case 'type': {
+        // insertText rather than a keystroke per character: it is one round trip instead of
+        // hundreds, it does not depend on the layout, and it is what a paste looks like to
+        // the page. Composition-sensitive editors still see a real input event.
+        const text = String(action.text ?? '');
+        if (!text) return { typed: 0 };
+        await send('Input.insertText', { text });
+        return { typed: text.length };
+      }
+
+      case 'keypress': {
+        const names = Array.isArray(action.keys) ? action.keys : [];
+        if (names.length === 0) throw fail('BAD_REQUEST', 'keypress needs at least one key');
+        const held = names.filter((name) => MODIFIERS[String(name).toLowerCase()] !== undefined);
+        const plain = names.filter((name) => MODIFIERS[String(name).toLowerCase()] === undefined);
+        const bits = held.reduce((all, name) => all | MODIFIERS[String(name).toLowerCase()], modifiers);
+        // A chord of modifiers alone is a real thing to send; a chord with keys sends those
+        // keys while the modifier bits are set, which is what every page listens for.
+        const targets = plain.length > 0 ? plain : held;
+        for (const name of targets) {
+          const key = keyDescriptor(name);
+          const base = {
+            modifiers: bits,
+            key: key.key,
+            code: key.code,
+            windowsVirtualKeyCode: key.vk,
+            nativeVirtualKeyCode: key.vk
+          };
+          // A modifier held down must not also insert text, and neither must a chord:
+          // Ctrl+A types nothing, it selects.
+          const text = bits === 0 && key.text ? key.text : undefined;
+          await send('Input.dispatchKeyEvent', { ...base, type: text ? 'keyDown' : 'rawKeyDown', text });
+          await send('Input.dispatchKeyEvent', { ...base, type: 'keyUp' });
+        }
+        return { pressed: names.length };
+      }
+
+      case 'wait': {
+        const ms = Math.min(10_000, Math.max(0, Number(action.ms ?? 250)));
+        await new Promise((resolve) => setTimeout(resolve, ms));
+        return { waited: ms };
+      }
+
+      default:
+        throw fail('BAD_REQUEST', `unknown browser action ${type || '(none)'}`);
+    }
+  },
+
+  /** One look: what the page is, what can be acted on, and a picture of it. */
+  async observe({ includeScreenshot = true } = {}) {
+    // Reading a page is as much a use of the session as acting on one — a refused page must not
+    // be readable either, and observe is how anything would be read.
+    if (session) await this.assertPageStillAllowed();
+    // And the screenshot below is where the pointer has to appear. A page can replace its own
+    // document without any navigation action to hook — a clicked link, a redirect — so drawing
+    // it here covers what re-drawing after the navigation actions cannot.
+    if (session) await restorePointer();
+    await this.ensureAttached();
+    const tab = await currentTab(session.tabId);
+    session.url = tab.url ?? session.url;
+    session.title = tab.title ?? session.title;
+    // Bumped before collecting, so every ref this observation mints is stamped with a number no
+    // earlier observation ever used and no later one ever will.
+    session.refGeneration = (session.refGeneration ?? 0) + 1;
+    const page = await collectElements(session.refGeneration);
+    // Only the newest observation's refs are addressable. Keeping older ones alive would let
+    // a ref from three pages ago resolve against whatever happens to match now.
+    session.refs = new Map(
+      (page.elements ?? []).map((element) => [
+        element.ref,
+        // No offset stored. It used to read element.frameX/frameY, which collectElements never
+        // sets — so it was always {0,0}, harmless only because resolveRef recomputes the offset
+        // from the frame itself and ignored the stored value. A dead field that looks like a
+        // fallback is worse than no field: the next reader trusts it.
+        { path: element.path, frameId: element.frameId }
+      ])
+    );
+    const view = await viewport();
+    const shot = includeScreenshot ? await screenshot() : null;
+    return {
+      tabId: session.tabId,
+      url: page.url || session.url,
+      title: page.title || session.title,
+      viewport: view,
+      scrollY: page.scrollY,
+      scrollHeight: page.scrollHeight,
+      // The path and the frame are how a ref is resolved, not something the model should
+      // reason about: it names a ref and gets coordinates already in the page's own space.
+      elements: (page.elements ?? []).map(({ path, frameId, ...element }) => element),
+      screenshot: shot
+    };
+  }
+};
+
+/**
+ * The browser tearing a session down is not an error, it is news.
+ *
+ * A user closing the tab, hitting Chrome's own "Cancel" on the debugging banner, or opening
+ * DevTools all end the session without asking us. Forgetting it here is what keeps `status()`
+ * honest and stops the next action from addressing a tab that is not ours any more.
+ */
+let lifecycleInstalled = false;
+
+export function installBrowserDriverLifecycle() {
+  if (lifecycleInstalled) return;
+  lifecycleInstalled = true;
+  chrome.debugger.onDetach.addListener((source) => {
+    if (source?.tabId !== undefined) browserDriver.forget(source.tabId);
+  });
+  chrome.tabs.onRemoved.addListener((tabId) => browserDriver.forget(tabId));
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,11 +3,16 @@
   "name": "Chat On Steroids companion",
   "version": "2.0.8",
   "description": "Records your ChatGPT session into the local Chat On Steroids app and labels its MCP tool calls with what they actually did.",
-  "minimum_chrome_version": "116",
+  "minimum_chrome_version": "121",
   "permissions": [
     "storage",
     "scripting",
-    "alarms"
+    "alarms",
+    "debugger"
+  ],
+  "optional_permissions": [
+    "tabs",
+    "tabGroups"
   ],
   "host_permissions": [
     "https://chatgpt.com/*",
@@ -17,6 +22,9 @@
     "http://127.0.0.1:8767/*",
     "http://127.0.0.1:8768/*",
     "http://127.0.0.1:8769/*"
+  ],
+  "optional_host_permissions": [
+    "<all_urls>"
   ],
   "background": {
     "service_worker": "background.js",

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -641,3 +641,20 @@ button:focus-visible {
   font-size: 12px;
   line-height: 1.4;
 }
+
+/*
+ * Why browser control could not be switched on.
+ *
+ * A refused permission used to leave no trace: the switch snapped back and said nothing, so a
+ * request the browser was never going to grant looked like a broken control. Uses the same red
+ * the capture rows already use, so a problem reads as a problem here too.
+ */
+.perm-error {
+  margin: 2px 12px 8px;
+  padding: 7px 9px;
+  border-radius: 8px;
+  background: var(--red-soft);
+  color: var(--red);
+  font-size: 11px;
+  line-height: 1.4;
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -84,6 +84,13 @@
         <input id="overwriteToggle" type="checkbox" checked />
         <span class="track" aria-hidden="true"><span class="thumb"></span></span>
       </label>
+      <label class="row" for="browserControlToggle" title="Let the app drive other browser tabs: real clicks and keystrokes through the DevTools protocol, with a visible pointer. The browser asks for site access the first time. ChatGPT's own tabs, browser pages and local files are always refused.">
+        <svg class="ico"><use href="#i-pen" /></svg>
+        <span class="name">Browser control</span>
+        <input id="browserControlToggle" type="checkbox" />
+        <span class="track" aria-hidden="true"><span class="thumb"></span></span>
+      </label>
+      <p class="perm-error" id="browserControlError" hidden></p>
       <label class="row" for="timeToggle">
         <svg class="ico"><use href="#i-clock" /></svg>
         <span class="name">Timestamps</span>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -364,6 +364,9 @@ async function loadPreferences() {
   showTimes = stored[SHOW_TIMES_KEY] === true;
   syncOverwrite();
   $('timeToggle').checked = showTimes;
+  // The browser-control row reflects a browser permission rather than a stored preference,
+  // so it has to be read on open. Without this it only paints after somebody clicks it.
+  await syncBrowserControl();
 }
 
 /** Puts one value on the clipboard and says so in place, without moving anything. */
@@ -426,6 +429,145 @@ $('overwriteToggle').addEventListener('change', async () => {
   } catch {
     overwriteEnabled = previous;
     syncOverwrite();
+  }
+});
+
+/**
+ * Browser control is the one switch that changes what the extension is allowed to do.
+ *
+ * Chrome only shows a permission prompt from a real user gesture, which is why this lives in
+ * the popup rather than in a settings round trip: the click that turns it on *is* the consent.
+ * Turning it off both revokes the permissions and drops any live session, so "off" means the
+ * capability is gone, not merely unused.
+ */
+/**
+ * Chrome answers a callback and returns nothing; Firefox returns a promise and ignores the
+ * callback. Waiting only for the callback waits forever on Firefox, which this extension
+ * supports, so whichever the browser actually hands back is accepted.
+ */
+/*
+ * What browser control still asks for at runtime.
+ *
+ * `debugger` is deliberately absent, and this is the whole reason the switch used to be
+ * unusable: Chrome does not accept `debugger` in optional_permissions. It drops the entry when
+ * the manifest loads, so a later request for it comes back "Only permissions specified in the
+ * manifest may be requested" — verified against Chrome 152. Every request here failed on that
+ * one entry, the failure was swallowed, and the toggle simply snapped back off. `debugger` is a
+ * required permission now; site and tab access stay optional, which is what actually decides
+ * whether this extension can read a page.
+ */
+const BROWSER_CONTROL_PERMISSIONS = {
+  permissions: ['tabs', 'tabGroups'],
+  origins: ['<all_urls>']
+};
+
+/**
+ * Shows why browser control could not be switched on, or clears it.
+ *
+ * A permission refusal used to be invisible: the switch flipped back and said nothing, so a
+ * request Chrome was never going to grant looked like a broken control. The message is the
+ * browser's own wherever there is one, because a summary loses the detail that makes it fixable.
+ */
+function showBrowserControlError(message) {
+  const node = document.getElementById('browserControlError');
+  if (!node) return;
+  node.textContent = message ?? '';
+  node.hidden = !message;
+}
+
+/** The reason the last permission call failed, for the popup to show rather than hide. */
+let lastPermissionError = null;
+
+function browserPermissions(method) {
+  lastPermissionError = null;
+  return new Promise((resolve) => {
+    const api = webext?.permissions;
+    if (!api?.[method]) return resolve(false);
+    try {
+      const returned = api[method](BROWSER_CONTROL_PERMISSIONS, (granted) => {
+        // Kept, not discarded: a refusal the user cannot see reads as a broken switch, which is
+        // exactly how a permission Chrome would never grant went unnoticed.
+        lastPermissionError = chrome.runtime.lastError?.message ?? null;
+        resolve(Boolean(granted));
+      });
+      if (returned && typeof returned.then === 'function') {
+        returned.then(
+          (granted) => resolve(Boolean(granted)),
+          (error) => {
+            lastPermissionError = error?.message ?? String(error);
+            resolve(false);
+          }
+        );
+      }
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+async function syncBrowserControl() {
+  // Whether the browser knows this permission at all, which is not the same as holding it.
+  // `chrome.debugger` does not exist until the permission is granted, so testing for that
+  // object would hide the switch that grants it and make the feature unreachable — measured
+  // in a real Edge run, where the popup saw no debugger API before granting.
+  const supported = await new Promise((resolve) => {
+    try {
+      const returned = chrome.permissions.contains({ permissions: ['debugger'] }, (held) => {
+        resolve(!chrome.runtime.lastError && typeof held === 'boolean');
+      });
+      if (returned && typeof returned.then === 'function') {
+        returned.then(() => resolve(true), () => resolve(false));
+      }
+    } catch {
+      resolve(false);
+    }
+  });
+  $('browserControlToggle').closest('.row').hidden = !supported;
+  if (!supported) return;
+  try {
+    const status = await chrome.runtime.sendMessage({ type: 'browser_status' });
+    const on = status?.granted === true;
+    $('browserControlToggle').checked = on;
+    $('browserControlToggle').closest('.row')?.classList.toggle('on', on);
+    // A worker that answers with a failure is not the same as one that says "not granted", and
+    // the switch cannot show the difference. It showed off for both, which is how a worker that
+    // could not load the driver at all looked exactly like a permission nobody had granted.
+    showBrowserControlError(
+      status?.ok === false && status?.error
+        ? `Browser control is unavailable: ${status.error}`
+        : null
+    );
+  } catch (error) {
+    $('browserControlToggle').checked = false;
+    showBrowserControlError(
+      `Browser control could not be read from the extension worker: ${error?.message ?? String(error)}`
+    );
+  }
+}
+
+$('browserControlToggle').addEventListener('change', async () => {
+  const wanted = $('browserControlToggle').checked === true;
+  try {
+    if (wanted) {
+      if (!(await browserPermissions('request'))) {
+        $('browserControlToggle').checked = false;
+        showBrowserControlError(
+          lastPermissionError
+            ? `Browser control could not be enabled: ${lastPermissionError}`
+            : 'Browser control could not be enabled. The browser declined the permission request.'
+        );
+      } else {
+        showBrowserControlError(null);
+      }
+    } else {
+      showBrowserControlError(null);
+      // Stop first, then revoke: revoking under a live session would leave a debugger
+      // attachment this extension can no longer address, and the banner with it.
+      await chrome.runtime.sendMessage({ type: 'browser_detach' }).catch(() => null);
+      await browserPermissions('remove');
+    }
+  } finally {
+    await syncBrowserControl();
   }
 });
 

--- a/scripts/smoke-packaged-runtime.mjs
+++ b/scripts/smoke-packaged-runtime.mjs
@@ -73,6 +73,7 @@ for (const relative of [
   'LICENSES.chromium.html',
   'extension/manifest.json',
   'extension/background.js',
+  'extension/browser-driver.js',
   'extension/chatgpt-dom.js',
   'extension/content.js',
   'extension/fiber.js',

--- a/src/main/browser-control.ts
+++ b/src/main/browser-control.ts
@@ -1,0 +1,168 @@
+/**
+ * The app's side of browser control.
+ *
+ * The driver that does the work lives in the extension's service worker, because only an
+ * extension can hold a DevTools session and only a DevTools session produces trusted input.
+ * This is the other end: a place to park one command per conversation, hand it to the browser
+ * that asks, and wake the caller when the answer comes back.
+ *
+ * ## Why it rides on `/activity`
+ *
+ * The alternatives were a WebSocket the bridge does not speak, or a native messaging host that
+ * would need an installer change on every platform. Neither is necessary. A browser command is
+ * always issued *by* a ChatGPT conversation, so the tab that will carry it is open by
+ * definition, and its content script is already polling `/activity` several times a second
+ * while work is live. Riding that poll costs one field in a reply that is already in flight,
+ * inherits the ownership model that decides which conversation a request belongs to, and
+ * cannot outlive the page it belongs to.
+ *
+ * ## One at a time
+ *
+ * A conversation may have exactly one command outstanding. Browser actions are ordered — a
+ * click after a scroll means something different from the reverse — and a queue that could
+ * reorder or interleave them would be a queue that occasionally does the wrong thing on a page
+ * nobody is watching.
+ */
+
+/**
+ * How long a command may wait to be collected and answered before the caller gives up.
+ *
+ * Has to outlast the driver, not merely match it. The extension allows a navigate or a reload 30
+ * seconds and a screenshot the same, an observe walks up to a dozen frames before it captures,
+ * and none of that starts until the page collects the command on its next activity poll — up to
+ * two seconds later. Sharing the driver's own number meant a slow navigate reported
+ * BROWSER_TIMEOUT for an action that had in fact succeeded, and abandoned the rest of the batch
+ * on the strength of it.
+ */
+const BROWSER_COMMAND_TIMEOUT_MS = 45_000;
+
+export interface BrowserCommandResult {
+  ok: boolean;
+  /** Whatever the driver returned; shape depends on the action. */
+  data?: Record<string, unknown>;
+  error?: string;
+  detail?: string;
+}
+
+interface PendingCommand {
+  id: string;
+  conversationId: string;
+  action: Record<string, unknown>;
+  /** Set once a browser has actually taken the command, so a re-poll does not run it twice. */
+  collectedAt: number | null;
+  settle: (result: BrowserCommandResult) => void;
+  timer: NodeJS.Timeout;
+}
+
+const pending = new Map<string, PendingCommand>();
+
+let counter = 0;
+const nextId = (): string => `bc-${Date.now().toString(36)}-${(++counter).toString(36)}`;
+
+function finish(command: PendingCommand, result: BrowserCommandResult): void {
+  clearTimeout(command.timer);
+  if (pending.get(command.conversationId) === command) pending.delete(command.conversationId);
+  command.settle(result);
+}
+
+/**
+ * Queues one action for the browser showing this conversation and waits for its answer.
+ *
+ * Rejects rather than queues when something is already outstanding: the caller is a tool call
+ * that is itself waiting, so a second one arriving means the model issued two actions at once,
+ * and running them in an order nobody chose is worse than refusing the second.
+ */
+export function runBrowserCommand(
+  conversationId: string,
+  action: Record<string, unknown>
+): Promise<BrowserCommandResult> {
+  const existing = pending.get(conversationId);
+  if (existing) {
+    return Promise.resolve({
+      ok: false,
+      error: 'BROWSER_BUSY',
+      detail: 'another browser action for this conversation is still running'
+    });
+  }
+
+  return new Promise<BrowserCommandResult>((resolve) => {
+    const command: PendingCommand = {
+      id: nextId(),
+      conversationId,
+      action,
+      collectedAt: null,
+      settle: resolve,
+      timer: setTimeout(() => {
+        finish(command, {
+          ok: false,
+          error: 'BROWSER_TIMEOUT',
+          // The two cases differ in what the caller may safely do next, and only one of them is
+          // safe to retry. QA hit the second: the click landed, the page changed, and the reply
+          // was a failure — a blind retry would have clicked twice. So the message says what to
+          // do rather than only what went wrong.
+          detail: command.collectedAt === null
+            ? 'no browser tab collected the action, so it did not run; is the ChatGPT tab still open and paired? Safe to retry.'
+            : 'the browser took the action and did not report back, so it may well have happened. Do NOT retry it — observe first and decide from what the page now shows.'
+        });
+      }, BROWSER_COMMAND_TIMEOUT_MS)
+    };
+    pending.set(conversationId, command);
+  });
+}
+
+/**
+ * The command this conversation should carry, if any, marked as collected.
+ *
+ * Handed out once. A second poll before the result arrives gets nothing, so two tabs showing
+ * the same conversation cannot both perform the same click.
+ */
+export function collectBrowserCommand(
+  conversationId: string
+): { id: string; action: Record<string, unknown> } | null {
+  const command = pending.get(conversationId);
+  if (!command || command.collectedAt !== null) return null;
+  command.collectedAt = Date.now();
+  return { id: command.id, action: command.action };
+}
+
+/**
+ * Delivers a browser's answer.
+ *
+ * Returns false for an id this conversation does not have outstanding — a late result from a
+ * command that already timed out, or a report aimed at another chat. Neither is trusted.
+ */
+export function settleBrowserCommand(
+  conversationId: string,
+  id: string,
+  result: BrowserCommandResult
+): boolean {
+  const command = pending.get(conversationId);
+  if (!command || command.id !== id) return false;
+  finish(command, result);
+  return true;
+}
+
+/** Gives up anything outstanding for a conversation whose page has gone. */
+export function abandonBrowserCommands(conversationId: string): void {
+  const command = pending.get(conversationId);
+  if (!command) return;
+  finish(command, {
+    ok: false,
+    error: 'BROWSER_GONE',
+    // Same distinction as the timeout, for the same reason: whether it was collected decides
+    // whether it may have run, and that decides whether a retry is safe.
+    detail:
+      command.collectedAt === null
+        ? 'the ChatGPT page closed before any tab collected the action, so it did not run. Safe to retry once a page is back.'
+        : 'the ChatGPT page closed after a tab took the action, so it may well have happened. Do NOT retry it — observe first.'
+  });
+}
+
+/** Tests only: no command may survive from one case into the next. */
+export function resetBrowserControlForTests(): void {
+  for (const command of [...pending.values()]) {
+    clearTimeout(command.timer);
+    command.settle({ ok: false, error: 'BROWSER_GONE', detail: 'reset' });
+  }
+  pending.clear();
+}

--- a/src/main/mcp/surfaces.ts
+++ b/src/main/mcp/surfaces.ts
@@ -133,7 +133,7 @@ const DESKTOP: SurfaceDefinition = {
   cardSummary:
     'Screenshots, windows, mouse/keyboard control and the clipboard. Optional — connect it only if you want desktop automation.',
   required: false,
-  tools: ['observe', 'computer']
+  tools: ['observe', 'computer', 'browser']
 };
 
 const PLUGINS: SurfaceDefinition = {

--- a/src/main/mcp/tools-browser.ts
+++ b/src/main/mcp/tools-browser.ts
@@ -1,0 +1,226 @@
+/**
+ * The browser connector tool: driving a real web page through the companion extension.
+ *
+ * Separate from tools-desktop because the two answer different questions. The desktop driver
+ * can click anywhere in a browser window but cannot see a web page: it has no refs, no DOM and
+ * no way to tell a link from the pixels around it. This tool speaks to the page itself.
+ *
+ * Kept in its own module so the capability is reviewable on its own terms: its tab ownership,
+ * its live capability gate and its bounded output are all here, and none of it is entangled
+ * with native desktop input.
+ */
+
+import { z } from 'zod';
+import { runBrowserCommand } from '../browser-control.js';
+import { currentCall } from './call-context.js';
+import { desktopImageResult } from './tools-desktop.js';
+import {
+  fail,
+  imageCoordinateArg,
+  mouseButtonArg,
+  ok,
+  pointArg,
+  type SurfaceRegistrar
+} from './kernel.js';
+
+const scrollDeltaArg = z.number().int().min(-10_000).max(10_000);
+
+const browserActionArg = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('observe') }).strict().describe('Page, refs, screenshot.'),
+  // The driver has always been able to let go of a tab and the command channel has always
+  // carried the message; only this schema never offered it, so a model could take control of a
+  // page and had no way to give it back. QA reached for the extension popup instead and clicked
+  // it with desktop automation, which is neither reliable nor what anyone should have to do.
+  z.object({ type: z.literal('detach') }).strict().describe('Let go of the tab.'),
+  z.object({ type: z.literal('status') }).strict().describe('Which tab is held.'),
+  z.object({ type: z.literal('navigate'), url: z.string().min(1).max(2_000) }).strict().describe('Go to a URL.'),
+  z.object({ type: z.literal('back') }).strict().describe('Back.'),
+  z.object({ type: z.literal('forward') }).strict().describe('Forward.'),
+  z.object({ type: z.literal('reload') }).strict().describe('Reload.'),
+  // 32, not 16: refs now carry the observation generation that minted them (e.g. "g12_e4"), so a
+  // stale one from an earlier observation never coincidentally matches a live one after a later
+  // observation recycles the same short index.
+  z.object({ type: z.literal('click_ref'), ref: z.string().min(1).max(32), button: mouseButtonArg.optional() }).strict().describe('Click a ref.'),
+  // The select half is worth its bytes: a native dropdown cannot be driven by clicking, because
+  // Chrome paints it outside the page, and a QA run burned a step discovering that the hard way.
+  z.object({ type: z.literal('set_value'), ref: z.string().min(1).max(32), text: z.string().max(20_000) }).strict().describe('Replace a field by ref. On a select, picks the option with that label or value.'),
+  z.object({ type: z.literal('click'), x: imageCoordinateArg, y: imageCoordinateArg, button: mouseButtonArg.optional() }).strict().describe('Click at pixels.'),
+  z.object({ type: z.literal('double_click'), x: imageCoordinateArg, y: imageCoordinateArg }).strict().describe('Double-click at pixels.'),
+  z.object({ type: z.literal('move'), x: imageCoordinateArg, y: imageCoordinateArg }).strict().describe('Move the pointer.'),
+  z.object({ type: z.literal('move_ref'), ref: z.string().min(1).max(32) }).strict().describe('Hover a ref, pressing nothing.'),
+  z.object({ type: z.literal('drag'), path: z.array(pointArg).min(2).max(64), button: mouseButtonArg.optional() }).strict().describe('Drag along a path.'),
+  z.object({ type: z.literal('scroll'), x: imageCoordinateArg, y: imageCoordinateArg, scroll_x: scrollDeltaArg.optional(), scroll_y: scrollDeltaArg.optional() }).strict().describe('Scroll at a point.'),
+  z.object({ type: z.literal('type'), text: z.string().max(4_000) }).strict().describe('Type into focus.'),
+  z.object({ type: z.literal('keypress'), keys: z.array(z.string().max(20)).min(1).max(6) }).strict().describe('Press keys.'),
+  z.object({ type: z.literal('wait'), ms: z.number().int().min(0).max(10_000).optional() }).strict().describe('Pause.')
+]);
+
+export function registerBrowserTool(reg: SurfaceRegistrar): void {
+  const { exposedCaps } = reg;
+    /**
+     * Web-page control, carried out by the extension rather than the operating system.
+     *
+     * Everything here goes through the ChatGPT page that issued the call: the app parks one
+     * action, that page collects it on its next activity poll, and the extension's service
+     * worker performs it over the DevTools protocol. The worker is the only part that can hold
+     * such a session, and a DevTools session is the only route to trusted input — events a
+     * content script dispatches are `isTrusted: false` and real pages reject them.
+     *
+     * Refused for ChatGPT's own tabs before anything else, in the driver: the model asking for
+     * this is sitting in one, and a driver able to attach there could drive its own
+     * conversation.
+     */
+    if (exposedCaps.control) reg.register(
+      'browser',
+      {
+        title: 'Control a web page',
+        description:
+          'Drive a web page. observe first: refs plus a screenshot whose pixels are the coordinates. ' +
+          'Prefer refs — re-resolved before use, so a moved element is hit and a vanished one refuses. ' +
+          'No attach step: navigate starts a run, taking the newest ordinary tab or opening ' +
+          'one; ChatGPT tabs are never driven. Needs browser control on in the extension popup.',
+        inputSchema: z.object({ actions: z.array(browserActionArg).min(1).max(20) }).strict(),
+        annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }
+      },
+      async (input) =>
+        reg.guarded('control', 'browser', async () => {
+          // The conversation is the address: the action is delivered to the page showing it,
+          // which is the same evidence every identity-sensitive route in this app uses.
+          const conversationId = currentCall()?.caller.conversationId ?? null;
+          if (!conversationId) {
+            return fail(
+              'CALLER_IDENTITY_REQUIRED: browser control is delivered to the ChatGPT page that asked for it, ' +
+                'and this call could not be attributed to a conversation. No browser action was taken.'
+            );
+          }
+
+          // One block per action rather than one flat list, because an earlier observation has
+          // to be removable at the end: the driver keeps only the newest observation's refs
+          // addressable and replaces that map wholesale each time. Printing every observation's
+          // refs hands back a list whose earlier half is already dead, with nothing marking
+          // which half — a model would pick one, be refused, and have no reason why.
+          const blocks: Array<{ observed: boolean; lines: string[] }> = [];
+          let shot: { data: string; width: number; height: number } | null = null;
+          for (const [index, action] of input.actions.entries()) {
+            const reply = await runBrowserCommand(conversationId, action as Record<string, unknown>);
+            if (!reply.ok) {
+              // Stops at the first failure rather than pressing on: later actions were chosen
+              // for a page state that this one did not produce.
+              return fail(
+                // The detail is a sentence written by the driver and often ends in one already;
+                // appending a second full stop produced "let go of.." in a run's report. Small,
+                // but it is the kind of thing that makes an error message look unfinished.
+                `${reply.error ?? 'BROWSER_FAILED'}: ` +
+                  `${(reply.detail ?? 'the browser action did not complete').replace(/\.\s*$/, '')}. ` +
+                  `Completed ${index} of ${input.actions.length}.`
+              );
+            }
+            const data = reply.data ?? {};
+            const rendered = renderBrowserAction(action.type, data);
+            blocks.push({ observed: rendered.observed, lines: rendered.lines });
+            if (rendered.screenshot) shot = rendered.screenshot;
+          }
+
+          const newestObservation = blocks.reduce(
+            (latest, block, index) => (block.observed ? index : latest),
+            -1
+          );
+          const body = blocks
+            .flatMap((block, index) =>
+              block.observed && index !== newestObservation
+                ? ['observe: superseded by a later observation in this call; those refs are gone']
+                : block.lines
+            )
+            .join('\n');
+          if (shot) {
+            return desktopImageResult(
+              `${body}\nScreenshot ${shot.width}x${shot.height}; its pixels are the coordinates for this page.`,
+              shot.data
+            );
+          }
+          return ok(body);
+        })
+    );
+}
+
+/**
+ * One browser action, rendered as the driver answered it.
+ *
+ * Pulled out of the tool so it can be tested. It was inline, reachable only through a live
+ * extension and a real browser, and it silently replaced every reply but observe and status with
+ * the word `ok` — discarding `hit`, `covered`, and the driver build. The driver had a suite that
+ * proved those fields, the helper had one too, and the piece between them had none, so a QA run
+ * found it instead of a test. Being a plain function of its input is what fixes that.
+ */
+export function renderBrowserAction(
+  type: string,
+  data: Record<string, unknown>
+): { observed: boolean; lines: string[]; screenshot?: { data: string; width: number; height: number } } {
+  if (type === 'observe') {
+            const elements = Array.isArray(data['elements']) ? (data['elements'] as Array<Record<string, unknown>>) : [];
+            const picture = data['screenshot'] as { data: string; width: number; height: number } | null | undefined;
+            return ({
+              observed: true,
+              ...(picture && typeof picture.data === 'string' ? { screenshot: picture } : {}),
+              lines: [
+              `page: ${String(data['url'] ?? '')}`,
+              `title: ${String(data['title'] ?? '')}`,
+              ...elements.map(
+                (element) =>
+                  `${String(element['ref'])} ${String(element['role'])} ${JSON.stringify(String(element['name'] ?? ''))}` +
+                  // What the control currently holds. The driver has collected both since it was
+                  // written and neither was ever printed, so a checkbox that is already ticked
+                  // looked exactly like one that is not — and the only way to find out was to
+                  // click it, which is also the way to get it wrong. Same for a field that
+                  // already contains the text a caller is about to set.
+                  `${element['checked'] ? ` checked=${String(element['checked'])}` : ''}` +
+                  `${element['value'] ? ` value=${JSON.stringify(String(element['value']))}` : ''}` +
+                  `${element['disabled'] === true ? ' disabled' : ''} at ${String(element['x'])},${String(element['y'])}`
+              )
+            ] });
+          } else if (type === 'detach' || type === 'status') {
+            // These answer a question about the session rather than doing something to a page,
+            // so "ok" is not an answer. Say which tab is held, or that none is.
+            const attached = data['attached'] === true;
+            const released = data['released'] as Record<string, unknown> | undefined;
+            // The digest of the driver Chrome is actually running. Installing a package
+            // rewrites the extension folder, but Chrome keeps the copy it already loaded until
+            // someone reloads it by hand — so a run can measure old code while reading new
+            // release notes, and has. This is the only place a caller can ask which code
+            // answered, which is why it belongs on the answer that reports the session.
+            const build = data['build'] === undefined || data['build'] === null
+              ? '; driver build unreported'
+              : `; driver build ${String(data['build'])}`;
+            return ({ observed: false, lines: [
+              attached
+                ? `${type}: holding tab ${String(data['tabId'])} — ${String(data['title'] ?? '')} ` +
+                  `(${String(data['url'] ?? '')})` +
+                  // The group is the visible claim that this tab is being driven. Saying it here
+                  // is what lets the caller check that claim instead of a person having to look
+                  // at the tab strip.
+                  (data['groupId'] === null || data['groupId'] === undefined
+                    ? ', not in a driven group'
+                    : `, in driven group ${String(data['groupId'])}`)
+                : released
+                  ? `${type}: let go of tab ${String(released['tabId'])} — ` +
+                    `${String(released['title'] ?? '')} (${String(released['url'] ?? '')}); ` +
+                    'no tab is under control'
+                  : `${type}: no tab is under control`
+            ].map((line) => line + build) });
+          } else {
+            // Everything the driver answered with, rather than the fields this renderer
+            // happens to know about. `ok` threw away three separate pieces of evidence a QA
+            // run needed — `hit`, `covered`, and the driver build — and no test could catch
+            // it, because all three existed and were correct one layer below. A run then
+            // reported working fixes as missing, twice. Reading the answer instead of
+            // enumerating it means the next field a driver adds arrives on its own.
+            const said = Object.entries(data)
+              .filter(([, value]) => value !== undefined)
+              .map(([key, value]) => {
+                const text = value !== null && typeof value === 'object' ? JSON.stringify(value) : String(value);
+                return `${key}=${text.length > 200 ? `${text.slice(0, 200)}…` : text}`;
+              })
+              .join(' ');
+            return ({ observed: false, lines: [`${type}: ${said || 'ok'}`] });
+          }
+}

--- a/src/main/mcp/tools-desktop.ts
+++ b/src/main/mcp/tools-desktop.ts
@@ -94,7 +94,7 @@ const MCP_RESPONSE_ENVELOPE_RESERVE_BYTES = 64 * 1024;
  * The image and its observation text share one MCP response budget. The capture layer can
  * bound PNG bytes, but only this final assembly layer knows the actual control metadata.
  */
-function desktopImageResult(text: string, data: string): { content: ToolContent[] } {
+export function desktopImageResult(text: string, data: string): { content: ToolContent[] } {
   const result = {
     content: [
       { type: 'text', text } as ToolContent,

--- a/src/main/mcp/tools.ts
+++ b/src/main/mcp/tools.ts
@@ -19,6 +19,7 @@ import type { PluginToolSchema } from '../../shared/plugin-refresh.js';
 import { createRegistrar, type ToolContext } from './kernel.js';
 import { registerCoreTools } from './tools-core.js';
 import { registerDesktopTools } from './tools-desktop.js';
+import { registerBrowserTool } from './tools-browser.js';
 import { registerPluginTools } from './tools-plugins.js';
 import { surfaceDefinition, type SurfaceId } from './surfaces.js';
 import { serverInstructions } from './instructions.js';
@@ -45,7 +46,12 @@ export function buildServer(ctx: ToolContext, surface: SurfaceId, observe?: (con
     tools.push({ name, description: config.description, inputSchema: { type: 'object', ...schema }, ...(config.annotations ? { annotations: { ...config.annotations } } : {}) });
   } : undefined);
   if (surface === 'core') registerCoreTools(registrar);
-  else registerDesktopTools(registrar);
+  else {
+    registerDesktopTools(registrar);
+    // Driving a web page is its own capability with its own gate; it rides the Desktop
+    // surface because that is where control-class tools live, not because it is desktop input.
+    registerBrowserTool(registrar);
+  }
 
   // Cheap self-check on a property the tests assert and the design depends on: a surface
   // may register fewer tools than it declares — permissions decide that — but it may never

--- a/test/browser-answer.test.ts
+++ b/test/browser-answer.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import { renderBrowserAction } from '../src/main/mcp/tools-browser';
+
+/**
+ * The layer that lost three fixes.
+ *
+ * The driver had a suite proving it returns `hit`, `covered` and its own build; the macOS helper
+ * had one too. Between them sat the rendering, reachable only through a live extension and a real
+ * browser, and it replaced every reply but observe and status with the word `ok`. Two QA runs
+ * reported working fixes as missing, and one of them I answered by blaming their browser — which
+ * was wrong, and cost them a round.
+ *
+ * These tests call the rendering directly. Each one fails against the code as it was.
+ */
+describe('a browser answer carries what the driver answered', () => {
+  it('keeps the fields that say where a click actually landed', () => {
+    const { lines } = renderBrowserAction('click_ref', {
+      clicked: { x: 12, y: 34 },
+      hit: 'a#result',
+      covered: true
+    });
+    expect(lines[0]).toContain('hit=a#result');
+    expect(lines[0]).toContain('covered=true');
+  });
+
+  it('keeps them for a hover too, which is a different action and the same question', () => {
+    const { lines } = renderBrowserAction('move_ref', { moved: { x: 5, y: 6 }, hit: 'button#menu', covered: false });
+    expect(lines[0]).toContain('hit=button#menu');
+    expect(lines[0]).toContain('covered=false');
+  });
+
+  it('says when a click opened a new ordinary tab', () => {
+    // QA check 45: a target="_blank" click succeeded, but status kept naming only the original
+    // tab and nothing in the click's own answer said a second tab now existed. createdTab is
+    // driver-supplied, generic-field passthrough; this proves the renderer actually surfaces it.
+    const { lines } = renderBrowserAction('click_ref', {
+      clicked: { x: 12, y: 34 },
+      hit: 'a#newTab',
+      covered: false,
+      createdTab: { tabId: 99, url: 'https://example.com/new', title: 'New tab' }
+    });
+    expect(lines[0]).toContain('createdTab={"tabId":99,"url":"https://example.com/new","title":"New tab"}');
+  });
+
+  /**
+   * Passing a field through is not the same as passing it through whole.
+   *
+   * The generic renderer above truncates any value past 200 characters with an ellipsis, which is
+   * right for a page title or a long url and wrong for a sentence written to be read. The
+   * swallowed-click note was drafted at 315 and lost its second half at exactly that cut — the
+   * caller would have been told a click reached nothing and not what to do about it, which is the
+   * half worth having. Nothing below the MCP layer could see that: the driver's own suite proved
+   * the field was set, and it was, in full.
+   *
+   * So this asserts the remedy survives rendering, not merely that the field appears.
+   */
+  it('renders the swallowed-click note whole, remedy included', () => {
+    const note =
+      'delivered, but the page did not go there. A Chrome password or permission dialog in ' +
+      'front of the tab can swallow a click invisibly. Check the screen, or use navigate ' +
+      'to reach the address directly.';
+    const { lines } = renderBrowserAction('click_ref', {
+      clicked: { x: 12, y: 34 },
+      hit: 'i',
+      covered: false,
+      navigated: false,
+      expected: 'https://example.com/secure',
+      note
+    });
+    expect(lines[0]).toContain('navigated=false');
+    expect(lines[0]).toContain('expected=https://example.com/secure');
+    // The whole sentence, and no ellipsis: the actionable clause is the last one.
+    expect(lines[0]).toContain('use navigate to reach the address directly.');
+    expect(lines[0]).not.toContain('…');
+  });
+
+  it('carries a field nobody has thought of yet', () => {
+    // The point of reading the answer rather than listing its fields: this test passes without
+    // anyone editing the renderer, which is exactly what did not happen for hit and covered.
+    const { lines } = renderBrowserAction('navigate', { navigated: 'https://example.com', somethingNew: 7 });
+    expect(lines[0]).toContain('somethingNew=7');
+  });
+
+  it('names the running driver on the answer a run reads before it starts', () => {
+    const held = renderBrowserAction('status', {
+      attached: true, tabId: 42, title: 'Example', url: 'https://example.com', groupId: 9, build: 'a40c45c0ba34'
+    });
+    expect(held.lines[0]).toContain('driver build a40c45c0ba34');
+    // Including the branch that holds nothing, which is the one a run reads first.
+    const idle = renderBrowserAction('status', { attached: false, build: 'a40c45c0ba34' });
+    expect(idle.lines[0]).toContain('no tab is under control');
+    expect(idle.lines[0]).toContain('driver build a40c45c0ba34');
+  });
+
+  it('names the driver on a detach that actually let a tab go', () => {
+    // The branch a review found bare. `status` had the build on both of its branches and detach
+    // on only one, so the answer that reports a real release printed the one phrase the QA
+    // instructions tell a run to treat as a finding.
+    const { lines } = renderBrowserAction('detach', {
+      attached: false,
+      released: { tabId: 7, url: 'https://example.com', title: 'Example' },
+      build: 'a40c45c0ba34'
+    });
+    expect(lines[0]).toContain('let go of tab 7');
+    expect(lines[0]).toContain('driver build a40c45c0ba34');
+    expect(lines[0]).not.toContain('unreported');
+  });
+
+  it('says so plainly when the driver did not name itself', () => {
+    // Silence here is what made a stale extension indistinguishable from a fresh one.
+    const { lines } = renderBrowserAction('status', { attached: false });
+    expect(lines[0]).toContain('driver build unreported');
+  });
+
+  it('still answers ok when the driver genuinely said nothing', () => {
+    expect(renderBrowserAction('reload', {}).lines[0]).toBe('reload: ok');
+  });
+
+  it('says a control is unticked, and stays silent where there is nothing to tick', () => {
+    // Printing `checked=false` beside every text field was a regression the moment the field was
+    // first rendered: `el.checked` is a boolean on every input, and the string 'false' is truthy.
+    // On a settings page that is noise on nearly every line, and it buries the one case the field
+    // exists for. An unticked checkbox must still say so — that is the useful half.
+    const { lines } = renderBrowserAction('observe', {
+      url: 'https://example.com', title: 'Settings',
+      elements: [
+        { ref: 'e1', role: 'textbox', name: 'Search', value: '', checked: '', x: 1, y: 2 },
+        { ref: 'e2', role: 'checkbox', name: 'Remember me', value: '', checked: 'false', x: 3, y: 4 },
+        { ref: 'e3', role: 'checkbox', name: 'Notify', value: '', checked: 'true', x: 5, y: 6 },
+        { ref: 'e4', role: 'checkbox', name: 'Partly', value: '', checked: 'mixed', x: 7, y: 8 }
+      ]
+    });
+    expect(lines.find((l) => l.startsWith('e1'))).not.toContain('checked');
+    expect(lines.find((l) => l.startsWith('e2'))).toContain('checked=false');
+    expect(lines.find((l) => l.startsWith('e3'))).toContain('checked=true');
+    expect(lines.find((l) => l.startsWith('e4'))).toContain('checked=mixed');
+  });
+
+  it('hands back the observation screenshot, and only a real one', () => {
+    const withShot = renderBrowserAction('observe', {
+      url: 'https://example.com', title: 'Example', elements: [],
+      screenshot: { data: 'AAAA', width: 800, height: 600 }
+    });
+    expect(withShot.observed).toBe(true);
+    expect(withShot.screenshot).toEqual({ data: 'AAAA', width: 800, height: 600 });
+    expect(renderBrowserAction('observe', { url: '', title: '', elements: [], screenshot: null }).screenshot).toBeUndefined();
+  });
+});

--- a/test/browser-driver.test.ts
+++ b/test/browser-driver.test.ts
@@ -1,0 +1,634 @@
+/**
+ * The browser driver's decidable parts.
+ *
+ * The protocol traffic itself needs a real browser and is proven by using it. Everything that
+ * can be decided without one is decided here, and the first block is the important one: the
+ * refusal list is the only thing standing between "the model can drive a web page" and "the
+ * model can drive the conversation it is having with you".
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { JSDOM } from 'jsdom';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  BROWSER_PERMISSIONS,
+  browserDriver,
+  COLLECT_SOURCE,
+  DRIVEN_GROUP_TITLE,
+  buttonMask,
+  cdpButton,
+  browserControlSupported,
+  hasBrowserPermissions,
+  keyDescriptor,
+  refusedUrl,
+  requestBrowserPermissions
+} from '../extension/browser-driver.js';
+
+const manifest = JSON.parse(
+  readFileSync(path.join(process.cwd(), 'extension', 'manifest.json'), 'utf8')
+);
+
+describe('what browser control refuses to attach to', () => {
+  /**
+   * The model asking for browser control is sitting in a ChatGPT tab. A driver able to attach
+   * there could send messages as the user, answer its own confirmations, or read a different
+   * conversation the person has open. This is the one refusal that is not about tidiness.
+   */
+  it('never attaches to ChatGPT itself', () => {
+    for (const url of [
+      'https://chatgpt.com/',
+      'https://chatgpt.com/c/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      'https://chatgpt.com/g/g-p-project/c/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      'https://CHATGPT.com/',
+      'https://chat.openai.com/',
+      // Four addresses a string prefix got wrong. The first two reached ChatGPT: `http://` was
+      // not matched at all and Chrome redirects it to https with the session still attached, and
+      // userinfo sits exactly where the host was expected. The third is a subdomain the prefix
+      // never covered. The fourth is the same host wearing a port.
+      'http://chatgpt.com/',
+      'https://user@chatgpt.com/',
+      'https://sub.chatgpt.com/',
+      'https://chatgpt.com:443/',
+      'https://chatgpt.com./'
+    ]) {
+      expect(refusedUrl(url), url).toBe(true);
+    }
+  });
+
+  it('refuses a scheme by it not being the web, rather than by name', () => {
+    // The list named `chrome:`, `file:`, `javascript:` and the rest, so anything nobody thought
+    // of read as an ordinary page. Only http and https are drivable; everything else follows.
+    for (const url of ['data:text/html,<p>hi', 'blob:https://example.com/abc', 'ws://example.com/', 'intent://scan/#Intent;end']) {
+      expect(refusedUrl(url), url).toBe(true);
+    }
+  });
+
+  it('never attaches to the browser, its extensions or the filesystem', () => {
+    for (const url of [
+      'chrome://settings',
+      'chrome://extensions',
+      'edge://settings',
+      'about:blank',
+      'about:config',
+      'devtools://devtools/bundled/inspector.html',
+      'chrome-extension://abcdefghijklmnop/popup.html',
+      'moz-extension://abcdefghijklmnop/popup.html',
+      'view-source:https://example.com',
+      'file:///C:/Users/you/secrets.txt'
+    ]) {
+      expect(refusedUrl(url), url).toBe(true);
+    }
+  });
+
+  it('allows the ordinary web, which is the entire point', () => {
+    for (const url of [
+      'https://example.com/',
+      'http://localhost:3000/app',
+      'https://github.com/some/repo/pull/1',
+      'https://notchatgpt.com/',
+      'https://example.com/?next=https://chatgpt.com/',
+      // Refused by the old prefix and correctly allowed now: it is not ChatGPT, it merely starts
+      // with those letters. A rule that refuses this is refusing by spelling, not by identity.
+      'https://chatgpt.com.example.org/'
+    ]) {
+      expect(refusedUrl(url), url).toBe(false);
+    }
+  });
+
+  it('treats a missing or malformed url as refusable rather than allowed', () => {
+    // This is what the test has always been called and what it now asserts. It used to assert
+    // the opposite: an unreadable address was allowed, on the reasoning that attach would stop
+    // it on an http(s) check. There is no such check on that path — only navigate has one — so
+    // the reasoning described a gate that did not exist.
+    //
+    // It matters because `tab.url` is undefined for every tab the extension cannot see, and the
+    // whole refusal list is written against that field. Allowing an unknown address turns the
+    // list off exactly where it cannot be checked.
+    expect(refusedUrl(undefined)).toBe(true);
+    expect(refusedUrl('')).toBe(true);
+    expect(refusedUrl('   ')).toBe(true);
+    expect(refusedUrl('javascript:alert(1)')).toBe(true);
+  });
+});
+
+describe('why no tab could be taken', () => {
+  const withTabs = async (tabs: unknown[], run: () => Promise<void>) => {
+    const original = (globalThis as { chrome?: unknown }).chrome;
+    (globalThis as { chrome?: unknown }).chrome = { tabs: { query: async () => tabs } };
+    try {
+      await run();
+    } finally {
+      (globalThis as { chrome?: unknown }).chrome = original;
+    }
+  };
+
+  /**
+   * "Nothing is open" and "nothing whose address I may read" are different problems, and only
+   * the second is the user's to solve. Chrome answers `tab.url` with undefined wherever the
+   * extension has no access, and those tabs are refused rather than driven — so a browser full
+   * of pages can present as an empty one, and the advice to open a page changes nothing.
+   */
+  it('says the addresses cannot be read rather than that nothing is open', async () => {
+    await withTabs([{ id: 1 }, { id: 2 }], async () => {
+      await expect(browserDriver.ensureAttached()).rejects.toMatchObject({
+        code: 'BROWSER_PERMISSION_REQUIRED'
+      });
+    });
+  });
+
+  it('still says nothing is drivable when the only readable tabs are refused ones', async () => {
+    await withTabs([{ id: 1, url: 'https://chatgpt.com/c/x' }], async () => {
+      await expect(browserDriver.ensureAttached()).rejects.toMatchObject({ code: 'BROWSER_NO_TAB' });
+    });
+  });
+});
+
+describe('permissions are opt-in', () => {
+  /**
+   * `debugger` is required, and it has to be.
+   *
+   * It was optional here, on the reasoning that shipping the most far-reaching permission as
+   * required would re-prompt every user on update for a capability most never switch on. Sound
+   * reasoning about a design Chrome does not allow: `debugger` cannot appear in
+   * optional_permissions. Chrome drops the entry when the manifest loads, so requesting it later
+   * answers "Only permissions specified in the manifest may be requested" — measured against
+   * Chrome 152 with a trusted click, where `chrome.debugger` was also simply `undefined`. One
+   * unavailable entry failed the whole request, so the popup switch could never stay on, and QA
+   * found the feature unusable.
+   *
+   * The opt-in still means something: site and tab access stay optional, and those are what
+   * decide whether the extension can read a page at all.
+   */
+  it('requires debugger, because Chrome will not grant it any other way', () => {
+    expect(manifest.permissions).toEqual(['storage', 'scripting', 'alarms', 'debugger']);
+    expect(manifest.optional_permissions).toEqual(['tabs', 'tabGroups']);
+    expect(manifest.optional_host_permissions).toEqual(['<all_urls>']);
+    // Site access is still not granted at install; that is the part worth keeping optional.
+    expect(manifest.host_permissions).not.toContain('<all_urls>');
+  });
+
+  /**
+   * The guard for the class of mistake, not just this instance.
+   *
+   * Chrome documents a set of permissions that may never be optional, and declaring one there is
+   * silent: the manifest loads, the entry vanishes, and the only symptom is a runtime request
+   * that fails for a reason nobody sees. A build should not be able to reach a browser in that
+   * state again.
+   */
+  it('declares no permission Chrome refuses to treat as optional', () => {
+    // Verified empirically for `debugger` against Chrome 152; the rest are documented alongside
+    // it as install-time only.
+    const NEVER_OPTIONAL = [
+      'debugger',
+      'declarativeNetRequest',
+      'devtools',
+      'experimental',
+      'mdns',
+      'proxy',
+      'tts',
+      'ttsEngine',
+      'wallpaper'
+    ];
+    const declared = manifest.optional_permissions ?? [];
+    expect(declared.filter((name: string) => NEVER_OPTIONAL.includes(name))).toEqual([]);
+  });
+
+  it('asks for exactly what the manifest offers, and no more', () => {
+    expect(BROWSER_PERMISSIONS.permissions).toEqual(manifest.optional_permissions);
+    expect(BROWSER_PERMISSIONS.origins).toEqual(manifest.optional_host_permissions);
+  });
+
+  /**
+   * A capture is not an ordinary command.
+   *
+   * `Page.captureScreenshot` answers when the renderer produces a frame, and a tab that is not
+   * compositing can take seconds to make one — measured at over ten in a real headless run.
+   * Holding it to the ordinary deadline turns "the page was quiet" into a failed observation.
+   */
+  it('gives the two compositor-bound operations their own deadline', () => {
+    const driver = readFileSync(path.join(process.cwd(), 'extension', 'browser-driver.js'), 'utf8');
+    expect(driver).toContain('const COMPOSITOR_TIMEOUT_MS = 30_000;');
+    // A capture answers when a frame is produced; a wheel event when the compositor has taken
+    // it. Both were measured stalling past ten seconds on an idle tab in a real browser.
+    expect(driver).toMatch(/Page\.captureScreenshot[\s\S]{0,220}COMPOSITOR_TIMEOUT_MS/);
+    // Scrolling has its own, shorter budget. It is judged by where the page ended up rather than
+    // by an acknowledgement, so waiting the full compositor deadline buys nothing — two failed
+    // attempts cost a minute of a run in which nothing happened, measured on a Mac.
+    expect(driver).toContain('const SCROLL_TIMEOUT_MS = 5_000;');
+    expect(driver).toMatch(/Input\.synthesizeScrollGesture[\s\S]{0,200}SCROLL_TIMEOUT_MS/);
+    expect(driver).toMatch(/type: 'mouseWheel'[\s\S]{0,200}SCROLL_TIMEOUT_MS/);
+    // Clicks and keystrokes are acknowledged directly and keep the ordinary deadline, which
+    // still exists: an unbounded wait is how a stuck tab becomes a stuck tool call.
+    expect(driver).toContain('const COMMAND_TIMEOUT_MS = 15_000;');
+    expect(driver).not.toMatch(/type: 'mousePressed'[\s\S]{0,200}COMPOSITOR_TIMEOUT_MS/);
+  });
+
+  it('names the driven tab group after the product so it is recognisable', () => {
+    expect(DRIVEN_GROUP_TITLE).toBe('Chat On Steroids');
+  });
+
+  /**
+   * Chrome answers `permissions.*` through a callback and returns nothing. Firefox returns a
+   * promise and ignores the callback. This extension ships for both, so waiting only for the
+   * callback would hang forever on one of them — and the symptom would be a toggle that does
+   * nothing at all, with no error to chase.
+   */
+  describe('across both extension APIs', () => {
+    // The driver reads whichever of the two globals the browser provides, so the test has to
+    // be able to install either and put the environment back afterwards.
+    const globals = globalThis as unknown as Record<string, unknown>;
+    const original = { chrome: globals.chrome, browser: globals.browser };
+    afterEach(() => {
+      globals.chrome = original.chrome;
+      globals.browser = original.browser;
+    });
+
+    /** Every fake carries the debugger API, because a browser without it cannot do any of this. */
+    const debuggerApi = { attach() {}, detach() {}, sendCommand() {}, onDetach: { addListener() {} } };
+
+    it('accepts the Chrome callback', async () => {
+      globals.browser = undefined;
+      globals.chrome = {
+        runtime: {},
+        debugger: debuggerApi,
+        permissions: {
+          contains: (_perms: unknown, done: (granted: boolean) => void) => done(true),
+          request: (_perms: unknown, done: (granted: boolean) => void) => done(false)
+        }
+      };
+      await expect(hasBrowserPermissions()).resolves.toBe(true);
+      await expect(requestBrowserPermissions()).resolves.toBe(false);
+    });
+
+    it('accepts the Firefox promise, which never calls the callback', async () => {
+      globals.browser = {
+        runtime: {},
+        debugger: debuggerApi,
+        permissions: {
+          contains: () => Promise.resolve(true),
+          request: () => Promise.resolve(true)
+        }
+      };
+      await expect(hasBrowserPermissions()).resolves.toBe(true);
+      await expect(requestBrowserPermissions()).resolves.toBe(true);
+    });
+
+    it('answers false rather than hanging when the API is absent or throws', async () => {
+      globals.browser = undefined;
+      globals.chrome = { runtime: {}, debugger: debuggerApi };
+      await expect(hasBrowserPermissions()).resolves.toBe(false);
+
+      globals.chrome = {
+        runtime: {},
+        debugger: debuggerApi,
+        permissions: { contains: () => { throw new Error('no'); } }
+      };
+      await expect(hasBrowserPermissions()).resolves.toBe(false);
+
+      globals.browser = {
+        runtime: {},
+        debugger: debuggerApi,
+        permissions: { contains: () => Promise.reject(new Error('denied')) }
+      };
+      await expect(hasBrowserPermissions()).resolves.toBe(false);
+    });
+
+    /**
+     * Support is decided by whether the browser recognises the permission, not by whether the
+     * `debugger` object is there.
+     *
+     * That object does not exist until the optional permission is granted, so a presence check
+     * would hide the very switch that grants it and make the feature permanently unreachable —
+     * which is exactly what a real Edge run reported before this was corrected: the popup saw
+     * no debugger API at all, on a browser that supports it perfectly well.
+     */
+    it('supports a browser that knows the permission, granted or not', async () => {
+      globals.browser = undefined;
+      // Chrome shape: knows the name, has not granted it. The switch must be offered.
+      globals.chrome = {
+        runtime: {},
+        permissions: { contains: (_p: unknown, done: (held: boolean) => void) => done(false) }
+      };
+      await expect(browserControlSupported()).resolves.toBe(true);
+
+      // Granted: still supported, and now actually held.
+      globals.chrome = {
+        runtime: {},
+        debugger: debuggerApi,
+        permissions: { contains: (_p: unknown, done: (held: boolean) => void) => done(true) }
+      };
+      await expect(browserControlSupported()).resolves.toBe(true);
+      await expect(hasBrowserPermissions()).resolves.toBe(true);
+    });
+
+    it('treats a browser that does not know the permission as unsupported', async () => {
+      globals.chrome = undefined;
+      // A browser that never implemented it reports the unknown name rather than answering.
+      globals.browser = {
+        runtime: { lastError: { message: 'Type error for parameter permissions' } },
+        permissions: { contains: (_p: unknown, done: (held: unknown) => void) => done(undefined) }
+      };
+      await expect(browserControlSupported()).resolves.toBe(false);
+      await expect(hasBrowserPermissions()).resolves.toBe(false);
+
+      // And the promise shape of the same refusal.
+      globals.browser = {
+        runtime: {},
+        permissions: { contains: () => Promise.reject(new Error('unknown permission')) }
+      };
+      await expect(browserControlSupported()).resolves.toBe(false);
+    });
+  });
+
+  /**
+   * electron-builder copies the whole extension folder, but the packaged-runtime smoke check
+   * names every file it expects. A driver missing from the package would otherwise ship as a
+   * browser-control toggle that fails on first use.
+   */
+  it('is required by the packaged-runtime smoke check', () => {
+    const smoke = readFileSync(path.join(process.cwd(), 'scripts', 'smoke-packaged-runtime.mjs'), 'utf8');
+    expect(smoke).toContain("'extension/browser-driver.js'");
+    // And the declaration file, which a browser cannot run, stays out of both packages: the
+    // app's bundled copy and the standalone add-on zip are produced by different steps, and
+    // only the first was filtered — the published zip carried it until a built artifact was
+    // actually opened and looked at.
+    const builder = readFileSync(path.join(process.cwd(), 'electron-builder.yml'), 'utf8');
+    expect(builder).toContain("- '!**/*.d.ts'");
+    const release = readFileSync(path.join(process.cwd(), '.github', 'workflows', 'release.yml'), 'utf8');
+    expect(release).toContain("-x '*.map' -x '*.d.ts'");
+    expect(release).toContain('required in manifest.json background.js browser-driver.js');
+    expect(release).toContain('Extension zip carries TypeScript declarations');
+  });
+});
+
+describe('the shared input vocabulary', () => {
+  it('maps every mouse button the rest of the product accepts', () => {
+    expect(cdpButton('left')).toBe('left');
+    expect(cdpButton('right')).toBe('right');
+    expect(cdpButton('middle')).toBe('middle');
+    expect(cdpButton('wheel')).toBe('middle');
+    expect(cdpButton('back')).toBe('back');
+    expect(cdpButton('forward')).toBe('forward');
+    expect(cdpButton(undefined)).toBe('left');
+    expect(cdpButton('nonsense')).toBe('left');
+  });
+
+  it('holds the right bit while a drag is in progress', () => {
+    expect(buttonMask('left')).toBe(1);
+    expect(buttonMask('right')).toBe(2);
+    expect(buttonMask('wheel')).toBe(4);
+    expect(buttonMask('back')).toBe(8);
+    expect(buttonMask('forward')).toBe(16);
+  });
+
+  it('accepts the same key names as the desktop driver, DOM spellings included', () => {
+    expect(keyDescriptor('ArrowLeft')).toMatchObject({ key: 'ArrowLeft', code: 'ArrowLeft', vk: 37 });
+    expect(keyDescriptor('left')).toMatchObject({ key: 'ArrowLeft', vk: 37 });
+    expect(keyDescriptor('Enter')).toMatchObject({ key: 'Enter', vk: 13 });
+    expect(keyDescriptor('Return')).toMatchObject({ key: 'Enter', vk: 13 });
+    expect(keyDescriptor('Escape')).toMatchObject({ key: 'Escape', vk: 27 });
+    expect(keyDescriptor('PageDown')).toMatchObject({ key: 'PageDown', vk: 34 });
+    expect(keyDescriptor('F5')).toMatchObject({ key: 'F5', code: 'F5', vk: 116 });
+    expect(keyDescriptor('a')).toMatchObject({ key: 'a', code: 'KeyA', text: 'a' });
+    expect(keyDescriptor('7')).toMatchObject({ key: '7', code: 'Digit7', text: '7' });
+  });
+
+  it('refuses a key it cannot name rather than pressing something arbitrary', () => {
+    expect(() => keyDescriptor('NotAKey')).toThrowError(/unknown key/i);
+  });
+});
+
+/**
+ * The page reader, run against a real DOM.
+ *
+ * This is the part most likely to be quietly wrong — a selector that misses the button the
+ * model needs, a name that comes back empty, a hidden element reported as clickable — so it
+ * is exercised rather than asserted. jsdom computes no layout, so the fixture declares each
+ * element's rectangle and the test installs a `getBoundingClientRect` that returns it.
+ */
+describe('reading a page', () => {
+  function read(body: string, viewport = { width: 1000, height: 800 }) {
+    const dom = new JSDOM(`<!doctype html><title>Fixture page</title><body>${body}</body>`, {
+      url: 'https://example.com/page',
+      // The collector runs inside the page, so the test has to run it there too.
+      runScripts: 'outside-only'
+    });
+    const window = dom.window as unknown as Window & typeof globalThis;
+    Object.defineProperty(window, 'innerWidth', { value: viewport.width, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: viewport.height, configurable: true });
+    window.Element.prototype.getBoundingClientRect = function rect(this: Element) {
+      const spec = (this as HTMLElement).dataset?.rect;
+      const [left = 0, top = 0, width = 0, height = 0] = (spec ?? '0,0,0,0').split(',').map(Number);
+      return {
+        left, top, width, height,
+        right: left + width, bottom: top + height,
+        x: left, y: top, toJSON: () => ({})
+      } as DOMRect;
+    };
+    const raw = window.eval(COLLECT_SOURCE) as string;
+    return JSON.parse(raw) as {
+      url: string;
+      title: string;
+      elements: Array<Record<string, unknown>>;
+    };
+  }
+
+  it('finds what can be acted on, and says where', () => {
+    const page = read(`
+      <a href="/next" data-rect="10,20,100,30">Next page</a>
+      <button data-rect="10,60,80,24">Save</button>
+      <input type="text" placeholder="Search" data-rect="10,100,200,28">
+      <div role="button" data-rect="10,140,60,20">Custom</div>
+    `);
+
+    expect(page.url).toBe('https://example.com/page');
+    expect(page.title).toBe('Fixture page');
+    expect(page.elements).toHaveLength(4);
+    // Every element carries the path its ref is re-resolved with. Refs themselves are numbered
+    // by the driver across all frames, not here: this collector runs once per frame and a
+    // per-frame counter would hand out the same ref for two different elements.
+    expect(page.elements.every((e) => typeof e.path === 'string' && (e.path as string).length > 0)).toBe(true);
+    expect(page.elements.some((e) => 'ref' in e)).toBe(false);
+    expect(page.elements.map((e) => [e.role, e.name])).toEqual([
+      ['link', 'Next page'],
+      ['button', 'Save'],
+      ['textbox', 'Search'],
+      ['button', 'Custom']
+    ]);
+    // Coordinates are the element's centre, in the same space the input methods use.
+    expect(page.elements[1]).toMatchObject({ x: 50, y: 72, width: 80, height: 24 });
+  });
+
+  it('prefers the accessible name over the visible text', () => {
+    const page = read(`
+      <button aria-label="Close dialog" data-rect="0,0,20,20">×</button>
+      <span id="lbl">Email address</span>
+      <input type="text" aria-labelledby="lbl" data-rect="0,30,200,28">
+      <button data-rect="0,70,40,40"><img alt="Print" src="p.png"></button>
+    `);
+    expect(page.elements.map((e) => e.name)).toEqual(['Close dialog', 'Email address', 'Print']);
+  });
+
+  it('leaves out what a pointer could not reach', () => {
+    const page = read(`
+      <button data-rect="10,10,60,20">Visible</button>
+      <button data-rect="0,0,0,0">Zero size</button>
+      <button style="display:none" data-rect="10,40,60,20">Display none</button>
+      <button style="visibility:hidden" data-rect="10,70,60,20">Hidden</button>
+      <button aria-hidden="true" data-rect="10,100,60,20">Aria hidden</button>
+      <button data-rect="-200,10,60,20">Scrolled off the left</button>
+      <button data-rect="10,900,60,20">Below the fold</button>
+    `);
+    expect(page.elements.map((e) => e.name)).toEqual(['Visible']);
+  });
+
+  it('reports state the model has to know before it acts', () => {
+    const page = read(`
+      <button disabled data-rect="0,0,50,20">Submit</button>
+      <input type="checkbox" checked data-rect="0,30,20,20" aria-label="Remember me">
+      <input type="text" value="already here" data-rect="0,60,200,28" aria-label="Note">
+    `);
+    expect(page.elements[0]).toMatchObject({ name: 'Submit', disabled: true });
+    expect(page.elements[1]).toMatchObject({ name: 'Remember me', checked: 'true' });
+    expect(page.elements[2]).toMatchObject({ name: 'Note', value: 'already here' });
+  });
+
+  it('bounds a hostile page instead of handing the model everything it has', () => {
+    const many = Array.from(
+      { length: 400 },
+      (_, index) => `<button data-rect="0,${index % 700},40,10">B${index}</button>`
+    ).join('');
+    expect(read(many).elements.length).toBeLessThanOrEqual(200);
+  });
+});
+
+/**
+ * Two protocols, two conventions, and they are not the same.
+ *
+ * CoreGraphics' wheel API takes an inverted sign, and the macOS helper negates for it correctly.
+ * CDP's mouseWheel carries the DOM convention instead, where a positive deltaY scrolls down —
+ * which is also what the caller means. The driver negated anyway, carrying the macOS reasoning
+ * to the wrong protocol, and scrolled every page backwards. Nothing caught it: a wheel event is
+ * acknowledged only once a compositor has taken it, and headless has none, so the real-browser
+ * run cannot reach this at all.
+ */
+describe('the browser driver scrolls the way the caller asked', () => {
+  const driver = readFileSync(path.join(process.cwd(), 'extension/browser-driver.js'), 'utf8');
+  const swift = readFileSync(path.join(process.cwd(), 'native/macos-desktop-helper/main.swift'), 'utf8');
+
+  /**
+   * Two protocols, two conventions, and the caller only ever means the DOM one.
+   *
+   * `Input.dispatchMouseEvent` carries the DOM convention: a positive deltaY scrolls down, so the
+   * caller's numbers pass through untouched. `Input.synthesizeScrollGesture` is the opposite —
+   * `yDistance` is positive to scroll *up* — so those are negated. Both appear in the same
+   * function, which is exactly the shape that produced the original bug: the macOS helper's
+   * inversion was carried to CDP by reasoning rather than measurement, and every page scrolled
+   * backwards.
+   *
+   * These assertions pin the pairing. The direction itself is proven in `verify:browser` against
+   * a real browser, because that is the only thing that can actually settle it.
+   */
+  it('negates for the gesture and not for the wheel, which disagree about the sign', () => {
+    expect(driver).toMatch(/synthesizeScrollGesture[\s\S]{0,120}xDistance: -dx, yDistance: -dy/);
+    expect(driver).toMatch(/type: 'mouseWheel'[\s\S]{0,80}deltaX: dx, deltaY: dy/);
+    expect(driver).not.toMatch(/deltaY: -dy/);
+    expect(driver).not.toMatch(/yDistance: dy/);
+  });
+
+  it('still negates for CoreGraphics, which really is inverted', () => {
+    expect(swift).toMatch(/wheel1|scrollWheelEvent/);
+  });
+
+  /**
+   * Select-all is Cmd on a Mac and Ctrl everywhere else. Hardcoding Meta made set_value append
+   * instead of replace off macOS, and made an intentional clear delete a single character.
+   */
+  it('chooses the select-all modifier for the platform it runs on', () => {
+    expect(driver).toContain('const SELECT_ALL_MODIFIER =');
+    expect(driver).toContain("/Mac/i.test(globalThis.navigator?.userAgent ?? '') ? 4 : 2");
+    expect(driver).toContain('modifiers: SELECT_ALL_MODIFIER');
+    expect(driver).not.toMatch(/modifiers: 4, key: 'a'/);
+  });
+});
+
+/**
+ * Two findings from a review of the ensureTabActive round, both real.
+ *
+ * The scroll and click cases were each fixed in their own commit; a drag is the same
+ * Input.dispatchMouseEvent machinery those fixes exist for, and was never given the same call.
+ * And ensureTabActive's own return had a gap the review found by reading, not by running: a tab
+ * whose windowId is somehow undefined skips the escalation entirely, but execution still fell
+ * through the unconditional `return { broughtToFront: true }` at the end of the function — the
+ * exact misreport class this round's whole fix was for, on a path no live-Chrome run exercises
+ * (a real tab always carries a windowId), which is why this is a source assertion and not a
+ * driven-fixture one.
+ */
+describe('the ensureTabActive review findings', () => {
+  const driver = readFileSync(path.join(process.cwd(), 'extension/browser-driver.js'), 'utf8');
+
+  it('activates the driven tab before a drag, the same as before a scroll or a click', () => {
+    const dragCase = driver.slice(driver.indexOf("case 'drag': {"), driver.indexOf('case \'scroll\': {'));
+    expect(dragCase).toMatch(/const \{ broughtToFront \} = await ensureTabActive\(session\.tabId\);/);
+    // Before the first Input.dispatchMouseEvent this case sends, not after.
+    const activateAt = dragCase.indexOf('ensureTabActive(session.tabId)');
+    // The literal call, not a comment mentioning the method — this file's own comments say
+    // "Input.dispatchMouseEvent" in prose above the real call.
+    const firstDispatchAt = dragCase.indexOf("send('Input.dispatchMouseEvent'");
+    expect(activateAt).toBeGreaterThan(-1);
+    expect(activateAt).toBeLessThan(firstDispatchAt);
+  });
+
+  it('never reports broughtToFront: true on the one path that never attempted it', () => {
+    const body = driver.slice(driver.indexOf('async function ensureTabActive'));
+    const fn = body.slice(0, body.indexOf('\n}\n'));
+    // The undefined-windowId guard must return on its own, before the escalation call — not
+    // fall through to it, and not fall through to the unconditional true at the end.
+    expect(fn).toMatch(/if \(tab\.windowId === undefined\) return \{ broughtToFront: false \};/);
+    const guardAt = fn.indexOf('tab.windowId === undefined');
+    const updateAt = fn.indexOf('chrome.windows.update(tab.windowId');
+    const finalReturnAt = fn.lastIndexOf('return { broughtToFront: true };');
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(guardAt).toBeLessThan(updateAt);
+    expect(updateAt).toBeLessThan(finalReturnAt);
+  });
+});
+
+describe('a driven tab group does not outlive the session that created it', () => {
+  const driver = readFileSync(path.join(process.cwd(), 'extension/browser-driver.js'), 'utf8');
+  const background = readFileSync(path.join(process.cwd(), 'extension/background.js'), 'utf8');
+
+  it('sweeps stale groups before creating a new one, not after', () => {
+    const body = driver.slice(driver.indexOf('async function groupDrivenTab'));
+    const fn = body.slice(0, body.indexOf('\n}\n'));
+    const sweepAt = fn.indexOf('await sweepStaleDrivenGroups()');
+    const createAt = fn.indexOf('chrome.tabs.group(');
+    expect(sweepAt).toBeGreaterThan(-1);
+    expect(createAt).toBeGreaterThan(-1);
+    expect(sweepAt).toBeLessThan(createAt);
+  });
+
+  it('never ungroups the session it is currently running', () => {
+    const body = driver.slice(driver.indexOf('export async function sweepStaleDrivenGroups'));
+    const fn = body.slice(0, body.indexOf('\n}\n'));
+    expect(fn).toMatch(/if \(session && group\.id === session\.groupId\) continue;/);
+    const guardAt = fn.indexOf('session.groupId) continue');
+    const ungroupAt = fn.indexOf('chrome.tabs.ungroup(tabIds)');
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(guardAt).toBeLessThan(ungroupAt);
+  });
+
+  it('never closes the tabs it ungroups, only the grouping', () => {
+    const body = driver.slice(driver.indexOf('export async function sweepStaleDrivenGroups'));
+    const fn = body.slice(0, body.indexOf('\n}\n'));
+    expect(fn).not.toMatch(/chrome\.tabs\.remove/);
+  });
+
+  it('also runs on the extension\'s own wake timer, not only before a new attach', () => {
+    const alarmHandler = background.slice(
+      background.indexOf('chrome.alarms.onAlarm.addListener'),
+      background.indexOf('chrome.alarms.onAlarm.addListener') + 800
+    );
+    expect(alarmHandler).toMatch(/browserDriverModule\.sweepStaleDrivenGroups\(\)/);
+  });
+});

--- a/test/desktop-input-maintenance.test.ts
+++ b/test/desktop-input-maintenance.test.ts
@@ -3,7 +3,23 @@ import vm from 'node:vm';
 import { describe, expect, it, vi } from 'vitest';
 import { BRIDGE_PROTOCOL } from '../src/main/version.js';
 
-const source = readFileSync(new URL('../extension/background.js', import.meta.url), 'utf8');
+const backgroundSource = readFileSync(new URL('../extension/background.js', import.meta.url), 'utf8');
+
+/*
+ * background.js statically imports the browser driver, and this harness evaluates the worker as
+ * a classic script, where an import statement is a parse error. Strip the statement here and,
+ * where the worker actually calls the driver, supply the binding through the context instead.
+ * The import is static so that a broken browser_* message fails in a real browser rather than
+ * passing here; fail loudly if it stops looking the way this expects.
+ */
+const importPattern = /^import \* as browserDriverModule from '\.\/browser-driver\.js';$/m;
+if (!importPattern.test(backgroundSource)) {
+  throw new Error(
+    'background.js no longer statically imports browser-driver.js as expected; ' +
+      'update this harness rather than making the worker import dynamically'
+  );
+}
+const source = backgroundSource.replace(importPattern, '');
 const firstId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
 const secondId = 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff';
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -599,7 +599,26 @@ function loadWorker(options: {
     }
   };
   const fetch = options.fetch ?? (async () => response(503, {}));
-  vm.runInNewContext(backgroundSource, {
+  /**
+   * background.js statically imports the browser driver, because a service worker may not
+   * import dynamically: the specification forbids it and Chrome refuses at runtime. This
+   * harness evaluates the file as a classic script, where an import statement is a parse
+   * error, so the statement is removed here and the binding supplied instead.
+   *
+   * Removed rather than accommodated by keeping the product dynamic, which is what used to
+   * happen: the import was dynamic so this line would parse, every browser_* message failed
+   * in a real browser, and these tests stayed green throughout because they never execute one.
+   * The check below fails loudly if the import stops looking the way this rewrite expects.
+   */
+  const importPattern = /^import \* as browserDriverModule from '\.\/browser-driver\.js';$/m;
+  if (!importPattern.test(backgroundSource)) {
+    throw new Error(
+      'background.js no longer statically imports browser-driver.js as expected; ' +
+        'update this harness rather than making the worker import dynamically'
+    );
+  }
+
+  vm.runInNewContext(backgroundSource.replace(importPattern, ''), {
     chrome,
     fetch,
     AbortController,
@@ -607,7 +626,22 @@ function loadWorker(options: {
     clearTimeout,
     URL,
     TextEncoder,
-    console
+    console,
+    // Stubbed: these tests exercise the worker's messaging, never a debugger session. A test
+    // that needs the real driver needs a real browser to run it in.
+    browserDriverModule: {
+      installBrowserDriverLifecycle() {},
+      sweepStaleDrivenGroups: async () => undefined,
+      hasBrowserPermissions: async () => false,
+      requestBrowserPermissions: async () => false,
+      browserDriver: {
+        status: () => ({ attached: false, tabId: null, url: null, title: null }),
+        attach: async () => ({ attached: false }),
+        detach: async () => ({ attached: false }),
+        act: async () => ({}),
+        observe: async () => ({})
+      }
+    }
   }, { filename: 'background.js' });
   if (!listener) throw new Error('background.js did not register a message listener');
 

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -688,7 +688,7 @@ describe('surface boundaries', () => {
   it('advertises exactly Desktop’s tools on Desktop, with nothing from Core', async () => {
     everything();
     const names = toolNames(await desktop('tools/list'));
-    expect(names).toEqual(['computer', 'observe']);
+    expect(names).toEqual(['browser', 'computer', 'observe']);
     for (const name of surfaceDefinition('core').tools) expect(names, name).not.toContain(name);
   });
 
@@ -804,19 +804,25 @@ describe('surface boundaries', () => {
     const desktopTools = toolList(await desktop('tools/list'));
 
     // Counts are the design: Core is capped at eight live schemas because find and the exec
-    // pair cannot both exist, and Desktop is two.
+    // pair cannot both exist, and Desktop is three.
     expect(coreTools).toHaveLength(8);
-    expect(desktopTools).toHaveLength(2);
+    expect(desktopTools).toHaveLength(3);
 
     // And the size, which is what a discovery pull actually costs the model on every
     // conversation that touches the connector. The ceilings sit just above what the
-    // surface measures today (core 12.5k, desktop 7.9k on 2026-08-17) rather than at a
+    // surface measures today (core 12.5k, desktop 12.9k on 2026-09-09) rather than at a
     // round number well above it: a budget with room to spare is a budget that never
     // catches the regression it exists to catch.
+    //
+    // Desktop went from 7.9k to 12.9k when the browser tool arrived, and that is the whole
+    // cost of the capability at discovery time, paid by every conversation that touches the
+    // connector whether or not it drives a page. It is a discriminated union of nine actions;
+    // the ceiling is raised deliberately here rather than the schema trimmed to fit, so the
+    // number stays visible and the next growth still has to argue for itself.
     const coreBytes = Buffer.byteLength(JSON.stringify(coreTools), 'utf8');
     const desktopBytes = Buffer.byteLength(JSON.stringify(desktopTools), 'utf8');
     expect(coreBytes, `core tools/list is ${coreBytes} bytes`).toBeLessThan(18_000);
-    expect(desktopBytes, `desktop tools/list is ${desktopBytes} bytes`).toBeLessThan(8_500);
+    expect(desktopBytes, `desktop tools/list is ${desktopBytes} bytes`).toBeLessThan(13_500);
 
     // Per tool as well as per surface, so one schema cannot quietly eat the whole budget
     // while the total stays under it. `computer` is the largest by design: fourteen
@@ -842,7 +848,14 @@ describe('surface boundaries', () => {
                 // budget. The non-Windows number is the one that says whether *our* additions have
                 // grown, so both are asserted rather than one loose bound covering both.
                 ? (process.platform === 'win32' ? 3_800 : 3_500)
-                : 3_000;
+                : tool.name === 'browser'
+                  // Nine discriminated action variants, for the same reason `computer` has
+                  // fourteen: spelling each one out is what keeps its validation errors small
+                  // and its action set explicit rather than a free-form string the model has to
+                  // guess at. Smaller than `computer` and asserted separately, so the two cannot
+                  // hide each other's growth.
+                  ? 5_500
+                  : 3_000;
       expect(bytes, `${tool.name} schema is ${bytes} bytes`).toBeLessThan(budget);
     }
   });


### PR DESCRIPTION
Replaces #78, which you asked to be split. This is the browser capability on its own.

| | #78 | this |
|---|---|---|
| files | 156 | **20** |
| insertions | 31,773 | **3,746** |
| `docs/` | 45 files, 13,804 lines | **none** |
| native / session / scripts changes | yes | **none** |

Nothing here is QA history or implementation unrelated to driving a page. The native and session fixes that were mixed into #78 are being submitted separately — #139 and #141 are the first two.

### What it is

The desktop driver can click anywhere in a browser window but cannot see a web page: no refs, no DOM, no way to tell a link from the pixels around it. This tool speaks to the page instead, through the companion extension and CDP.

It lives in its own module, `src/main/mcp/tools-browser.ts`, rather than threaded through `tools-desktop.ts`. That is the main structural difference from #78 and it is deliberate: the three things you named are then reviewable in one place.

### Exact tab ownership

A run takes the newest ordinary tab or opens one. ChatGPT's own tabs are never driven; neither are browser pages or local files. The driven tab is placed in its own titled group so it is visibly driven, ungrouped when the run ends, and a group orphaned by an MV3 worker recycle is swept both before the next attach and on the extension's own wake timer — the case where nothing ever attaches again.

`test/browser-driver.test.ts` pins this, including that the sweep ungroups without ever closing the tabs.

### Live capability enforcement

`tabs`, `tabGroups` and host access are **optional** permissions, requested from the popup toggle rather than declared in the manifest. Chrome only prompts on a real user gesture, so the click that turns it on is the consent. Turning it off revokes them and drops any live session — off means the capability is gone, not merely unused. A refused request now says so in the popup instead of the switch snapping back silently.

The tool is registered only when control is exposed, and it is declared on the Desktop surface so the existing "never advertises a tool its surface does not declare" check covers it.

### Bounded output

Every action's reply is bounded, and the rendering is a plain function with its own tests (`test/browser-answer.test.ts`). It was inline before, reachable only through a live extension and a real browser, and it silently replaced every reply but `observe` and `status` with the word `ok` — discarding `hit`, `covered` and the driver build. That is the kind of gap a QA run found instead of a test.

### Discovery cost, stated

Desktop's worst-case `tools/list` goes from **7.9k to 12.9k bytes**. The ceiling in `test/mcp.test.ts` is raised deliberately to 13.5k and a per-tool ceiling for `browser` added at 5.5k, so the number stays visible and the next growth has to argue for itself rather than hiding under a surface total.

This is the honest price of the capability and the reason it is not on Core.

### One thing worth flagging

The worker imports the driver **statically**, because a service worker may not import dynamically — the specification forbids it and Chrome refuses at runtime with exactly that message. It was dynamic once, so the file parsed in the harnesses, every `browser_*` message failed in a real browser, and the tests stayed green throughout because they never execute one.

The three harnesses that evaluate `background.js` as a classic script now strip the import and supply the binding, and throw if the statement stops looking the way they expect — so the next person cannot quietly make the product dynamic again to keep a test parsing.

### Verified

`npm run typecheck` clean. Full suite **3,481 passed**; the four failures are `renderer-usage` (locale-dependent number formatting) and one `mcp` shell test, which fail identically on unmodified `main` on this Windows machine and pass on Linux and macOS in CI.
