### PR TITLE
End an armed handoff the page proves ChatGPT never took

### DIFF
--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -144,6 +144,7 @@ import {
   abortContinuation,
   abortContinuationNow,
   abortContinuationSourceBeforeSendNow,
+  releaseContinuationSourceSendNow,
   attachSummary,
   beginContinuationDestinationSendNow,
   beginContinuationSourceSendNow,
@@ -2243,7 +2244,23 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
           origin
         );
       }
-      if (!aborted) return json(res, 409, { error: 'source_send_not_releasable' }, origin);
+      if (!aborted) {
+        // The two pre-Send states are handled above. An armed dispatch that the page then
+        // proved unaccepted - none of send()'s five acceptance signals inside its window, on
+        // a chat this flow had already stopped and settled - falls past them, and refusing it
+        // leaves the ticket armed until the six-hour TTL with the chat kept out of browser
+        // recovery for all of it. Nothing is re-offered on either path; only the transaction
+        // ends.
+        const released = await releaseContinuationSourceSendNow(
+          checkpointToken,
+          'ChatGPT did not take the handoff instruction, and an armed dispatch is never sent twice'
+        );
+        if (!released) return json(res, 409, { error: 'source_send_not_releasable' }, origin);
+        compactionWatch.delete(id);
+        if (repairsInFlight.get(id)?.reason === 'compaction') repairsInFlight.delete(id);
+        changed();
+        return json(res, 200, { released: true, sessionId: entry.sessionId }, origin);
+      }
       compactionWatch.delete(id);
       if (repairsInFlight.get(id)?.reason === 'compaction') repairsInFlight.delete(id);
       changed();

--- a/src/main/session/continuation.ts
+++ b/src/main/session/continuation.ts
@@ -843,6 +843,47 @@ export async function abortContinuationSourceBeforeSendNow(token: string, reason
   });
 }
 
+/**
+ * Gives up an armed source dispatch that the page proved ChatGPT never took.
+ *
+ * `dispatched-unresolved` is deliberately never replayed: it is written before the click, so a
+ * document that dies there may or may not have left the prompt with ChatGPT, and re-sending
+ * would be the double-send the whole fence exists to prevent. That is right, and this does not
+ * change it — nothing here re-offers the prompt to any page.
+ *
+ * What was missing is the other half. The destination side has had
+ * `releaseContinuationDestinationSendNow` since 2026-09-02, so a replacement chat whose click
+ * never landed hands the brief back at once. The source side had no equivalent, so the same
+ * event left the ticket in `dispatched-unresolved` until AUTOMATIC_HANDOVER_TTL_MS — six hours —
+ * with `handoffAsked()` true, so no pickup could re-ask and the page refusing to retype it. A
+ * 2026-09-04 QA run measured exactly that: three phase pickups fired and expired against a chat
+ * whose composer had never received the prompt. Worse than the stall itself, the chat stays in
+ * `pendingAutomaticContinuations()` the whole time, and `inspectSilentChats()` skips those — so
+ * a chat that is merely wedged also loses browser recovery for the rest of the six hours.
+ *
+ * The evidence is the page's own `send()` returning false, which is not a bare timeout: it
+ * watches five independent acceptance signals — the composer clearing, a new conversation id,
+ * generation starting, the Stop control appearing, and a freshly rendered user message matching
+ * the text — for three seconds. The compaction flow has already stopped generation and waited
+ * for settle before it types, so a landed click flips generating/Stop within milliseconds. None
+ * of the five inside three seconds is the strongest negative this page can produce.
+ *
+ * Aborting rather than releasing is the deliberate asymmetry with the destination half. The
+ * destination can prove nothing was sent (a chat that still has no id cannot have accepted a
+ * message) and so may safely re-offer the brief; here the evidence is strong but not proof, so
+ * the transaction ends instead of being re-armed. Nothing is ever sent twice, and the cost of
+ * being wrong is one abandoned compaction that auto-compaction re-files on the next qualifying
+ * turn — against six hours of a wedged chat with no browser recovery.
+ */
+export async function releaseContinuationSourceSendNow(token: string, reason: string): Promise<boolean> {
+  const entry = byToken.get(token);
+  if (!entry || !isOpen(entry) || entry.state !== 'awaiting-summary') return false;
+  // Only the armed-but-unproven state. `sent` has ChatGPT's own marker behind it and is not in
+  // doubt; the earlier states were never dispatched and are reclaimable without this.
+  if (entry.sourceSend.state !== 'dispatched-unresolved') return false;
+  return abortContinuation(token, reason);
+}
+
 /** Binds the marked source prompt to ChatGPT's stable user-message identity. */
 export async function bindContinuationSourceMessageNow(token: string, messageId: string, progress?: number): Promise<boolean> {
   if (!messageId || messageId.length > 200) return false;

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -1575,6 +1575,34 @@ describe('automatic compaction', () => {
     expect((await request('POST', '/compact', { body: { conversationId, token, sourceDispatch: true } })).status).toBe(409);
   });
 
+  /**
+   * The same proof, one state later. Once the click is armed the pre-Send abort no longer
+   * applies, and refusing here is what left the ticket standing for its whole six-hour TTL
+   * with the chat out of browser recovery for all of it.
+   */
+  it('ends an armed handoff the page proves ChatGPT never took', async () => {
+    await pair();
+    const conversationId = 'a1a1a1a1-0000-4000-8000-00000000ac0a';
+    await request('POST', '/events', {
+      body: {
+        conversationId,
+        events: [{ kind: 'user_message', time: Date.now(), text: 'armed but never taken', messageId: 'm-armed-lost' }]
+      }
+    });
+    const filed = await request('POST', '/compact', { body: { conversationId, ticket: true, automatic: true } });
+    const token = filed.body.token as string;
+    expect((await request('POST', '/compact', { body: { conversationId, token, sourceAttempt: true } })).body.allowed).toBe(true);
+    // Armed: past this point the pre-Send states are gone and only this path can end it.
+    expect((await request('POST', '/compact', { body: { conversationId, token, sourceDispatch: true } })).body.armed).toBe(true);
+
+    const lost = await request('POST', '/compact', { body: { conversationId, token, sourceLost: true } });
+
+    expect(lost.status).toBe(200);
+    expect(lost.body.released).toBe(true);
+    expect(continuationByToken(token)?.state).toBe('aborted');
+    expect(continuationForSession(filed.body.sessionId as string)).toBeNull();
+  });
+
   it('does not immediately refile a rejected automatic compaction in the same working turn', async () => {
     await pair();
     const conversationId = 'a1a1a1a1-0000-4000-8000-00000000ac09';

--- a/test/continuation.test.ts
+++ b/test/continuation.test.ts
@@ -53,6 +53,8 @@ const {
   CONTINUATION_TTL_MS,
   abortContinuation,
   abortContinuationSourceBeforeSendNow,
+  releaseContinuationSourceSendNow,
+  pendingContinuations,
   attachSummary,
   beginContinuationDestinationSendNow,
   beginContinuationSourceSendNow,
@@ -916,6 +918,52 @@ describe('restart lifetime recovery', () => {
     await restoreContinuations(saved);
     expect(compactingConversation(CHAT_A)).toBeNull();
     expect(continuationForSession(summary.id)).toBeNull();
+  });
+
+  /**
+   * The same wedge as above, ended in seconds rather than six hours.
+   *
+   * The test above is the backstop: an armed dispatch that nobody resolves is eventually given
+   * up by the TTL. A 2026-09-04 QA run measured what that costs when the click simply did not
+   * land — three phase pickups firing and expiring against a chat whose composer had never
+   * received the prompt, and, because `pendingContinuations()` still named it and
+   * `inspectSilentChats()` skips those, no browser recovery for the whole window either.
+   *
+   * The page can say so: `send()` watches five acceptance signals and this flow settles the turn
+   * before typing, so none of them inside its window is the strongest negative the page has.
+   * Aborting rather than re-arming is deliberate — the prompt may still be with ChatGPT, and
+   * nothing is ever sent twice.
+   */
+  it('gives up an armed source dispatch the page proves ChatGPT never took', async () => {
+    const summary = await createSession({ title: 'source send lost', conversationId: CHAT_A });
+    const opened = await openContinuationNow(summary.id, CHAT_A, true);
+    expect((await beginContinuationSourceSendNow(opened.token))?.allowed).toBe(true);
+    expect(await dispatchContinuationSourceSendNow(opened.token)).toBe(true);
+    // Armed: chat A is refused every tool from here until something resolves it.
+    expect(compactingConversation(CHAT_A)?.token).toBe(opened.token);
+
+    expect(await releaseContinuationSourceSendNow(opened.token, 'nothing was taken')).toBe(true);
+
+    // Ended, without waiting out the TTL: the fence is down, the chat is out of the pending set
+    // that was costing it browser recovery, and the record is terminal rather than re-armed.
+    expect(compactingConversation(CHAT_A)).toBeNull();
+    expect(continuationForSession(summary.id)).toBeNull();
+    expect(continuationByToken(opened.token)?.state).toBe('aborted');
+    expect(pendingContinuations().some((entry) => entry.token === opened.token)).toBe(false);
+  });
+
+  it('refuses to give up a source dispatch ChatGPT is proven to have taken', async () => {
+    const summary = await createSession({ title: 'source send landed', conversationId: CHAT_A });
+    const opened = await openContinuationNow(summary.id, CHAT_A, true);
+    expect((await beginContinuationSourceSendNow(opened.token))?.allowed).toBe(true);
+    expect(await dispatchContinuationSourceSendNow(opened.token)).toBe(true);
+    // ChatGPT's own marker landed, so the send is not in doubt and a late "nothing was taken"
+    // from some other document must not tear down a handover that is genuinely under way.
+    expect(await bindContinuationSourceMessageNow(opened.token, 'msg-source-landed')).toBe(true);
+
+    expect(await releaseContinuationSourceSendNow(opened.token, 'nothing was taken')).toBe(false);
+    expect(continuationForSession(summary.id)?.state).toBe('awaiting-summary');
+    expect(compactingConversation(CHAT_A)?.token).toBe(opened.token);
   });
 
   it('keeps a committed record committed when the session has since moved on again', async () => {


### PR DESCRIPTION
One of the unrelated session fixes split out of #78.

### The gap

`abortContinuationSourceBeforeSendNow` ends the transaction from `not-attempted` and `attempted-unresolved`, and its comment says why it stops there:

> once the dispatch fence has been crossed the outcome is ambiguous and only ChatGPT's marker or an explicit user cancellation may end the transaction

That is right about **re-sending**, and nothing in this PR re-sends. But the ticket still has to end somewhere.

An armed dispatch the page then proved unaccepted falls past both pre-Send states, so `/compact` answers `409 source_send_not_releasable` and the ticket stands until `AUTOMATIC_HANDOVER_TTL_MS` — six hours — with `handoffAsked()` true, so no pickup can re-ask and the page will not retype it. Worse than the stall: the chat stays in `pendingAutomaticContinuations()` the whole time and `inspectSilentChats()` skips those, so a chat that is merely wedged also loses browser recovery for those six hours.

### Why the page's word is good enough here

Not a bare timeout. `send()` watches five independent acceptance signals — the composer clearing, a new conversation id, generation starting, the Stop control appearing, and a freshly rendered user message matching the text — for three seconds. The compaction flow has already stopped generation and waited for settle before it types, so a landed click flips generating/Stop within milliseconds. None of the five inside three seconds is the strongest negative this page can produce.

### The change

Only the refusal path is affected: the pre-Send abort still decides first, and just its `!aborted` answer now reaches `releaseContinuationSourceSendNow`, which aborts rather than re-arms.

The asymmetry with the destination half stays deliberate. The destination can prove nothing was sent — a chat with no id cannot have accepted a message — and may safely re-offer the brief; here the evidence is strong but not proof, so the transaction ends and nothing is offered again. Being wrong costs one abandoned compaction that auto-compaction refiles on the next qualifying turn, against six hours of a wedged chat.

### Verified

Fails before the change at the bridge level:

```
× ends an armed handoff the page proves ChatGPT never took
  AssertionError: expected 409 to be 200
```

Plus two unit tests: the armed dispatch is released and leaves the pending set, and a dispatch ChatGPT is *proven* to have taken (its marker bound) is still refused.

`npm run typecheck` clean. Full suite 3437 passed; the four failures are `renderer-usage` (locale-dependent number formatting) and one `mcp` shell test, which fail identically on unmodified `main` on this Windows machine and pass in CI.