### PR TITLE
Bound read-only tab reuse checks to unblock input delivery

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1721,6 +1721,18 @@ async function createChatTab(url, background = false, active = !background) {
   });
 }
 
+async function inputReuseProbe(tabId, documentId) {
+  let timer;
+  try {
+    // This is only an observation. A silent document is ineligible for reuse and
+    // must not hold the one global maintenance flight or its fresh-tab election.
+    return await Promise.race([
+      chrome.tabs.sendMessage(tabId, { type: 'clf-input-reuse-state' }, { documentId }),
+      new Promise(resolve => { timer = setTimeout(() => resolve(null), 3000); })
+    ]);
+  } catch { return null; } finally { clearTimeout(timer); }
+}
+
 async function deliverDesktopInputs(inputs, background, reusableConversations = [], activeIds) {
   if (!Array.isArray(inputs)) return;
   // Only the app's complete outbox projection retires spent opening authority.
@@ -1796,9 +1808,7 @@ async function deliverDesktopInputs(inputs, background, reusableConversations = 
         for (const candidate of choices) {
           const source = { tab: candidate.id, documentId: tabDocuments[String(candidate.id)], navigationEpoch: tabEpochs[String(candidate.id)] };
           if (!ownsDocument(source)) continue;
-          let proof;
-          try { proof = await chrome.tabs.sendMessage(candidate.id, { type: 'clf-input-reuse-state' }, { documentId: source.documentId }); }
-          catch { continue; }
+          const proof = await inputReuseProbe(candidate.id, source.documentId);
           const current = await chrome.tabs.get(candidate.id).catch(() => null);
           if (proof?.safe !== true || proof.navigationEpoch !== source.navigationEpoch || !ownsDocument(source) ||
               !current || current.pendingUrl || current.url !== candidate.url) continue;

--- a/extension/background.js
+++ b/extension/background.js
@@ -1733,6 +1733,26 @@ async function inputReuseProbe(tabId, documentId) {
   } catch { return null; } finally { clearTimeout(timer); }
 }
 
+async function prepareDesktopInputReceipt(tabId, id, documentId) {
+  let timer;
+  try {
+    // The content-side maximum is 13s: reveal sidebar (3s), reach New Chat
+    // (5s), then switch Work to Chat (5s). Two more seconds carry the reply.
+    // Timeout is ambiguity: keep `preparing` custody and grant no fallback.
+    return await Promise.race([
+      chrome.tabs.sendMessage(tabId, { type: 'clf-prepare-desktop-input', id }, { documentId }),
+      new Promise(resolve => { timer = setTimeout(() => resolve(null), 15000); })
+    ]);
+  } catch { return null; } finally { clearTimeout(timer); }
+}
+
+function offerDesktopInput(tabId, message) {
+  // The reply is not a delivery receipt: the content script synchronously owns
+  // one desktopInputBusy slot, then the app's durable browser claim and one-time
+  // sendAuthorizedAt fence every later offer. Waiting here only starves repairs.
+  void chrome.tabs.sendMessage(tabId, message).catch(() => undefined);
+}
+
 async function deliverDesktopInputs(inputs, background, reusableConversations = [], activeIds) {
   if (!Array.isArray(inputs)) return;
   // Only the app's complete outbox projection retires spent opening authority.
@@ -1764,6 +1784,7 @@ async function deliverDesktopInputs(inputs, background, reusableConversations = 
     const candidates = tabs.filter(tab => matchesInput(input, tab));
     let tab = candidates.sort((a, b) => a.id - b.id)[0];
     let elected = elections[input.id];
+    let recoveredReuse = null;
     // A queued checkpoint follows the app's durable session rebind. Transfer only
     // to an already-existing successor tab, never reopen a closed elected target.
     if (target && cleanConversationId(input.supersededConversationId) &&
@@ -1772,6 +1793,27 @@ async function deliverDesktopInputs(inputs, background, reusableConversations = 
       elected = elections[input.id];
     }
     if (elected?.tab != null) tab = candidates.find(candidate => candidate.id === elected.tab);
+    // A prepare receipt can be lost after its exact document changes nothing. Do
+    // not replay from elapsed time: only the still-elected, still-owned document
+    // can prove that it is idle again and therefore no old preparation is live.
+    if (!tab && !target && elected?.stage === 'preparing' && Number.isInteger(elected.tab)) {
+      const candidate = tabs.find(row => row.id === elected.tab);
+      const reusable = new Set(reusableConversations);
+      const conversation = conversationForTab(candidate);
+      if (candidate) {
+        if (candidate.pendingUrl || modelCatalogTarget?.tab === candidate.id || (conversation && !reusable.has(conversation))) continue;
+        const source = { tab: candidate.id, documentId: tabDocuments[String(candidate.id)], navigationEpoch: tabEpochs[String(candidate.id)] };
+        if (!ownsDocument(source)) continue;
+        const proof = await inputReuseProbe(candidate.id, source.documentId);
+        const current = await chrome.tabs.get(candidate.id).catch(() => null);
+        if (proof?.safe !== true || proof.navigationEpoch !== source.navigationEpoch || !ownsDocument(source) ||
+            !current || current.pendingUrl || current.url !== candidate.url) continue;
+        // Logically clear this pass for one same-tab retry while the durable row
+        // remains custody if the document changes before preparation begins.
+        elected = null;
+        recoveredReuse = source;
+      }
+    }
     if (input.close === true && input.lifetime === 'temporary-planner') {
       if (!tab) continue;
       // Preserve the warm planner until newer app work has an actual browser tab.
@@ -1797,34 +1839,34 @@ async function deliverDesktopInputs(inputs, background, reusableConversations = 
     if (!tab) {
       // Handout is opening authority, not a missing delivery receipt. A closed or
       // unresponsive elected document never grants another opening attempt.
-      if (elections[input.id]) continue;
+      if (elections[input.id] && !recoveredReuse) continue;
       if (Object.keys(elections).length >= 1000) continue;
       const url = target ? `https://chatgpt.com/c/${encodeURIComponent(target)}` : `https://chatgpt.com/?${input.lifetime === 'temporary-planner' ? 'temporary-chat=true&' : ''}${marker}#${marker}`;
       if (!target && input.lifetime !== 'temporary-planner') {
         const reusable = new Set(reusableConversations);
         const choices = tabs.filter(candidate => !candidate.pendingUrl && modelCatalogTarget?.tab !== candidate.id &&
-          (!conversationForTab(candidate) || reusable.has(conversationForTab(candidate))))
+          (!conversationForTab(candidate) || reusable.has(conversationForTab(candidate))) &&
+          (!recoveredReuse || candidate.id === recoveredReuse.tab))
           .sort((a, b) => Number(!!conversationForTab(a)) - Number(!!conversationForTab(b)) || a.id - b.id);
         for (const candidate of choices) {
           const source = { tab: candidate.id, documentId: tabDocuments[String(candidate.id)], navigationEpoch: tabEpochs[String(candidate.id)] };
           if (!ownsDocument(source)) continue;
-          const proof = await inputReuseProbe(candidate.id, source.documentId);
+          const proof = recoveredReuse?.tab === source.tab && recoveredReuse.documentId === source.documentId && recoveredReuse.navigationEpoch === source.navigationEpoch
+            ? { safe: true, navigationEpoch: source.navigationEpoch }
+            : await inputReuseProbe(candidate.id, source.documentId);
           const current = await chrome.tabs.get(candidate.id).catch(() => null);
           if (proof?.safe !== true || proof.navigationEpoch !== source.navigationEpoch || !ownsDocument(source) ||
               !current || current.pendingUrl || current.url !== candidate.url) continue;
           await elect(input.id, { tab: candidate.id, stage: 'preparing' });
           const owner = (await chrome.storage.session.get('modelCatalogOwner')).modelCatalogOwner;
           if (owner?.tab === candidate.id) await chrome.storage.session.set({ modelCatalogOwner: { ...owner, handedToInput: input.id } });
-          let prepared;
-          try { prepared = await chrome.tabs.sendMessage(candidate.id, { type: 'clf-prepare-desktop-input', id: input.id }, { documentId: source.documentId }); }
-          catch { break; } // Ambiguous preparation is not a fallback authorization.
+          const prepared = await prepareDesktopInputReceipt(candidate.id, input.id, source.documentId);
           const latest = await chrome.tabs.get(candidate.id).catch(() => null);
           if (!latest || latest.pendingUrl || tabDocuments[String(candidate.id)] !== source.documentId) break;
           if (prepared?.ready === true && matchesInput(input, latest)) {
             await elect(input.id, { tab: candidate.id, stage: 'ready' });
             tab = latest;
-            try { await chrome.tabs.sendMessage(tab.id, { type: 'clf-desktop-input', id: input.id, conversationId: null }); }
-            catch { /* Claim/send ambiguity keeps this exact tab elected. */ }
+            offerDesktopInput(tab.id, { type: 'clf-desktop-input', id: input.id, conversationId: null });
           } else if (prepared?.fallback === true && prepared.preSend === true) {
             // Explicit native transition failure, before claim/insertion/send, owns
             // exactly one replacement. Persist that expenditure before Chrome awaits.
@@ -1843,8 +1885,7 @@ async function deliverDesktopInputs(inputs, background, reusableConversations = 
       tabs.push(tab);
       continue;
     }
-    try { await chrome.tabs.sendMessage(tab.id, { type: 'clf-desktop-input', id: input.id, conversationId: target, ...(input.lifetime ? { lifetime: input.lifetime } : {}) }); }
-    catch { /* Navigation is not a delivery receipt; a later maintenance pass can offer it. */ }
+    offerDesktopInput(tab.id, { type: 'clf-desktop-input', id: input.id, conversationId: target, ...(input.lifetime ? { lifetime: input.lifetime } : {}) });
   }
 }
 
@@ -2154,14 +2195,6 @@ async function maintainOnce() {
   if (reply.data.placement) await placeSuccessorChat(reply.data.placement, null);
   inspectRequestedModels(reply.data.modelCatalogRequest);
   inspectRequestedPluginRefresh(reply.data.pluginRefreshRequests, reply.data.background === true, reply.data.browserOnly === true);
-  await deliverDesktopInputs(reply.data.inputs, reply.data.background === true, reply.data.reusableConversations, reply.data.inputOpeningIds);
-  if (!backgroundReady) await reconcileBackgroundWindow(reply.data);
-  const monitoring = reply.data.recoveryMonitoring === true;
-  if (monitoring !== recoveryMonitoring) {
-    recoveryMonitoring = monitoring;
-    await persistLive().catch(() => undefined);
-  }
-  if (await acceptBrowserRevival(reply.data.revival)) await recoverDeferredRevivals();
   // Quoted back exactly as they arrived. A token names the handout being answered, so that a
   // receipt this pass sends late cannot close a repair the app has since raised for a different
   // turn. An entry missing either half is not actionable and is dropped rather than guessed at.
@@ -2172,6 +2205,20 @@ async function maintainOnce() {
       focus: Boolean(entry && entry.focus === true)
     }))
     .filter((entry) => entry.conversationId && entry.token);
+  const repairConversations = new Set(repairs.map(entry => entry.conversationId));
+  // Reloading the same document races its final input offer. Repair it now; the
+  // still-durable app row is offered on the next status pass after the reload.
+  const inputs = Array.isArray(reply.data.inputs)
+    ? reply.data.inputs.filter(input => !repairConversations.has(cleanConversationId(input?.conversationId)))
+    : reply.data.inputs;
+  await deliverDesktopInputs(inputs, reply.data.background === true, reply.data.reusableConversations, reply.data.inputOpeningIds);
+  if (!backgroundReady) await reconcileBackgroundWindow(reply.data);
+  const monitoring = reply.data.recoveryMonitoring === true;
+  if (monitoring !== recoveryMonitoring) {
+    recoveryMonitoring = monitoring;
+    await persistLive().catch(() => undefined);
+  }
+  if (await acceptBrowserRevival(reply.data.revival)) await recoverDeferredRevivals();
   const nonDiscardable = new Set(
     (Array.isArray(reply.data.nonDiscardableConversations) ? reply.data.nonDiscardableConversations : [])
       .map(cleanConversationId)

--- a/extension/background.js
+++ b/extension/background.js
@@ -1799,9 +1799,14 @@ async function deliverDesktopInputs(inputs, background, reusableConversations = 
     if (!tab && !target && elected?.stage === 'preparing' && Number.isInteger(elected.tab)) {
       const candidate = tabs.find(row => row.id === elected.tab);
       const reusable = new Set(reusableConversations);
-      const conversation = conversationForTab(candidate);
+      // A completed conversation registry entry can survive New Chat and an
+      // extension reload. Only a concrete current/pending /c URL may protect a
+      // different conversation here; an unmarked home must reach the exact
+      // document/epoch/idle probe instead of deadlocking on stale metadata.
+      const concreteConversation = conversationFromUrl(candidate?.url) || conversationFromUrl(candidate?.pendingUrl);
       if (candidate) {
-        if (candidate.pendingUrl || modelCatalogTarget?.tab === candidate.id || (conversation && !reusable.has(conversation))) continue;
+        if (candidate.pendingUrl || modelCatalogTarget?.tab === candidate.id ||
+            (concreteConversation && !reusable.has(concreteConversation))) continue;
         const source = { tab: candidate.id, documentId: tabDocuments[String(candidate.id)], navigationEpoch: tabEpochs[String(candidate.id)] };
         if (!ownsDocument(source)) continue;
         const proof = await inputReuseProbe(candidate.id, source.documentId);
@@ -1845,8 +1850,8 @@ async function deliverDesktopInputs(inputs, background, reusableConversations = 
       if (!target && input.lifetime !== 'temporary-planner') {
         const reusable = new Set(reusableConversations);
         const choices = tabs.filter(candidate => !candidate.pendingUrl && modelCatalogTarget?.tab !== candidate.id &&
-          (!conversationForTab(candidate) || reusable.has(conversationForTab(candidate))) &&
-          (!recoveredReuse || candidate.id === recoveredReuse.tab))
+          (recoveredReuse ? candidate.id === recoveredReuse.tab :
+            (!conversationForTab(candidate) || reusable.has(conversationForTab(candidate)))))
           .sort((a, b) => Number(!!conversationForTab(a)) - Number(!!conversationForTab(b)) || a.id - b.id);
         for (const candidate of choices) {
           const source = { tab: candidate.id, documentId: tabDocuments[String(candidate.id)], navigationEpoch: tabEpochs[String(candidate.id)] };

--- a/test/desktop-input-maintenance.test.ts
+++ b/test/desktop-input-maintenance.test.ts
@@ -490,6 +490,40 @@ describe('one browser maintenance flight per desktop outbox publication', () => 
     expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-desktop-input')).toHaveLength(0);
     expect(h.create).not.toHaveBeenCalled();
   });
+  it('ignores a stale conversation registry entry on the exact elected home document', async () => {
+    const h = await worker([{ id: firstId, conversationId: null } as any], undefined,
+      { inputOpenings: { [firstId]: { tab: 7, stage: 'preparing' } } });
+    h.tabs.push({ id: 7, url: 'https://chatgpt.com/' });
+    const source = await h.authorizeDocument({ tab: { id: 7 }, documentId: 'idle', frameId: 0, url: h.tabs[0]!.url }, { navigationEpoch: 1 });
+    await h.noteTabConversation(source, secondId);
+    h.sendMessage.mockImplementation(async (_id, message) => {
+      if (message.type === 'clf-input-reuse-state') return { ok: true, safe: true, navigationEpoch: 1 } as never;
+      if (message.type === 'clf-prepare-desktop-input') {
+        h.tabs[0]!.url = `https://chatgpt.com/?cos-input=${firstId}`;
+        return { ready: true } as never;
+      }
+      return { ok: true };
+    });
+    await h.maintain();
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-input-reuse-state')).toHaveLength(1);
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-prepare-desktop-input')).toHaveLength(1);
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-desktop-input')).toHaveLength(1);
+    expect((h.localSaved.inputOpenings as any)[firstId]).toEqual({ tab: 7, stage: 'ready' });
+    expect(h.create).not.toHaveBeenCalled();
+  });
+  it('still protects a concrete non-reusable conversation during preparing recovery', async () => {
+    const h = await worker([{ id: firstId, conversationId: null } as any], undefined,
+      { inputOpenings: { [firstId]: { tab: 7, stage: 'preparing' } } });
+    h.tabs.push({ id: 7, url: `https://chatgpt.com/c/${secondId}` });
+    await h.authorizeDocument({ tab: { id: 7 }, documentId: 'other-chat', frameId: 0, url: h.tabs[0]!.url }, { navigationEpoch: 1 });
+    h.sendMessage.mockResolvedValue({ ok: true, safe: true, navigationEpoch: 1 } as never);
+    await h.maintain();
+    expect((h.localSaved.inputOpenings as any)[firstId]).toEqual({ tab: 7, stage: 'preparing' });
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-input-reuse-state')).toHaveLength(0);
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-prepare-desktop-input')).toHaveLength(0);
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-desktop-input')).toHaveLength(0);
+    expect(h.create).not.toHaveBeenCalled();
+  });
   it('retries the same preparation only after an exact idle proof for its owned document', async () => {
     const h = await worker([{ id: firstId, conversationId: null, reopenUnclaimed: true } as any], undefined,
       { inputOpenings: { [firstId]: { tab: 7, stage: 'preparing' } } });

--- a/test/desktop-input-maintenance.test.ts
+++ b/test/desktop-input-maintenance.test.ts
@@ -105,6 +105,7 @@ async function worker(inputs: Array<{ id: string; conversationId: string | null;
     update: vi.fn()
   };
   const remove = vi.fn(async (_id: number) => {});
+  const reload = vi.fn(async (_id: number) => {});
   const sendMessage = vi.fn(async (_id: number, _message: any): Promise<{ ok: boolean; ready?: boolean }> => ({ ok: true, ready: true }));
   const update = vi.fn(async (id: number, patch: Partial<Tab>) => { const tab = tabs.find(tab => tab.id === id)!; Object.assign(tab, patch); delete tab.pendingUrl; return tab; });
   const fetch = vi.fn(async (input: string, _init?: RequestInit): Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }> => ({
@@ -118,7 +119,7 @@ async function worker(inputs: Array<{ id: string; conversationId: string | null;
       storage: { local, session },
       windows,
       runtime: { getManifest: () => ({ version: '2.0.5' }), onMessage: event, onInstalled: event, onStartup: event },
-      tabs: { query: async () => [...tabs], get: async (id: number) => tabs.find(tab => tab.id === id), remove, create, update, sendMessage, onCreated: event, onUpdated: event, onRemoved: event },
+      tabs: { query: async () => [...tabs], get: async (id: number) => tabs.find(tab => tab.id === id), remove, reload, create, update, sendMessage, onCreated: event, onUpdated: event, onRemoved: event },
       alarms: { onAlarm: event, create: () => {}, clear: async () => true },
       scripting: { executeScript: async () => [], insertCSS: async () => {} }
     },
@@ -128,7 +129,7 @@ async function worker(inputs: Array<{ id: string; conversationId: string | null;
   const api = context.testMaintenance as { releaseTab(...args: any[]): Promise<any>; serializeTab(tab: number, operation: () => Promise<any>): Promise<any>; noteTabConversation(source: any, conversationId: string): Promise<any>; applyRequestedBrowserPreferences(request: object): Promise<void>; authorizeDocument(sender: unknown, message: unknown): Promise<any>; catalog(message: unknown, sender: unknown, source: unknown): Promise<any>; load(): Promise<void>; maintain(): Promise<void>; createChatTab(url: string, background: boolean): Promise<Tab> };
   await api.load();
   vm.runInContext('Object.assign(testMaintenance, { offerStopTurns, noteTabConversation, ackCommand })', context);
-  return { ...api, update, inspectModels: (context.testMaintenance as any).inspectRequestedModels as (request: unknown, background: boolean) => Promise<void>, ackDesktopInput: (context.testMaintenance as any).ackDesktopInput as (...args: string[]) => Promise<any>, drainCommandAcks: (context.testMaintenance as any).drainCommandAcks as () => Promise<any>, desktopInput: (context.testMaintenance as any).desktopInput as (...args: any[]) => Promise<any>, events: (context.testMaintenance as any).events as (message: any, sender: any, source: any) => Promise<any>, create, sendMessage, tabs, fetch, windows, remove, local, localSaved, saved };
+  return { ...api, update, inspectModels: (context.testMaintenance as any).inspectRequestedModels as (request: unknown, background: boolean) => Promise<void>, ackDesktopInput: (context.testMaintenance as any).ackDesktopInput as (...args: string[]) => Promise<any>, drainCommandAcks: (context.testMaintenance as any).drainCommandAcks as () => Promise<any>, desktopInput: (context.testMaintenance as any).desktopInput as (...args: any[]) => Promise<any>, events: (context.testMaintenance as any).events as (message: any, sender: any, source: any) => Promise<any>, create, sendMessage, tabs, fetch, windows, remove, reload, local, localSaved, saved };
 }
 
 describe('one browser maintenance flight per desktop outbox publication', () => {
@@ -437,6 +438,140 @@ describe('one browser maintenance flight per desktop outbox publication', () => 
       await vi.runOnlyPendingTimersAsync();
       vi.useRealTimers();
     }
+  });
+  it('bounds a hung preparation receipt without granting fallback or send authority', async () => {
+    vi.useFakeTimers();
+    let resolvePrepare: ((value: unknown) => void) | undefined;
+    try {
+      const h = await worker([{ id: firstId, conversationId: null }]);
+      h.tabs.push({ id: 7, url: 'https://chatgpt.com/', active: true });
+      await h.authorizeDocument({ tab: { id: 7 }, documentId: 'idle', frameId: 0, url: h.tabs[0]!.url }, { navigationEpoch: 1 });
+      h.sendMessage.mockImplementation(async (_id, message) => {
+        if (message.type === 'clf-input-reuse-state') return { ok: true, safe: true, navigationEpoch: 1 } as never;
+        if (message.type === 'clf-prepare-desktop-input') return new Promise(resolve => { resolvePrepare = resolve; }) as never;
+        return { ok: true };
+      });
+
+      let released = false;
+      const wake = h.maintain().then(() => { released = true; });
+      await vi.advanceTimersByTimeAsync(15000);
+      await Promise.resolve();
+      expect(released).toBe(true);
+      await wake;
+      expect((h.localSaved.inputOpenings as any)[firstId]).toEqual({ tab: 7, stage: 'preparing' });
+      expect(h.create).not.toHaveBeenCalled();
+      expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-prepare-desktop-input')).toHaveLength(1);
+      expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-desktop-input')).toHaveLength(0);
+
+      resolvePrepare?.({ ready: false, fallback: true, preSend: true });
+      await Promise.resolve();
+      expect((h.localSaved.inputOpenings as any)[firstId]).toEqual({ tab: 7, stage: 'preparing' });
+      expect(h.create).not.toHaveBeenCalled();
+      expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-desktop-input')).toHaveLength(0);
+    } finally {
+      resolvePrepare?.({ ready: false, fallback: true, preSend: true });
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+  it.each(['unsafe', 'missing', 'stale'])('retains preparing custody when later reuse proof is %s', async proof => {
+    const h = await worker([{ id: firstId, conversationId: null, reopenUnclaimed: true } as any], undefined,
+      { inputOpenings: { [firstId]: { tab: 7, stage: 'preparing' } } });
+    h.tabs.push({ id: 7, url: 'https://chatgpt.com/' });
+    await h.authorizeDocument({ tab: { id: 7 }, documentId: 'idle', frameId: 0, url: h.tabs[0]!.url }, { navigationEpoch: 1 });
+    h.sendMessage.mockImplementation(async (_id, message) => message.type === 'clf-input-reuse-state'
+      ? (proof === 'unsafe' ? { ok: true, safe: false, navigationEpoch: 1 }
+        : proof === 'stale' ? { ok: true, safe: true, navigationEpoch: 2 } : undefined) as never
+      : { ok: true, ready: true });
+    await h.maintain();
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-input-reuse-state')).toHaveLength(1);
+    expect((h.localSaved.inputOpenings as any)[firstId]).toEqual({ tab: 7, stage: 'preparing' });
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-prepare-desktop-input')).toHaveLength(0);
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-desktop-input')).toHaveLength(0);
+    expect(h.create).not.toHaveBeenCalled();
+  });
+  it('retries the same preparation only after an exact idle proof for its owned document', async () => {
+    const h = await worker([{ id: firstId, conversationId: null, reopenUnclaimed: true } as any], undefined,
+      { inputOpenings: { [firstId]: { tab: 7, stage: 'preparing' } } });
+    h.tabs.push({ id: 7, url: 'https://chatgpt.com/' });
+    await h.authorizeDocument({ tab: { id: 7 }, documentId: 'idle', frameId: 0, url: h.tabs[0]!.url }, { navigationEpoch: 1 });
+    h.sendMessage.mockImplementation(async (_id, message) => {
+      if (message.type === 'clf-input-reuse-state') return { ok: true, safe: true, navigationEpoch: 1 } as never;
+      if (message.type === 'clf-prepare-desktop-input') {
+        h.tabs[0]!.url = `https://chatgpt.com/?cos-input=${firstId}`;
+        return { ready: true } as never;
+      }
+      return { ok: true };
+    });
+    await h.maintain();
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-input-reuse-state')).toHaveLength(1);
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-prepare-desktop-input'))
+      .toEqual([[7, { type: 'clf-prepare-desktop-input', id: firstId }, { documentId: 'idle' }]]);
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-desktop-input'))
+      .toEqual([[7, { type: 'clf-desktop-input', id: firstId, conversationId: null }]]);
+    expect((h.localSaved.inputOpenings as any)[firstId]).toEqual({ tab: 7, stage: 'ready' });
+    expect(h.create).not.toHaveBeenCalled();
+  });
+  it('resumes one offer when the exact preparing tab already carries the input marker', async () => {
+    const h = await worker([{ id: firstId, conversationId: null, reopenUnclaimed: true } as any], undefined,
+      { inputOpenings: { [firstId]: { tab: 7, stage: 'preparing' } } });
+    h.tabs.push({ id: 7, url: `https://chatgpt.com/?cos-input=${firstId}#cos-input=${firstId}` });
+    await h.maintain();
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-input-reuse-state')).toHaveLength(0);
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-prepare-desktop-input')).toHaveLength(0);
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-desktop-input'))
+      .toEqual([[7, { type: 'clf-desktop-input', id: firstId, conversationId: null }]]);
+    expect(h.create).not.toHaveBeenCalled();
+  });
+  it('continues to an independent repair when the final input offer never resolves', async () => {
+    let resolveOffer!: (value: unknown) => void;
+    const pendingOffer = new Promise(resolve => { resolveOffer = resolve; });
+    let wake: Promise<void> | undefined;
+    try {
+      const input = { id: firstId, conversationId: secondId };
+      const h = await worker([input]);
+      h.tabs.push({ id: 7, url: `https://chatgpt.com/c/${secondId}` }, { id: 8, url: `https://chatgpt.com/c/${firstId}` });
+      h.fetch.mockImplementation(async request => ({ ok: true, status: 200, json: async () => new URL(request).pathname === '/hello'
+        ? { app: 'chat-on-steroids', bridge: BRIDGE_PROTOCOL, compatible: true, paired: true }
+        : { ok: true, inputs: [input], inputOpeningIds: [firstId], repairs: [{ conversationId: firstId, token: 'repair-one' }] } }));
+      h.sendMessage.mockImplementation(async (_id, message) => message.type === 'clf-desktop-input'
+        ? pendingOffer as never : { ok: true, ready: true });
+
+      wake = h.maintain();
+      await vi.waitFor(() => expect(h.sendMessage.mock.calls.some(([, message]) => message.type === 'clf-desktop-input')).toBe(true));
+      expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-desktop-input'))
+        .toEqual([[7, { type: 'clf-desktop-input', id: firstId, conversationId: secondId }]]);
+      expect(h.reload).toHaveBeenCalledExactlyOnceWith(8);
+      expect((h.localSaved.inputOpenings as any)[firstId]).toEqual({ tab: 7, stage: 'ready', conversationId: secondId });
+      expect(h.create).not.toHaveBeenCalled();
+      resolveOffer({ ok: true });
+      await wake;
+    } finally {
+      resolveOffer({ ok: true });
+      await wake;
+    }
+  });
+  it('repairs a conversation before offering its queued input on a later status pass', async () => {
+    const input = { id: firstId, conversationId: secondId };
+    const h = await worker([input]);
+    let repaired = false;
+    h.tabs.push({ id: 7, url: `https://chatgpt.com/c/${secondId}` });
+    h.fetch.mockImplementation(async request => ({ ok: true, status: 200, json: async () => {
+      const url = new URL(request);
+      if (url.pathname === '/hello') return { app: 'chat-on-steroids', bridge: BRIDGE_PROTOCOL, compatible: true, paired: true };
+      if (url.searchParams.has('repaired')) { repaired = true; return { ok: true }; }
+      return { ok: true, inputs: [input], inputOpeningIds: [firstId],
+        repairs: repaired ? [] : [{ conversationId: secondId, token: 'repair-same' }] };
+    } }));
+    await h.maintain();
+    expect(h.reload).toHaveBeenCalledExactlyOnceWith(7);
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-desktop-input')).toHaveLength(0);
+    expect((h.localSaved.inputOpenings as any)[firstId]).toBeUndefined();
+    expect(h.create).not.toHaveBeenCalled();
+    await h.maintain();
+    expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-desktop-input'))
+      .toEqual([[7, { type: 'clf-desktop-input', id: firstId, conversationId: secondId }]]);
+    expect((h.localSaved.inputOpenings as any)[firstId]).toEqual({ tab: 7, stage: 'ready', conversationId: secondId });
   });
   it.each(['explicit-failure', 'ambiguous', 'closed'])('allows a single pre-send fallback only for %s', async reason => {
     const h = await worker([{ id: firstId, conversationId: null }]);

--- a/test/desktop-input-maintenance.test.ts
+++ b/test/desktop-input-maintenance.test.ts
@@ -400,6 +400,44 @@ describe('one browser maintenance flight per desktop outbox publication', () => 
     expect(h.sendMessage).toHaveBeenCalledWith(7, { type: 'clf-desktop-input', id: firstId, conversationId: null });
     expect((h.localSaved.inputOpenings as any)[firstId].tab).toBe(7);
   });
+  it('bounds a hung reuse observation before electing one fresh tab for the same input', async () => {
+    vi.useFakeTimers();
+    let resolveReuse: ((value: unknown) => void) | undefined;
+    try {
+      const h = await worker([{ id: firstId, conversationId: null }]);
+      h.tabs.push({ id: 7, url: 'https://chatgpt.com/', active: true });
+      await h.authorizeDocument({ tab: { id: 7 }, documentId: 'idle', frameId: 0, url: h.tabs[0]!.url }, { navigationEpoch: 1 });
+      h.sendMessage.mockImplementation(async (_id, message) => {
+        if (message.type === 'clf-input-reuse-state') return new Promise(resolve => { resolveReuse = resolve; }) as never;
+        return { ok: true, ready: true };
+      });
+
+      let released = false;
+      const firstWake = h.maintain().then(() => { released = true; });
+      await vi.advanceTimersByTimeAsync(3000);
+      await Promise.resolve();
+      expect(released).toBe(true);
+      await firstWake;
+
+      const marked = h.tabs.filter(tab => String(tab.pendingUrl || tab.url || '').includes(`cos-input=${firstId}`));
+      expect(marked).toHaveLength(1);
+      expect(h.create).toHaveBeenCalledTimes(1);
+      expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-prepare-desktop-input')).toHaveLength(0);
+      expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-desktop-input')).toHaveLength(0);
+
+      resolveReuse?.({ ok: true, safe: true, navigationEpoch: 1 });
+      await Promise.resolve();
+      await h.maintain();
+      expect(h.create).toHaveBeenCalledTimes(1);
+      expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-prepare-desktop-input')).toHaveLength(0);
+      expect(h.sendMessage.mock.calls.filter(([, message]) => message.type === 'clf-desktop-input'))
+        .toEqual([[marked[0]!.id, { type: 'clf-desktop-input', id: firstId, conversationId: null }]]);
+    } finally {
+      resolveReuse?.({ ok: true, safe: true, navigationEpoch: 1 });
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
   it.each(['explicit-failure', 'ambiguous', 'closed'])('allows a single pre-send fallback only for %s', async reason => {
     const h = await worker([{ id: firstId, conversationId: null }]);
     h.tabs.push({ id: 7, url: 'https://chatgpt.com/' });


### PR DESCRIPTION
A ChatGPT tab can hold the extension's shared maintenance flight at three separate browser-message boundaries: the read-only reuse probe, input-page preparation, and the final input offer. The first two waits prevented later maintenance entirely; waiting for the final offer also prevented unrelated repairs even though its reply is not a delivery receipt. A stale `tabConversations` entry could additionally survive New Chat and an extension reload, causing the exact elected home tab to be rejected forever as a non-reusable conversation.

This change:

- bounds the read-only reuse probe at three seconds; a silent tab is ineligible for reuse;
- bounds input-page preparation at 15 seconds and retains the exact request's `preparing` custody on timeout or rejection;
- retries preparation only when the same elected tab, document, navigation epoch, URL, and idle state are freshly proved;
- ignores stale conversation registry metadata only for that exact recovered home document, while a concrete current or pending `/c/<id>` URL still protects a different conversation;
- detaches the final input offer from the maintenance flight. The content script's synchronous busy slot, durable browser claim, and one-time `sendAuthorizedAt` authorization remain the send fences;
- performs a repair for a conversation before offering a queued input to that same conversation, leaving the input durable for the next status pass.

No timeout authorizes fallback, replays a prompt, creates a replacement request, or promotes a partial response to completion.

Fixes #143.

Validation:

- upstream-only branch: 75/75 focused desktop-input maintenance tests pass;
- local integration branch: 79/79 focused tests pass;
- `node --check extension/background.js`, typecheck, and production build pass in both trees;
- independent review found no request-identity, ownership, conversation-isolation, or replay blocker;
- the preserved live request retained its UUID and advanced from `queued` to a browser-acknowledged `running` session with the account-observed GPT-5.6/Pro selection. No resubmission, replacement UUID, fallback, or cancellation occurred.

The PR remains draft until that preserved live session reaches a terminal result. The broader Windows verification run still has unrelated capture/UIA, execution-policy, and MCP/compaction failures and is not reported as green.
