### PR TITLE
Make macOS desktop input physical, and say what it hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,29 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Compile macOS desktop helpers
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/prepare-macos-desktop-helper.mjs --platform darwin --arch x64
+          node scripts/prepare-macos-desktop-helper.mjs --platform darwin --arch arm64
+
+      # Compiling proves the Swift parses. It says nothing about whether the binary starts,
+      # answers, or reaches its capture path — and the pointer defect that prompted this work
+      # was a runtime property the compiler could not see. This runs it. A runner has no
+      # Screen Recording grant, so a capture is expected to be refused by name; that refusal is
+      # a working code path, while a crash, a hang or a malformed reply is not.
+      - name: Run the macOS desktop helper
+        if: runner.os == 'macOS'
+        shell: bash
+        run: node scripts/probe-macos-helper.mjs arm64
+
+      - name: Limit Vitest workers on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Add-Content -Path $env:GITHUB_ENV -Value 'VITEST_MAX_WORKERS=1'
+
       - name: Verify
         run: npm run verify:ci
 

--- a/native/macos-desktop-helper/main.swift
+++ b/native/macos-desktop-helper/main.swift
@@ -214,9 +214,11 @@ private func allWindowRows(includeMinimized: Bool = true) -> [WindowRow] {
         let onScreen = bool(item[kCGWindowIsOnscreen as String])
         let alpha = number(item[kCGWindowAlpha as String])?.doubleValue ?? 1
         guard layer == 0, alpha > 0 else { return nil }
-        let process = string(item[kCGWindowOwnerName as String], default: "Process \(pid)")
-        let title = string(item[kCGWindowName as String]).trimmingCharacters(in: .whitespacesAndNewlines)
-        let displayTitle = title.isEmpty ? "\(process) window" : title
+        let process = boundedAXString(string(item[kCGWindowOwnerName as String], default: "Process \(pid)"))
+        let title = boundedAXString(
+            string(item[kCGWindowName as String]).trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+        let displayTitle = boundedAXString(title.isEmpty ? "\(process) window" : title)
         return WindowRow(
             id: id,
             pid: pid,
@@ -237,8 +239,37 @@ private func windowRow(_ id: CGWindowID) -> WindowRow? {
     allWindowRows().first { $0.id == id }
 }
 
+/**
+ * Which application is active, read fresh rather than from a cache nobody is refilling.
+ *
+ * `NSWorkspace.shared.frontmostApplication` is served from an internal running-applications
+ * cache that AppKit keeps current by delivering notifications on a run loop. The standalone
+ * helper has none: it reads commands with `readLine()` on the main thread and never returns to
+ * a run loop, so the cache is fixed at first access and every application launched afterwards
+ * stays invisible to it — for the life of the process.
+ *
+ * The app runs one long-lived helper, which makes that permanent. QA reproduced it directly:
+ * two helpers on the same desktop at the same moment, one that had queried before TextEdit was
+ * launched and one started after. The first reported no foreground window and kept doing so; the
+ * second was correct throughout. Window *enumeration* was fine either way, because that goes
+ * through CGWindowListCopyWindowInfo — so the window was listed, capturable and visibly in
+ * front, while nothing would call it foreground. That is the `No foreground window` the release
+ * was held for, and it is a second, independent cause of the same symptom as the transient
+ * child-window case fixed earlier.
+ *
+ * Draining the run loop's ready sources first lets those pending notifications arrive. Bounded
+ * and non-blocking: each pass returns immediately when there is nothing to deliver, and in the
+ * in-process build — where Electron's main thread is already running a real run loop — there is
+ * never anything pending here and the loop exits on its first pass.
+ */
 private func frontmostPID() -> pid_t? {
-    NSWorkspace.shared.frontmostApplication?.processIdentifier
+    onMainQueue {
+        var drained = 0
+        while drained < 32, CFRunLoopRunInMode(.defaultMode, 0, true) == .handledSource {
+            drained += 1
+        }
+        return NSWorkspace.shared.frontmostApplication?.processIdentifier
+    }
 }
 
 private func windowServerFrontWindowID(rows suppliedRows: [WindowRow]? = nil) -> CGWindowID? {
@@ -263,15 +294,23 @@ private func windowServerFrontWindowID(rows suppliedRows: [WindowRow]? = nil) ->
 private func foregroundWindowID() -> CGWindowID? {
     guard let pid = frontmostPID() else { return nil }
     let rows = allWindowRows(includeMinimized: false)
-    guard let frontID = windowServerFrontWindowID(rows: rows),
+    // Read the focused window once and use that one answer for both decisions below.
+    //
+    // These used to be two separate queries of the same fact: frontWindowID asked which window
+    // has AX focus in order to resolve an app's transient child windows, and then this function
+    // asked again to check they agreed. Between the two reads focus can move — a bubble opens, a
+    // popup closes — and the second answer disagreeing with the first was read as "an app
+    // transition is in flight" and reported as no foreground window at all. QA saw exactly that:
+    // `No foreground window` while Chrome plainly occupied the screen, correcting itself as soon
+    // as anything was refocused. One read cannot disagree with itself.
+    let focused = AXIsProcessTrusted() ? focusedAXWindowID(for: pid, rows: rows) : nil
+    guard let frontID = frontWindowID(rows: rows, focusedWindow: focused),
           let front = rows.first(where: { $0.id == frontID }),
           front.pid == pid else { return nil }
     // Screen-only observation must still work without Accessibility. When AX is available,
-    // disagreement means an app transition is in flight, so expose no active window rather
-    // than attributing input or pixels to stale state from either subsystem.
-    if AXIsProcessTrusted(), let focused = focusedAXWindowID(for: pid, rows: rows), focused != front.id {
-        return nil
-    }
+    // genuine disagreement still means a transition is in flight, so expose no active window
+    // rather than attributing input or pixels to stale state from either subsystem.
+    if let focused, focused != front.id { return nil }
     return front.id
 }
 
@@ -311,12 +350,134 @@ private func axElementAttribute(_ element: AXUIElement, _ attribute: CFString) -
     return (value as! AXUIElement)
 }
 
+/**
+ * What sits under a screen point, across every application.
+ *
+ * A scroll wheel is delivered by the window server to whatever is under the pointer, not to
+ * whatever holds the lease. When a scroll reports success and the document has not moved, the
+ * usual reason is that some other window was under that point — and an answer that only says
+ * "sent" cannot tell that apart from "the app ignored it". So read it back.
+ */
+private func elementUnderPointer(_ point: CGPoint) -> AXUIElement? {
+    var element: AXUIElement?
+    let status = AXUIElementCopyElementAtPosition(
+        AXUIElementCreateSystemWide(), Float(point.x), Float(point.y), &element
+    )
+    return status == .success ? element : nil
+}
+
+/**
+ * How far the scroller nearest this element has travelled, 0...1, or nil when nothing scrolls here.
+ *
+ * The scroll bar carries the position as a fraction, which is all that is needed to answer "did it
+ * move": comparing the same fraction before and after needs no knowledge of the document at all.
+ */
+private func scrollFraction(near element: AXUIElement) -> Double? {
+    var current: AXUIElement? = element
+    for _ in 0..<8 {
+        guard let node = current else { return nil }
+        if let bar = axElementAttribute(node, "AXVerticalScrollBar" as CFString),
+           let value = axAttribute(bar, "AXValue" as CFString) as? NSNumber {
+            return value.doubleValue
+        }
+        current = axElementAttribute(node, "AXParent" as CFString)
+    }
+    return nil
+}
+
+/**
+ * Wait only as long as the scroll actually takes, then read it.
+ *
+ * This was a flat 120 ms, chosen without a measurement, and a QA run supplied the measurement:
+ * ten scrolls cost 2495 ms, 234 ms each, while the scroller itself finished moving after 21 to
+ * 26 ms — the wait was roughly five times the thing it was waiting for, on every single scroll.
+ *
+ * A shorter flat number would have been a second guess. Polling until two readings agree costs
+ * about 30 ms where 120 was spent, and — unlike any fixed figure — it still waits for an
+ * application whose scrolling is animated rather than instant, which the measurement explicitly
+ * did not cover. The 120 ms survives as the ceiling, so nothing can wait longer than before.
+ *
+ * "Nothing can wait longer than before" held only in requested microseconds, not on the clock. A
+ * later QA round measured the actual ceiling at 145–348 ms and traced it here: the loop counted
+ * `elapsed` by adding the *requested* 10_000 µs each turn, never the time `usleep` had actually
+ * spent — and `usleep(10_000)` measured a median 12.06 ms on that machine, over the nominal
+ * request before a single read even ran. Twelve turns of that under-count alone reach 145 ms
+ * before the requested total says 120. `systemUptime`, the deadline idiom every other wait in
+ * this file already uses, reads the clock instead of trusting the request.
+ */
+private func settledScrollState(_ point: CGPoint, startedAt start: Double?) -> (pid: pid_t?, role: String?, fraction: Double?) {
+    // Nothing scrollable is under the pointer, so there is no reading to settle. Give the
+    // application a moment anyway — the answer still reports what was hit.
+    guard let start else {
+        usleep(30_000)
+        return pointerScrollState(point)
+    }
+    var last: (pid: pid_t?, role: String?, fraction: Double?) = (nil, nil, nil)
+    var moved = false
+    let deadline = ProcessInfo.processInfo.systemUptime + 0.120
+    while ProcessInfo.processInfo.systemUptime < deadline {
+        usleep(10_000)
+        let current = pointerScrollState(point)
+        guard let now = current.fraction else { return current }
+        // Two readings agree only once the scroll has actually begun. Comparing a reading to
+        // itself before then would answer "nothing moved" at 10 ms, which is a third of the way
+        // to the movement even starting — the measurement puts that at 21 to 26 ms.
+        if now != start { moved = true }
+        if moved, let previous = last.fraction, previous == now { return current }
+        last = current
+    }
+    return last.fraction == nil ? pointerScrollState(point) : last
+}
+
+private func pointerScrollState(_ point: CGPoint) -> (pid: pid_t?, role: String?, fraction: Double?) {
+    guard let element = elementUnderPointer(point) else { return (nil, nil, nil) }
+    var pid: pid_t = 0
+    let owner = AXUIElementGetPid(element, &pid) == .success ? pid : nil
+    return (owner, axString(element, "AXRole" as CFString), scrollFraction(near: element))
+}
+
 private func axString(_ element: AXUIElement, _ attribute: CFString) -> String? {
     axAttribute(element, attribute) as? String
 }
 
 private func axBool(_ element: AXUIElement, _ attribute: CFString, default fallback: Bool) -> Bool {
-    (axAttribute(element, attribute) as? NSNumber)?.boolValue ?? fallback
+    axOptionalBool(element, attribute) ?? fallback
+}
+
+/** Nil when the control publishes no readable boolean, which is not the same as false. */
+private func axOptionalBool(_ element: AXUIElement, _ attribute: CFString) -> Bool? {
+    (axAttribute(element, attribute) as? NSNumber)?.boolValue
+}
+
+/**
+ * A comparable snapshot of a control's own reported value, when it has one.
+ *
+ * `AnyObject` bridges every AXValue shape this actually returns for a value worth comparing —
+ * `NSNumber` for a checkbox or switch, `NSString` for a text control — to something `isEqual`
+ * can judge. Nil is not "empty" or "false"; it is "this control publishes no comparable value
+ * at all", which an ordinary action button does not, and must stay distinguishable from a
+ * value that was read and did not change.
+ *
+ * A Chromium accessibility tree answers `AXValue` with an empty string for a control that has
+ * nothing to say about its own state, rather than omitting the attribute the way AppKit does —
+ * measured on both a `PopUpButton` (the extension's own toolbar icon) and a real
+ * `<input type="checkbox">` inside its popup. An empty string still equals itself, so treating
+ * it as a genuine value reported `changed: false` — "nothing changed" — for both, when the
+ * honest answer this function exists to give is "nothing to compare".
+ */
+private func axComparableValue(_ element: AXUIElement) -> NSObject? {
+    guard let value = axAttribute(element, kAXValueAttribute as CFString) as? NSObject else { return nil }
+    if let text = value as? String, text.isEmpty { return nil }
+    return value
+}
+
+/** Whether accessibility itself says this control's value can be written. */
+private func axValueIsSettable(_ element: AXUIElement) -> Bool {
+    var settable = DarwinBoolean(false)
+    guard AXUIElementIsAttributeSettable(element, kAXValueAttribute as CFString, &settable) == .success else {
+        return false
+    }
+    return settable.boolValue
 }
 
 private func axPoint(_ element: AXUIElement, _ attribute: CFString) -> CGPoint? {
@@ -375,6 +536,45 @@ private func axName(_ element: AXUIElement) -> String {
     return ""
 }
 
+/**
+ * Whether two titles name the same window, when one of them carries decoration the other does not.
+ *
+ * A window's accessibility title and its title in the window list are not the same string. Chrome
+ * lists "Example Domain" and answers "Example Domain - Google Chrome - mydealz" — the browser name
+ * and the profile appended. Comparing them for equality therefore matched nothing, and the tie-break
+ * built on it did nothing at all for the application it was written for: a QA run met two Chrome
+ * windows of identical size with plainly different titles and still could not address either.
+ *
+ * Containment is the honest relation between them. It is one-sided by design: if two windows both
+ * carry the shorter title, they remain ambiguous, which is correct.
+ */
+/**
+ * Whether a failure was only about reading the accessibility tree, leaving a capture still valid.
+ *
+ * This was written as a list of codes to let through, and a list is wrong for the job: splitting
+ * `UIA_AMBIGUOUS_WINDOW` out of `UIA_FAILED` last round quietly took the new code off it, so a
+ * snapshot of a window this scan cannot tell apart returned neither the tree *nor* the picture —
+ * while asking for the picture alone still worked, and while the very same call on a window with no
+ * accessibility representation at all returned both. The refusal even advised moving one of the
+ * windows, which is exactly what the picture would have helped with.
+ *
+ * Asking what the failure *is* survives the next split. Only a target-identity failure — the window
+ * is gone, moving, or was never named — invalidates the capture too.
+ */
+private func onlyTheTreeFailed(_ code: String) -> Bool {
+    switch code {
+    case "WINDOW_NOT_FOUND", "WINDOW_MOVING", "BAD_REQUEST":
+        return false
+    default:
+        return true
+    }
+}
+
+private func titlesAgree(_ a: String?, _ b: String?) -> Bool {
+    guard let a, let b, !a.isEmpty, !b.isEmpty else { return false }
+    return a == b || a.contains(b) || b.contains(a)
+}
+
 private func axWindowNumber(_ element: AXUIElement) -> CGWindowID? {
     (axAttribute(element, "AXWindowNumber" as CFString) as? NSNumber)?.uint32Value
 }
@@ -384,14 +584,35 @@ private func axPID(_ element: AXUIElement) -> pid_t? {
     return AXUIElementGetPid(element, &pid) == .success ? pid : nil
 }
 
-private func unambiguousWindowID(bounds: CGRect, pid: pid_t, rows: [WindowRow]) -> CGWindowID? {
+/**
+ * Which listed window an accessibility window is, when the id it should carry does not exist.
+ *
+ * `title` is not optional decoration; leaving it out is what made the previous round's fix useless
+ * in practice. The title tie-break went into `matchingAXWindow`, which turns a row into an element,
+ * and not into this, which turns an element back into a row — and every focus and every input
+ * target goes through here. So `find_ui` could tell two identical windows apart while any batch
+ * beginning with `focus` still failed, and a focus that had actually worked was reported as
+ * FOCUS_FAILED because the window that came to the front could not be attributed. Two independent
+ * QA runs met that same message from opposite directions.
+ */
+private func unambiguousWindowID(
+    bounds: CGRect,
+    pid: pid_t,
+    rows: [WindowRow],
+    title: String? = nil
+) -> CGWindowID? {
     let candidates = rows
         .filter { $0.pid == pid && convincinglyMatchesWindow(bounds, $0.bounds) }
-        .map { (id: $0.id, distance: windowGeometryDistance(bounds, $0.bounds)) }
+        .map { (id: $0.id, title: $0.title, distance: windowGeometryDistance(bounds, $0.bounds)) }
         .sorted { $0.distance < $1.distance }
     guard let winner = candidates.first else { return nil }
-    if candidates.count > 1, candidates[1].distance - winner.distance < 32 { return nil }
-    return winner.id
+    guard candidates.count > 1, candidates[1].distance - winner.distance < 32 else { return winner.id }
+    // Geometry cannot separate them. The title often can, and it is already here.
+    if let title, !title.isEmpty {
+        let titled = candidates.filter { titlesAgree(title, $0.title) }
+        if titled.count == 1 { return titled[0].id }
+    }
+    return nil
 }
 
 private func owningAXWindowID(
@@ -412,7 +633,8 @@ private func owningAXWindowID(
                 return unambiguousWindowID(
                     bounds: bounds,
                     pid: pid,
-                    rows: suppliedRows ?? allWindowRows(includeMinimized: false)
+                    rows: suppliedRows ?? allWindowRows(includeMinimized: false),
+                    title: axString(window, kAXTitleAttribute as CFString)
                 )
             }
         }
@@ -428,7 +650,12 @@ private func focusedAXWindowID(for pid: pid_t, rows suppliedRows: [WindowRow]? =
     if let exact = axWindowNumber(focused) { return exact }
     guard let bounds = axBounds(focused) else { return nil }
     let rows = suppliedRows ?? allWindowRows(includeMinimized: false)
-    return unambiguousWindowID(bounds: bounds, pid: pid, rows: rows)
+    return unambiguousWindowID(
+        bounds: bounds,
+        pid: pid,
+        rows: rows,
+        title: axString(focused, kAXTitleAttribute as CFString)
+    )
 }
 
 private func focusedAXElementWindowID(for pid: pid_t, rows suppliedRows: [WindowRow]? = nil) -> CGWindowID? {
@@ -438,11 +665,64 @@ private func focusedAXElementWindowID(for pid: pid_t, rows suppliedRows: [Window
     return owningAXWindowID(element, pid: pid, rows: suppliedRows)
 }
 
+/**
+ * The front window, with one application's own transient child windows resolved by AX.
+ *
+ * WindowServer z-order answers "what is on top", which is not the same question as "which
+ * window receives keyboard input". Chrome's link-preview bubble and its omnibox popup are
+ * ordinary layer-0 windows of the browser that legitimately sit above the window the user is
+ * typing in. Reading the topmost one as the front window made `observe` report no foreground
+ * window at all while Chrome was plainly active, and made `focusWindow` poll a condition it
+ * could never satisfy until the bubble happened to disappear.
+ *
+ * Across applications nothing is relaxed. A window owned by another process still wins the
+ * z-order comparison, and every caller separately requires the answer to belong to
+ * `frontmostPID()`, so a covering window from another app still refuses input. The
+ * resolution applies only inside the frontmost application, where `AXFocusedWindow` is by
+ * definition the authority on where that application's keyboard input goes — and it is only
+ * trusted when it names a window this scan already saw and admitted.
+ */
+private func frontWindowID(rows: [WindowRow], focusedWindow: CGWindowID? = nil) -> CGWindowID? {
+    guard let top = windowServerFrontWindowID(rows: rows) else { return nil }
+    guard let topRow = rows.first(where: { $0.id == top }), frontmostPID() == topRow.pid else { return top }
+    // A caller that has already read the focused window passes it in, so the two of us cannot
+    // reach different conclusions from two reads taken moments apart.
+    guard let focused = focusedWindow ?? focusedAXWindowID(for: topRow.pid, rows: rows),
+          focused != top else { return top }
+    guard rows.contains(where: { $0.id == focused && $0.pid == topRow.pid }) else { return top }
+    return focused
+}
+
+/**
+ * A note for whoever next reads `INPUT_TARGET_LOST` against a browser and files it as a bug.
+ *
+ * It is usually not one, and it is not specific to this helper. The last clause below asks the
+ * application which control has keyboard focus. A browser answers that only when the *page* has
+ * a focused control it exposes to accessibility: measured on 2026-09-04, macOS Chrome on
+ * `chatgpt.com` with the composer focused resolved `AXFocusedUIElement` to an `AXTextArea` and
+ * input was delivered normally, while the same Chrome on a plain page with nothing focused could
+ * not be read at all (AppleScript saw `-1728`, "cannot be read") and every action was refused.
+ * Repeated deep AX walks of the window do not change it — it is a property of the page, not a
+ * lazily-activated process-wide tree.
+ *
+ * The consequence is a real corner and worth stating plainly: `computer` cannot click *into* a
+ * web page that has nothing focused yet, because the click that would create focus is itself
+ * fenced by the absence of focus. That is the fence failing closed on an honest ignorance of
+ * where input would land, which is what it is for — it must not be "fixed" by assuming the
+ * frontmost window will receive the keystroke. The `browser` tool is the way to drive a web
+ * page; it speaks CDP and needs none of this.
+ */
 private func inputTargetMatches(_ row: WindowRow) -> Bool {
     guard frontmostPID() == row.pid else { return false }
     let rows = allWindowRows(includeMinimized: false)
-    guard windowServerFrontWindowID(rows: rows) == row.id else { return false }
-    guard focusedAXWindowID(for: row.pid, rows: rows) == row.id else { return false }
+    // One read, two uses — as in foregroundWindowID, and here it matters more. This is the
+    // fence physical input passes through, so a disagreement between two reads of the same
+    // fact refuses a legitimate action: QA hit FOCUS_FAILED against a window that was visibly
+    // active, because focusWindow polls this and could never satisfy a condition that was
+    // partly a race. Every clause still has to hold; they just judge one observation.
+    let focused = focusedAXWindowID(for: row.pid, rows: rows)
+    guard frontWindowID(rows: rows, focusedWindow: focused) == row.id else { return false }
+    guard focused == row.id else { return false }
     // Missing focused-control evidence is not agreement. AX can return nil on a timeout,
     // an untyped value or an app transition; accepting that would turn an unprovable
     // keyboard destination into global physical input.
@@ -450,12 +730,81 @@ private func inputTargetMatches(_ row: WindowRow) -> Bool {
     return true
 }
 
+/**
+ * Which clause of the input fence refuses this window, for the error message only.
+ *
+ * `inputTargetMatches` above stays the authority and is deliberately left exactly as it is: it is
+ * the fence physical input passes through, and its shape is asserted clause by clause elsewhere.
+ * This re-reads the same three facts a moment later purely to say which one disagreed.
+ *
+ * It earns its keep because "the requested window could not be activated" is a sentence with no
+ * next step in it. QA hit it against a Chrome window that was plainly on screen, and answering
+ * why took a separate instrumented build on the machine that could reproduce it — for a fact the
+ * helper already knew and threw away. Being a second observation it can name a reason that has
+ * since changed; a diagnostic that is occasionally stale is still worth more than none.
+ */
+private func inputTargetRefusal(_ row: WindowRow) -> String {
+    guard frontmostPID() == row.pid else { return "another application is frontmost" }
+    let rows = allWindowRows(includeMinimized: false)
+    let focused = focusedAXWindowID(for: row.pid, rows: rows)
+    if let front = frontWindowID(rows: rows, focusedWindow: focused), front != row.id {
+        // Naming it is the whole value. A measurement on a Mac found this reason appearing only
+        // for Chrome's transient omnibox container — a second window the application opens on
+        // Cmd+L, which `windows` lists like any other and which a caller can easily address by
+        // mistake. Told only that "another window is in front", there is nothing to do about it;
+        // told which one, the caller can target that window or dismiss it.
+        return "another window of the same application is in front (window \(front))"
+    }
+    if focused != row.id {
+        return "the application's focused window is \(windowIDDescription(focused))"
+    }
+    let element = focusedAXElementWindowID(for: row.pid, rows: rows)
+    if element != row.id {
+        return "the focused control belongs to \(windowIDDescription(element))"
+    }
+    return "focus moved while the window was being checked"
+}
+
+private func windowIDDescription(_ id: CGWindowID?) -> String {
+    guard let id else { return "no window this scan can attribute" }
+    return "window \(id)"
+}
+
+/**
+ * A leased window has to contain the point, or the lease meant nothing.
+ *
+ * `assertInputTarget` proves which window keyboard input reaches. It says nothing about where a
+ * pointer event lands, and nothing did: QA leased a window, asked for a click at 5,5 — a corner of
+ * the desktop outside every window — and the click was sent, with `Done 1/1`. The fence proved the
+ * wrong fact, and the caller was told the right one had been proved.
+ *
+ * Clicking already requires a lease, so input in this helper always belongs to a window by
+ * construction. Requiring the point to be in that window is the other half of the same rule.
+ *
+ * One pixel of slack on each edge, because a window's own border is part of it and a coordinate
+ * read off a screenshot can land exactly on it.
+ */
+private func requirePointInWindow(_ point: CGPoint, _ row: WindowRow, _ what: String) throws {
+    guard row.bounds.insetBy(dx: -1, dy: -1).contains(point) else {
+        throw fail(
+            "OUTSIDE_TARGET_WINDOW",
+            "\(what) at \(Int(point.x)),\(Int(point.y)) is outside window \(row.id), which this " +
+                "batch is leased to (\(Int(row.bounds.minX)),\(Int(row.bounds.minY)) " +
+                "\(Int(row.bounds.width))x\(Int(row.bounds.height))). No input was sent. Lease the " +
+                "window you meant, or take a screenshot of it and use coordinates from that image."
+        )
+    }
+}
+
 private func assertInputTarget(_ id: CGWindowID) throws -> WindowRow {
     guard let row = windowRow(id), row.onScreen else {
         throw fail("INPUT_TARGET_LOST", "target window \(id) no longer exists on screen; no input was sent")
     }
     guard inputTargetMatches(row) else {
-        throw fail("INPUT_TARGET_LOST", "window \(id) is no longer the exact active input target; no input was sent")
+        throw fail(
+            "INPUT_TARGET_LOST",
+            "window \(id) is no longer the exact active input target (\(inputTargetRefusal(row))); no input was sent"
+        )
     }
     return row
 }
@@ -485,7 +834,38 @@ private func matchingAXWindow(_ row: WindowRow, deadline suppliedDeadline: TimeI
         guard ProcessInfo.processInfo.systemUptime < deadline else {
             throw fail("UIA_TIMEOUT", "exact accessibility window matching exceeded its bounded native deadline")
         }
-        if axWindowNumber(window) == row.id { return window }
+        guard axWindowNumber(window) == row.id else { continue }
+        // An id match is normally conclusive, and geometry is the second opinion when it is not.
+        //
+        // This was written on a wrong diagnosis and is kept on a right one. The report it came
+        // from said Chrome hands the transient panel over its omnibox the same AXWindowNumber as
+        // the window beneath, so asking about the panel returned the main window's tree. The
+        // author of that report then measured again and corrected themselves: the panel has its
+        // own accessibility window, and the wrong answer came from the request naming the window
+        // under a key the helper ignores — refused now, at the top of `handle`.
+        //
+        // What remains true without that story: an accessibility window carrying this row's id
+        // while describing a rectangle nothing like it is not this row's window, and returning
+        // its tree would be answering about something else.
+        //
+        // On macOS 27 this branch is unreachable, and that is measured rather than assumed:
+        // `AXWindowNumber` is not an offered attribute there at all — it is absent from the 28 a
+        // Chrome window carries, and reading it directly returns kAXErrorAttributeUnsupported
+        // (-25205). Across 26 windows of 11 processes, not one matched by id; every match went
+        // through geometry. The guard stays for whatever version or application does offer the
+        // attribute, but nothing here can exercise it, and the cost of it never firing is the
+        // ambiguity handled below.
+        guard let bounds = axBounds(window), !convincinglyMatchesWindow(bounds, row.bounds) else {
+            return window
+        }
+        throw fail(
+            "UIA_NO_OWN_WINDOW",
+            "window \(row.id) has no accessibility window of its own — the one carrying its id " +
+                "describes a different window (\(Int(bounds.width))x\(Int(bounds.height)) against " +
+                "\(Int(row.bounds.width))x\(Int(row.bounds.height))). Transient panels an " +
+                "application draws over its own window behave this way; ask about the window " +
+                "underneath instead."
+        )
     }
     var geometryCandidates: [(element: AXUIElement, distance: CGFloat)] = []
     for window in windows {
@@ -497,10 +877,75 @@ private func matchingAXWindow(_ row: WindowRow, deadline suppliedDeadline: TimeI
     }
     geometryCandidates.sort { $0.distance < $1.distance }
     guard let winner = geometryCandidates.first else {
+        /*
+         * Geometry is the fallback, and a window in motion has none that agrees.
+         *
+         * The row was scanned a moment ago and the accessibility bounds are being read now; a
+         * window dragged between the two matches nothing, because the two rectangles describe it
+         * at different instants. QA reached this by capturing a window while moving it and got
+         * "no accessibility window convincingly matches", which reads as a window that has no
+         * accessibility representation at all — and sends someone to check a permission that was
+         * never the problem.
+         *
+         * So look again with the bounds it has now. A window that has come to rest matches on the
+         * second read and the caller never learns there was a race. One still moving is told
+         * that, which is a different instruction from the one above and the only actionable one.
+         */
+        if let fresh = windowRow(row.id), fresh.bounds != row.bounds {
+            for window in windows {
+                guard ProcessInfo.processInfo.systemUptime < deadline else {
+                    throw fail("UIA_TIMEOUT", "accessibility window matching exceeded its bounded native deadline")
+                }
+                guard let bounds = axBounds(window), convincinglyMatchesWindow(bounds, fresh.bounds) else { continue }
+                return window
+            }
+            throw fail(
+                "WINDOW_MOVING",
+                "window \(row.id) moved while its accessibility tree was being read — from " +
+                    "\(Int(row.bounds.minX)),\(Int(row.bounds.minY)) to " +
+                    "\(Int(fresh.bounds.minX)),\(Int(fresh.bounds.minY)). Nothing was read. Let it " +
+                    "come to rest and ask again."
+            )
+        }
         throw fail("UIA_FAILED", "no accessibility window convincingly matches window \(row.id)")
     }
     if geometryCandidates.count > 1, geometryCandidates[1].distance - winner.distance < 32 {
-        throw fail("UIA_FAILED", "multiple accessibility windows ambiguously match window \(row.id)")
+        /*
+         * Geometry alone cannot separate two windows of one application at the same place, and on
+         * macOS 27 geometry is all there is: `AXWindowNumber` is not merely nil there, it is not an
+         * offered attribute at all — reading it returns kAXErrorAttributeUnsupported (-25205), and a
+         * measurement across 26 windows of 11 processes matched exactly none of them by id. So the
+         * exact branch above never runs, and two Finder windows of identical size at identical
+         * coordinates made a QA run's drag impossible until a window was moved by hand.
+         *
+         * The title is already in the row and was going unused. It does not always separate them —
+         * one of the pairs on that desktop shared its title too — but when it does, it costs one
+         * attribute read and turns an impossible request into an ordinary one.
+         */
+        let titled = geometryCandidates.filter {
+            titlesAgree(axString($0.element, kAXTitleAttribute as CFString), row.title)
+        }
+        if titled.count == 1 { return titled[0].element }
+        // Still ambiguous. Name the candidates: "ambiguous" with nothing else leaves the caller
+        // with no move to make, and the one move that works — close or move one of them — needs
+        // to know which ones they are.
+        let described = geometryCandidates.prefix(4).map { candidate -> String in
+            let title = axString(candidate.element, kAXTitleAttribute as CFString) ?? ""
+            let bounds = axBounds(candidate.element)
+            let size = bounds.map { "\(Int($0.width))x\(Int($0.height)) at \(Int($0.minX)),\(Int($0.minY))" } ?? "no bounds"
+            return title.isEmpty ? "an untitled window \(size)" : "\"\(title)\" \(size)"
+        }.joined(separator: "; ")
+        throw fail(
+            // Its own code, because the caller's next move differs. `UIA_FAILED` also means "there
+            // is no accessibility window here at all", and a QA run measured `focusable` reporting
+            // a save dialog with no accessibility representation as "ambiguous" — telling someone to
+            // move one of two windows when there was only ever one.
+            "UIA_AMBIGUOUS_WINDOW",
+            "window \(row.id) cannot be told apart from another window of the same application: " +
+                "\(described). Nothing was done. Nothing here can address them apart either — a focus " +
+                "would meet the same ambiguity — so move or close one of them from the application " +
+                "itself, then ask again."
+        )
     }
     return winner.element
 }
@@ -548,12 +993,21 @@ private var nextSnapshotID = 1
 private var snapshots: [Int: UISnapshot] = [:]
 private var snapshotOrder: [Int] = []
 
+/// One helper serves every chat, so this cap is shared across a whole swarm: with sixteen,
+/// thirteen workers taking turns evicted each other's newest snapshot before its owner could
+/// act on a ref from it — forty `STALE_UI_SNAPSHOT` refusals in one run on 2026-09-01. The
+/// Windows helper was raised to 96 for that measured failure the same day; this side kept the
+/// sixteen that was measured as broken, which is a difference in the number and not in the
+/// reasoning. A snapshot holds AX element handles, not screenshots, so keeping a few per
+/// worker is cheap.
+private let maxUISnapshots = 96
+
 private func rememberSnapshot(window: CGWindowID, windowBounds: CGRect, elements: [String: AXUIElement]) -> Int {
     let id = nextSnapshotID
     nextSnapshotID += 1
     snapshots[id] = UISnapshot(window: window, windowBounds: windowBounds, elements: elements)
     snapshotOrder.append(id)
-    while snapshotOrder.count > 16 {
+    while snapshotOrder.count > maxUISnapshots {
         let removed = snapshotOrder.removeFirst()
         snapshots.removeValue(forKey: removed)
     }
@@ -582,7 +1036,7 @@ private func findUI(
     } else if let foreground = foregroundWindowID(), let found = windowRow(foreground) {
         row = found
     } else {
-        throw fail("WINDOW_NOT_FOUND", "no matching visible window is available")
+        throw fail("WINDOW_NOT_FOUND", "no window is in the foreground to read")
     }
     let root = try matchingAXWindow(row, deadline: deadline)
     let query = string(request["query"]).lowercased()
@@ -642,15 +1096,23 @@ private func mouseButton(_ name: String) -> CGMouseButton {
     switch name.lowercased() {
     case "right": return .right
     case "middle", "wheel": return .center
+    // Buttons 3 and 4 are the conventional back/forward side buttons. AppKit and every
+    // browser read them from the button number on an other-mouse event, so they are posted
+    // exactly like the middle button with a different number — not as synthetic shortcuts,
+    // which would go to whatever happens to be focused rather than to the pointer's window.
+    case "back": return CGMouseButton(rawValue: 3) ?? .center
+    case "forward": return CGMouseButton(rawValue: 4) ?? .center
     default: return .left
     }
 }
 
 private func mouseTypes(_ button: CGMouseButton) -> (CGEventType, CGEventType, CGEventType) {
     switch button {
+    case .left: return (.leftMouseDown, .leftMouseUp, .leftMouseDragged)
     case .right: return (.rightMouseDown, .rightMouseUp, .rightMouseDragged)
-    case .center: return (.otherMouseDown, .otherMouseUp, .otherMouseDragged)
-    default: return (.leftMouseDown, .leftMouseUp, .leftMouseDragged)
+    // The middle button and both side buttons are all other-mouse events, told apart only
+    // by the button number carried on the event itself.
+    default: return (.otherMouseDown, .otherMouseUp, .otherMouseDragged)
     }
 }
 
@@ -662,9 +1124,37 @@ private func postMouse(_ type: CGEventType, point: CGPoint, button: CGMouseButto
     event.post(tap: .cghidEventTap)
 }
 
-private func movePointer(_ point: CGPoint) throws {
+/**
+ * Moves the pointer, and — when asked — checks that it went.
+ *
+ * Posting is not moving. A run asked for a move using coordinates read off a frame that had since
+ * gone stale, was told `Done 1/1 via sendinput: move`, and the pointer had not left where it
+ * started; the same move through a fresh frame worked. The answer described the event rather than
+ * the desktop, which is the failure this whole layer exists to avoid.
+ *
+ * Only the explicit `move` action verifies. A drag is a hundred interpolated steps of a pixel or
+ * two, and reading the position back after each would cost more than it proves — the drag already
+ * judges itself by what it moved.
+ */
+private func movePointer(_ point: CGPoint, verify: Bool = false) throws {
     try requirePointOnActiveDisplay(point)
+    let before = CGEvent(source: nil)?.location ?? .zero
     try postMouse(.mouseMoved, point: point, button: .left)
+    // A move to where the pointer already is has nothing to prove.
+    guard verify, hypot(point.x - before.x, point.y - before.y) > 1 else { return }
+    let deadline = ProcessInfo.processInfo.systemUptime + 0.25
+    while ProcessInfo.processInfo.systemUptime < deadline {
+        let now = CGEvent(source: nil)?.location ?? .zero
+        if hypot(point.x - now.x, point.y - now.y) <= 2 { return }
+        usleep(5_000)
+    }
+    let ended = CGEvent(source: nil)?.location ?? .zero
+    throw fail(
+        "POINTER_DID_NOT_MOVE",
+        "asked for \(Int(point.x)),\(Int(point.y)); the pointer is at \(Int(ended.x)),\(Int(ended.y)) " +
+            "and did not move. Nothing else in this batch ran. Take a fresh screenshot and use " +
+            "coordinates from it — a frame from earlier can describe a desktop that has changed."
+    )
 }
 
 private func click(_ point: CGPoint, button: CGMouseButton, count: Int, targetWindow: CGWindowID? = nil) throws {
@@ -690,28 +1180,148 @@ private func drag(
     _ xs: [NSNumber],
     _ ys: [NSNumber],
     button: CGMouseButton,
-    targetWindow: CGWindowID? = nil
+    targetWindow: CGWindowID? = nil,
+    expectedDisplays: [CGRect]? = nil
 ) throws {
     guard xs.count == ys.count, xs.count >= 2 else { throw fail("BAD_ACTION", "drag needs at least two points") }
     let points = zip(xs, ys).map { CGPoint(x: $0.0.doubleValue, y: $0.1.doubleValue) }
-    let displays = try activeDisplayRects()
+
+    // Window identity and screen topology are independent leases. A screen-bound frame can
+    // still carry an explicit targetWindow, so never choose one fence at the expense of the
+    // other: re-prove every supplied authority before every physical drag event.
+    let displays: [CGRect]
+    if let expectedDisplays {
+        let currentDisplays = try activeDisplayRects()
+        guard sameDisplayTopology(expectedDisplays, currentDisplays) else {
+            throw fail("STALE_FRAME", "active display topology changed before the drag")
+        }
+        displays = expectedDisplays
+    } else {
+        displays = try activeDisplayRects()
+    }
     for point in points { try requirePointOnActiveDisplay(point, displays: displays) }
+
+    func assertDragTarget() throws {
+        if let targetWindow { _ = try assertInputTarget(targetWindow) }
+        if let expectedDisplays {
+            let currentDisplays = try activeDisplayRects()
+            guard sameDisplayTopology(expectedDisplays, currentDisplays) else {
+                throw fail("STALE_FRAME", "active display topology changed during the drag")
+            }
+        }
+    }
+
     let (down, up, dragged) = mouseTypes(button)
-    if let targetWindow { _ = try assertInputTarget(targetWindow) }
+    try assertDragTarget()
     try postMouse(down, point: points[0], button: button)
     var current = points[0]
     do {
-        for point in points.dropFirst() {
-            if let targetWindow { _ = try assertInputTarget(targetWindow) }
-            try postMouse(dragged, point: point, button: button)
+        // Hold before moving. AppKit decides whether a press begins a drag session or is just a
+        // click, and a press followed immediately by movement reads as the latter. QA dragged a
+        // file in Finder three times, was told "Done" three times, and the file never moved.
+        usleep(dragPressHoldMicroseconds)
+
+        // Interpolate. The caller gives waypoints, not a trajectory, and two of them are a
+        // teleport: nothing crosses the drag threshold, so no drag session ever starts and no
+        // destination is ever hovered. Real pointers move continuously, and the machinery that
+        // decides what a drag means is watching for exactly that.
+        //
+        // The budget is for the whole path, not per hop. Per hop, a 64-waypoint drag — which the
+        // schema permits — could post 15,000 events and spend two minutes inside a 15-second
+        // parent deadline, and being killed there leaves the button logically held down: the
+        // catch below that releases it never runs, because the process is gone. Sized for the
+        // whole path, a drag costs the same bounded time however many waypoints it names.
+        let stepsPerSegment = dragStepBudget(points)
+        for (index, point) in points.dropFirst().enumerated() {
+            for step in dragSteps(from: current, to: point, steps: stepsPerSegment[index]) {
+                try assertDragTarget()
+                try postMouse(dragged, point: step, button: button)
+                usleep(dragStepMicroseconds)
+            }
             current = point
-            usleep(12_000)
         }
-        if let targetWindow { _ = try assertInputTarget(targetWindow) }
+
+        // Dwell on the destination before releasing, so whatever is under the pointer has a
+        // chance to register the hover and accept the drop.
+        try assertDragTarget()
+        try postMouse(dragged, point: points[points.count - 1], button: button)
+        usleep(dragDropDwellMicroseconds)
+
+        try assertDragTarget()
         try postMouse(up, point: points[points.count - 1], button: button)
     } catch {
+        // A best-effort mouse-up is cleanup, not authorization to continue the drag.
         try? postMouse(up, point: current, button: button)
         throw error
+    }
+}
+
+/**
+ * How a drag is paced, in microseconds.
+ *
+ * Measured, not assumed. An ablation in Finder — one variable changed per run, three runs each —
+ * says only one of these is load-bearing:
+ *
+ *     control                       3/3 moved
+ *     no press hold                 3/3 moved
+ *     no drop dwell                 3/3 moved
+ *     no interpolation              0/3 moved
+ *     interpolation only            3/3 moved
+ *
+ * Interpolation is necessary and, for Finder, sufficient: two waypoints are a teleport, nothing
+ * crosses the drag threshold, and no drag session begins. The hold and the dwell are kept
+ * anyway — they cost 230ms and the measurement covers one application, while a press that
+ * settles and a destination that is hovered is what every other one is documented to want. They
+ * are insurance, and the comment should not pretend they were proven.
+ *
+ * Two things the same run established about judging a drag: the helper answers ok whether or not
+ * anything moved, so the return value is not evidence; and the filesystem takes 0-11ms to show
+ * the move, so a check with no settle produces false negatives.
+ */
+private let dragPressHoldMicroseconds: UInt32 = 90_000
+private let dragStepMicroseconds: UInt32 = 8_000
+private let dragDropDwellMicroseconds: UInt32 = 140_000
+/** Longest jump between two posted drag events; beyond this the motion stops looking like motion. */
+private let dragMaxStepDistance: CGFloat = 8
+/**
+ * Most move events one drag may post, whatever its shape.
+ *
+ * At dragStepMicroseconds each, this bounds the moving part of any drag to about 1.4 seconds —
+ * comfortably inside the parent's deadline for a whole batch of actions, which is the thing that
+ * must never be exceeded: the parent kills the helper on timeout, and a killed helper never runs
+ * the release that would let go of the button.
+ */
+private let dragMaxTotalSteps = 180
+
+/**
+ * How many events each hop of the path gets, sharing one budget for the whole journey.
+ *
+ * Longer paths take longer strides rather than more time. A drag is not made more convincing by
+ * being slower, and a budget spent per hop is not a budget.
+ */
+private func dragStepBudget(_ points: [CGPoint]) -> [Int] {
+    let hops = zip(points, points.dropFirst()).map { start, end -> CGFloat in
+        let dx = end.x - start.x
+        let dy = end.y - start.y
+        return (dx * dx + dy * dy).squareRoot()
+    }
+    let total = hops.reduce(0, +)
+    let wanted = hops.map { max(1, Int(($0 / dragMaxStepDistance).rounded(.up))) }
+    let wantedTotal = wanted.reduce(0, +)
+    guard wantedTotal > dragMaxTotalSteps, total > 0 else { return wanted }
+    // Over budget: give each hop its share of the cap, and never fewer than one event, so a
+    // short hop in a long path still happens.
+    return hops.map { max(1, Int((CGFloat(dragMaxTotalSteps) * $0 / total).rounded())) }
+}
+
+/** The points to post between two waypoints so the pointer travels rather than teleports. */
+private func dragSteps(from start: CGPoint, to end: CGPoint, steps: Int) -> [CGPoint] {
+    let dx = end.x - start.x
+    let dy = end.y - start.y
+    let count = max(1, steps)
+    return (1...count).map { index in
+        let progress = CGFloat(index) / CGFloat(count)
+        return CGPoint(x: start.x + dx * progress, y: start.y + dy * progress)
     }
 }
 
@@ -745,10 +1355,17 @@ private let modifierFlags: [String: CGEventFlags] = [
 
 private func normalizedKeyName(_ name: String) -> String {
     switch name.lowercased() {
-    case "cmd", "meta": return "command"
+    case "cmd", "meta", "super", "win": return "command"
     case "alt": return "option"
     case "ctrl": return "control"
     case "esc": return "escape"
+    // The DOM names for the arrow keys. A model that has learned browser key vocabulary
+    // emits these, and refusing them for the sake of four shorter synonyms is a needless
+    // BAD_KEY on the single most common navigation keys there are.
+    case "arrowleft": return "left"
+    case "arrowright": return "right"
+    case "arrowup": return "up"
+    case "arrowdown": return "down"
     default: return name.lowercased()
     }
 }
@@ -773,61 +1390,160 @@ private struct ResolvedKey {
     let requiredFlags: CGEventFlags
 }
 
+/** The active layout, copied out of the input source so it can be used off the main queue. */
 private struct KeyboardLayoutSnapshot {
     let data: Data
     let kbdType: UInt32
 }
 
-private final class KeyboardLayoutBox {
-    var snapshot: KeyboardLayoutSnapshot?
+/** Carries a main-queue result back to the requesting thread. */
+private final class MainQueueBox<Value> {
+    var value: Value?
+}
+
+/** How long a request will wait for the main queue before refusing rather than hanging. */
+private let mainQueueTimeout: TimeInterval = 2.0
+
+/**
+ * Runs a main-queue-affine platform call and returns its result, or nil if the main queue
+ * could not service it in time.
+ *
+ * AppKit, HIToolbox and Text Services all assert on the main queue, and a violation is not an
+ * error return: `dispatch_assert_queue` fails and raises EXC_BREAKPOINT, taking the whole host
+ * process down below anything Swift or JS above it can catch. Node enters this addon on a
+ * worker thread, so the hop belongs at this boundary rather than in every caller.
+ *
+ * Deliberately not `DispatchQueue.main.sync`: that deadlocks when this already is the main
+ * thread, and waits forever when the main thread is busy, trading a crash for a hang. Running
+ * inline covers the first; the bounded wait covers the second by surfacing an ordinary refusal.
+ */
+private func onMainQueue<Value>(_ work: @escaping () -> Value?) -> Value? {
+    if Thread.isMainThread { return work() }
+    let box = MainQueueBox<Value>()
+    let done = DispatchSemaphore(value: 0)
+    DispatchQueue.main.async {
+        box.value = work()
+        done.signal()
+    }
+    guard done.wait(timeout: .now() + mainQueueTimeout) == .success else { return nil }
+    return box.value
 }
 
 /**
- * Reads the active key layout on the main queue.
+ * Reads the active Unicode key layout, on the main queue.
  *
- * Text Services input-source lookups are main-queue-affine. Reached from anywhere else macOS
- * does not return an error: `dispatch_assert_queue` fails and raises EXC_BREAKPOINT, taking
- * the host process with it, below anything Swift or JS can catch. The addon is entered on a
- * Node worker thread, so the hop belongs here rather than in every caller.
+ * Text Services input-source lookups are main-queue-affine. Reached from anywhere else,
+ * macOS does not return an error: `dispatch_assert_queue` fails and raises EXC_BREAKPOINT,
+ * which takes the whole host process down. Nothing above this — not Swift, not the addon,
+ * not any JS layer — can catch that. Node enters this addon on a worker thread, so the hop
+ * has to live here; the public entry points stay safe to call from an arbitrary thread.
  *
- * Not `DispatchQueue.main.sync`: that deadlocks when already on main and waits forever when
- * the main thread is busy, trading the crash for a hang. Running inline covers the first, the
- * bounded wait covers the second. The layout bytes are copied because they belong to the input
- * source, which is released when this returns; UCKeyTranslate then reads the copy off-main.
+ * Deliberately not `DispatchQueue.main.sync`: that deadlocks if this is already the main
+ * thread, and it waits forever if the main thread is busy or blocked, trading a crash for a
+ * hang. Running inline when already on main covers the first, and the bounded wait covers
+ * the second by surfacing an ordinary refusal instead.
+ *
+ * Only the input-source read is marshalled. UCKeyTranslate is a pure function over the
+ * layout bytes, so the 128-keycode search stays off the main queue and off the UI thread.
  */
 private func currentKeyboardLayout() -> KeyboardLayoutSnapshot? {
-    func read() -> KeyboardLayoutSnapshot? {
+    onMainQueue {
         guard let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue() else { return nil }
         guard let rawData = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else { return nil }
         let data = unsafeBitCast(rawData, to: CFData.self)
         guard let bytes = CFDataGetBytePtr(data) else { return nil }
+        // Copied on purpose: those bytes belong to the input source, which is released as
+        // soon as this returns. The keycode search below then reads our own copy, off-main.
         return KeyboardLayoutSnapshot(
             data: Data(bytes: bytes, count: CFDataGetLength(data)),
             kbdType: UInt32(LMGetKbdType())
         )
     }
-    if Thread.isMainThread { return read() }
-    let box = KeyboardLayoutBox()
-    let done = DispatchSemaphore(value: 0)
-    DispatchQueue.main.async {
-        box.snapshot = read()
-        done.signal()
+}
+
+/** The live pointer, as pixels plus the offset from its image origin to the point it addresses. */
+private struct PointerImage {
+    let image: CGImage
+    let hotSpot: CGPoint
+    let size: CGSize
+}
+
+/**
+ * The pointer as it looks right now, read on the main queue because NSCursor is AppKit.
+ *
+ * Returns nil rather than a stand-in when the system will not describe its cursor: an invented
+ * pointer in a screenshot is worse than none, because a coordinate would be read off it.
+ */
+private func currentPointerImage() -> PointerImage? {
+    onMainQueue {
+        guard let cursor = NSCursor.currentSystem else { return nil }
+        let image = cursor.image
+        guard image.size.width > 0, image.size.height > 0 else { return nil }
+        var rect = CGRect(origin: .zero, size: image.size)
+        guard let cgImage = image.cgImage(forProposedRect: &rect, context: nil, hints: nil) else { return nil }
+        return PointerImage(image: cgImage, hotSpot: cursor.hotSpot, size: image.size)
     }
-    guard done.wait(timeout: .now() + 2.0) == .success else { return nil }
-    return box.snapshot
+}
+
+/**
+ * Draws the pointer into a window capture.
+ *
+ * `SCStreamConfiguration.showsCursor` is set on every capture in this file, but it can only
+ * act where the pointer exists in the captured content — and a desktop-independent window
+ * filter captures the window detached from the desktop, while the pointer is a display
+ * compositing layer. Display capture gets the pointer from the system; window capture, which
+ * is what an ordinary `observe` on a window uses, never could.
+ *
+ * Drawn at the hotspot, which is the pixel the pointer addresses: an I-beam or a resize arrow
+ * is centred, not top-left, and drawing at the image origin would put the tip several pixels
+ * off exactly when a coordinate is being read off the picture.
+ *
+ * Returns why it did nothing when it does nothing. Every reason here is silent in the picture
+ * — an absent pointer looks the same whether the system would not describe one, the pointer
+ * was outside the window, or the buffer failed — and "no pointer in the screenshot" has
+ * already cost one round of guessing at which. The caller puts this in the response.
+ */
+private func drawingPointer(on image: CGImage, region: CGRect) -> (CGImage, String) {
+    guard let pointer = currentPointerImage() else { return (image, "unavailable") }
+    let location = CGEvent(source: nil)?.location ?? .zero
+    guard region.width > 0, region.height > 0, region.contains(location) else {
+        return (image, "outside_region")
+    }
+
+    let scale = CGFloat(image.width) / region.width
+    let width = pointer.size.width * scale
+    let height = pointer.size.height * scale
+    // Global screen coordinates run top-down; a bitmap context runs bottom-up.
+    let x = (location.x - pointer.hotSpot.x - region.minX) * scale
+    let top = (location.y - pointer.hotSpot.y - region.minY) * scale
+    let y = CGFloat(image.height) - top - height
+
+    guard let context = CGContext(
+        data: nil,
+        width: image.width,
+        height: image.height,
+        bitsPerComponent: 8,
+        bytesPerRow: image.width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ) else { return (image, "buffer_unavailable") }
+    context.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
+    context.draw(pointer.image, in: CGRect(x: x, y: y, width: width, height: height))
+    guard let composited = context.makeImage() else { return (image, "buffer_unavailable") }
+    return (composited, "drawn")
 }
 
 private func currentLayoutKey(for logicalName: String, in snapshot: KeyboardLayoutSnapshot) -> ResolvedKey? {
+    let modifierCandidates: [(carbon: UInt32, event: CGEventFlags)] = [
+        (0, []),
+        (UInt32(shiftKey >> 8), .maskShift),
+        (UInt32(optionKey >> 8), .maskAlternate),
+        (UInt32((shiftKey | optionKey) >> 8), [.maskShift, .maskAlternate])
+    ]
+
     return snapshot.data.withUnsafeBytes { raw -> ResolvedKey? in
         guard let base = raw.baseAddress else { return nil }
         let layout = base.assumingMemoryBound(to: UCKeyboardLayout.self)
-        let modifierCandidates: [(carbon: UInt32, event: CGEventFlags)] = [
-            (0, []),
-            (UInt32(shiftKey >> 8), .maskShift),
-            (UInt32(optionKey >> 8), .maskAlternate),
-            (UInt32((shiftKey | optionKey) >> 8), [.maskShift, .maskAlternate])
-        ]
-
         for candidate in modifierCandidates {
             for rawCode in 0..<128 {
                 var deadKeyState: UInt32 = 0
@@ -870,17 +1586,34 @@ private func resolveKey(_ name: String, in snapshot: KeyboardLayoutSnapshot?) th
         }
         return resolved
     }
-    guard let code = keyCodes[name] else { throw fail("BAD_KEY", "unknown key \(name)") }
+    // Name what is accepted, not just what was refused. The Windows helper's own BAD_KEY has
+    // said this since 2026-09-04; a QA run met the terser macOS wording and had nothing to
+    // correct itself from, which is the whole job of this refusal. The list is written from
+    // `keyCodes` and `normalizedKeyName` above rather than copied from Windows: this helper
+    // takes the macOS modifier names, and forwarddelete/help/volume keys are its own.
+    guard let code = keyCodes[name] else {
+        throw fail(
+            "BAD_KEY",
+            "unknown key \(name). Use one character, or a key name: return, enter, tab, space, "
+                + "escape, backspace, delete, forwarddelete, home, end, pageup, pagedown, up, down, "
+                + "left, right, f1-f20, help, volumeup, volumedown, mute, capslock, or a modifier "
+                + "command, option, control, shift"
+        )
+    }
     return ResolvedKey(code: code, requiredFlags: [])
 }
 
 private func pressKeys(_ names: [String], targetWindow: CGWindowID? = nil) throws {
     let normalized = names.map(normalizedKeyName)
-    // One snapshot for the whole chord, taken before any window authority is resolved: the
-    // existing revalidations still sit immediately before the events they guard.
+    // One snapshot for the whole chord, taken before any window authority is resolved: every
+    // key resolves against the same input source, and the main queue is entered at most once
+    // per request. Named keys never need it, so an ordinary shortcut does not hop at all.
     let layout = normalized.contains { $0.count == 1 } ? currentKeyboardLayout() : nil
     let resolved = try normalized.map { try resolveKey($0, in: layout) }
     let globalShortcut = isSystemShortcut(normalized)
+    guard targetWindow != nil || globalShortcut else {
+        throw fail("INPUT_TARGET_REQUIRED", "application keyboard input requires targetWindow")
+    }
     guard let source = CGEventSource(stateID: .privateState) else {
         throw fail("INPUT_FAILED", "could not create a keyboard event source")
     }
@@ -933,37 +1666,82 @@ private func pressKeys(_ names: [String], targetWindow: CGWindowID? = nil) throw
     }
 }
 
+/**
+ * Types text, sending newlines as the Return key rather than as text.
+ *
+ * A newline inside a unicode string is where this used to lose whole sentences. The text was cut
+ * into chunks of at most 32 UTF-16 units and each chunk handed to `keyboardSetUnicodeString`; when
+ * a chunk happened to *begin* with U+000A, macOS delivered the newline — late, on the next event —
+ * and discarded the rest of that chunk. Up to 31 characters vanished, and the helper answered
+ * `ok: true` with `routes: ["sendinput"]`.
+ *
+ * That made it depend on the offset rather than on the text: the same words arrived or did not
+ * according to where a newline happened to land relative to a multiple of 32. It was found by
+ * prediction — cut the same sentence at index 32 and at index 20, and only the first loses its
+ * tail — which is why it survived so long: retrying the same string reproduces nothing.
+ *
+ * A newline is a keystroke, not a character, and sending it as one is also what a real keyboard
+ * does. Editors that treat Return specially — a search field that submits, a chat box that sends —
+ * now see what they expect instead of a control character in a paste.
+ */
 private func typeText(_ text: String, targetWindow: CGWindowID? = nil) throws {
     guard let source = CGEventSource(stateID: .privateState) else {
         throw fail("INPUT_FAILED", "could not create a keyboard event source")
     }
-    let units = Array(text.utf16)
-    var cursor = 0
-    while cursor < units.count {
-        var end = min(units.count, cursor + 32)
-        if end < units.count, end > cursor,
-           units[end - 1] >= 0xD800, units[end - 1] <= 0xDBFF,
-           units[end] >= 0xDC00, units[end] <= 0xDFFF {
-            end -= 1
-        }
-        let chunk = Array(units[cursor..<end])
-        guard let down = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
-              let up = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) else {
-            throw fail("INPUT_FAILED", "could not create a text input event")
-        }
-        chunk.withUnsafeBufferPointer { pointer in
-            down.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: pointer.baseAddress!)
-            up.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: pointer.baseAddress!)
-        }
+
+    func deliver(_ event: CGEvent) throws {
         if let targetWindow {
             let target = try assertInputTarget(targetWindow)
-            down.postToPid(target.pid)
-            up.postToPid(target.pid)
+            event.postToPid(target.pid)
         } else {
-            down.post(tap: .cghidEventTap)
-            up.post(tap: .cghidEventTap)
+            event.post(tap: .cghidEventTap)
         }
-        cursor = end
+    }
+
+    func sendRun(_ units: [UInt16]) throws {
+        var cursor = 0
+        while cursor < units.count {
+            var end = min(units.count, cursor + 32)
+            // Never split a surrogate pair across two events: half of one is not a character.
+            if end < units.count, end > cursor,
+               units[end - 1] >= 0xD800, units[end - 1] <= 0xDBFF,
+               units[end] >= 0xDC00, units[end] <= 0xDFFF {
+                end -= 1
+            }
+            let chunk = Array(units[cursor..<end])
+            guard let down = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
+                  let up = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) else {
+                throw fail("INPUT_FAILED", "could not create a text input event")
+            }
+            chunk.withUnsafeBufferPointer { pointer in
+                down.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: pointer.baseAddress!)
+                up.keyboardSetUnicodeString(stringLength: chunk.count, unicodeString: pointer.baseAddress!)
+            }
+            try deliver(down)
+            try deliver(up)
+            cursor = end
+        }
+    }
+
+    func sendReturn() throws {
+        guard let down = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: true),
+              let up = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: false) else {
+            throw fail("INPUT_FAILED", "could not create a newline event")
+        }
+        try deliver(down)
+        try deliver(up)
+    }
+
+    // Every line ending becomes the same thing, so a document written on one platform types the
+    // same as one written on another.
+    let normalized = text
+        .replacingOccurrences(of: "\r\n", with: "\n")
+        .replacingOccurrences(of: "\r", with: "\n")
+    let runs = normalized.components(separatedBy: "\n")
+    for (index, run) in runs.enumerated() {
+        if index > 0 { try sendReturn() }
+        let units = Array(run.utf16)
+        if !units.isEmpty { try sendRun(units) }
     }
 }
 
@@ -1000,24 +1778,43 @@ private func actUI(_ request: JSONObject) throws -> JSONObject {
             "the referenced accessibility control no longer belongs to snapshot window \(snapshot.window)"
         )
     }
-    // Mutation requires an explicitly readable true value. Missing, untyped or timed-out
-    // AXEnabled evidence is not permission to click through the uncertainty.
-    guard axBool(element, kAXEnabledAttribute as CFString, default: false) else {
+    let action = string(request["action"])
+    // What a control says about itself decides; silence defers to what it can do.
+    //
+    // An explicit AXEnabled=false always refuses: a control that says it is disabled is
+    // disabled, whatever else it reports. Absent, untyped or timed-out AXEnabled is not a
+    // refusal though — some genuinely interactive controls publish no such attribute at all,
+    // and TextEdit's document AXTextArea is one of them. For those, accessibility offers a
+    // second and more direct authority: whether AXValue can be written. A control whose value
+    // can be set is interactive by definition.
+    //
+    // That fallback was first allowed only for set_value, on the reasoning that silence should
+    // not license a click. QA then found the other half of the same defect: click_ref against
+    // that same editable TextArea was refused as disabled while a coordinate click focused it,
+    // typing worked, and set_value worked. Refusing there blocked legitimate ref-first work on
+    // a control already proven interactive by the very evidence being ignored. Silence alone
+    // still refuses — a control with no AXEnabled and no settable value gets nothing.
+    let enabled = axOptionalBool(element, kAXEnabledAttribute as CFString)
+    let permitted = enabled ?? axValueIsSettable(element)
+    guard permitted else {
         throw fail("UI_ACTION_DISABLED", "the referenced accessibility control is disabled")
     }
-    let action = string(request["action"])
     var route = "uia"
+    // Whether the control's own reported value actually moved, for the click branch only —
+    // nil where there is nothing comparable to say (an ordinary button, say), which is a
+    // different fact from "unchanged" and must not be reported as one.
+    var changed: Bool?
     if action == "set_value" {
-        var settable = DarwinBoolean(false)
-        guard AXUIElementIsAttributeSettable(element, kAXValueAttribute as CFString, &settable) == .success,
-              settable.boolValue,
+        guard axValueIsSettable(element),
               AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, string(request["value"]) as CFTypeRef) == .success else {
             throw fail("UI_ACTION_FAILED", "the control does not expose a settable value")
         }
     } else if action == "click" {
+        let beforeValue = axComparableValue(element)
         if AXUIElementPerformAction(element, kAXPressAction as CFString) != .success {
             guard try focusWindow(snapshot.window) else {
-                throw fail("FOCUS_FAILED", "snapshot window \(snapshot.window) could not be activated")
+                let why = windowRow(snapshot.window).map(inputTargetRefusal) ?? "the window is gone"
+                throw fail("FOCUS_FAILED", "snapshot window \(snapshot.window) could not be activated: \(why)")
             }
             guard let live = windowRow(snapshot.window),
                   live.bounds.integral == snapshot.windowBounds.integral else {
@@ -1038,11 +1835,27 @@ private func actUI(_ request: JSONObject) throws -> JSONObject {
                 targetWindow: snapshot.window
             )
             route = "sendinput"
+        } else {
+            /*
+             * `AXUIElementPerformAction` returning `.success` is the protocol saying the message
+             * was accepted, not that anything happened. QA measured the gap directly: pressing a
+             * System Settings toggle through AXPress returned success and the switch stayed
+             * exactly where it was; a coordinate click on the same spot moved it. This is the
+             * same shape as the scroll gesture that used to be judged by acknowledgement instead
+             * of by whether the page moved — so, the same fix: compare the control's own value
+             * before and after, and say so, rather than trust the API's verdict about itself.
+             */
+            let afterValue = axComparableValue(element)
+            if let beforeValue, let afterValue {
+                changed = !beforeValue.isEqual(afterValue)
+            }
         }
     } else {
         throw fail("BAD_ACTION", "unknown UI action \(action)")
     }
-    return ["runtimeKey": runtimeKey, "name": axName(element), "route": route]
+    var result: JSONObject = ["runtimeKey": runtimeKey, "name": axName(element), "route": route]
+    if let changed { result["changed"] = changed }
+    return result
 }
 
 private func validateFrame(_ frame: JSONObject) throws {
@@ -1055,11 +1868,9 @@ private func validateFrame(_ frame: JSONObject) throws {
         guard row.bounds.integral == expected.integral else {
             throw fail("STALE_FRAME", "target window \(windowID) moved or resized after the screenshot")
         }
-        guard try focusWindow(windowID) else { throw fail("FOCUS_FAILED", "window \(windowID) could not be activated") }
         guard let after = windowRow(windowID), after.bounds.integral == expected.integral else {
-            throw fail("STALE_FRAME", "target window \(windowID) changed geometry while it was activated")
+            throw fail("STALE_FRAME", "target window \(windowID) changed geometry during frame validation")
         }
-        _ = try assertFrameTarget(frame)
     } else {
         guard let expectedDisplays = displayTopology(frame["displays"]) else {
             throw fail("STALE_FRAME", "the screen frame has no exact display topology")
@@ -1243,7 +2054,7 @@ private func captureWindow(
     maxWidth: Int,
     content: SCShareableContent,
     expectedGeometry: CGRect
-) throws -> (CGImage, CGRect) {
+) throws -> (CGImage, CGRect, String) {
     guard #available(macOS 14.0, *) else {
         // Pre-14 direct window capture cannot disable the window shadow. Returning that
         // shadow-bearing bitmap against the shadow-free WindowServer frame would make every
@@ -1265,7 +2076,11 @@ private func captureWindow(
     configuration.ignoreShadowsSingleWindow = true
     let filter = SCContentFilter(desktopIndependentWindow: window)
     let image = try captureImage(filter: filter, configuration: configuration)
-    return (try resizedImage(image, width: width, height: height), region)
+    let resized = try resizedImage(image, width: width, height: height)
+    // showsCursor above cannot reach a desktop-independent filter, so the pointer is drawn
+    // here. Display capture keeps the system's own, which is why this is only done for windows.
+    let (drawn, pointerNote) = drawingPointer(on: resized, region: region)
+    return (drawn, region, pointerNote)
 }
 
 private func captureDisplay(_ display: SCDisplay, maxWidth: Int) throws -> (CGImage, CGRect) {
@@ -1358,6 +2173,7 @@ private func capture(_ request: JSONObject, forcedWindow: CGWindowID? = nil) thr
     let image: CGImage
     let region: CGRect
     let captureMode: String
+    let pointerNote: String
     var capturedWindowGeometry: CGRect?
     if let requestedWindow {
         guard let row = windowRow(requestedWindow) else {
@@ -1365,7 +2181,7 @@ private func capture(_ request: JSONObject, forcedWindow: CGWindowID? = nil) thr
         }
         capturedWindowGeometry = row.bounds
         do {
-            (image, region) = try captureWindow(
+            (image, region, pointerNote) = try captureWindow(
                 requestedWindow,
                 maxWidth: maxWidth,
                 content: content,
@@ -1388,6 +2204,7 @@ private func capture(_ request: JSONObject, forcedWindow: CGWindowID? = nil) thr
                 expectedDisplays: displayRects
             )
             captureMode = "screen_fallback"
+            pointerNote = "system"
         }
         guard let fresh = windowRow(requestedWindow), approximatelyEqual(fresh.bounds, row.bounds) else {
             throw fail("STALE_FRAME", "window \(requestedWindow) moved or resized while it was captured")
@@ -1401,6 +2218,7 @@ private func capture(_ request: JSONObject, forcedWindow: CGWindowID? = nil) thr
             expectedDisplays: displayRects
         )
         captureMode = "screen"
+        pointerNote = "system"
     } else if bool(request["full"]) {
         region = screen
         image = try captureComposite(
@@ -1410,12 +2228,18 @@ private func capture(_ request: JSONObject, forcedWindow: CGWindowID? = nil) thr
             expectedDisplays: displayRects
         )
         captureMode = "screen"
+        pointerNote = "system"
     } else {
         guard let display = content.displays.first(where: { $0.displayID == CGMainDisplayID() }) ?? content.displays.first else {
             throw fail("SCREEN_UNAVAILABLE", "ScreenCaptureKit reported no display")
         }
         (image, region) = try captureDisplay(display, maxWidth: maxWidth)
         captureMode = "screen"
+        pointerNote = "system"
+    }
+    let finalDisplayRects = try activeDisplayRects()
+    guard sameDisplayTopology(displayRects, finalDisplayRects) else {
+        throw fail("STALE_FRAME", "display topology changed while screenshot was captured")
     }
     guard sameDisplayTopology(displayRects, try activeDisplayRects()) else {
         throw fail("STALE_FRAME", "active display topology changed while screenshot was captured")
@@ -1425,9 +2249,10 @@ private func capture(_ request: JSONObject, forcedWindow: CGWindowID? = nil) thr
         "region": rectObject(region),
         "image": ["width": image.width, "height": image.height],
         "screen": rectObject(screen),
-        "displays": displayTopologyObject(displayRects),
+        "displays": displayTopologyObject(finalDisplayRects),
         "focused": requestedWindow == nil ? NSNull() : foregroundWindowID() == requestedWindow,
-        "captureMode": captureMode
+        "captureMode": captureMode,
+        "pointer": pointerNote
     ]
     if let capturedWindowGeometry {
         response["windowGeometry"] = rectObject(capturedWindowGeometry)
@@ -1437,6 +2262,84 @@ private func capture(_ request: JSONObject, forcedWindow: CGWindowID? = nil) thr
 
 private func handle(_ request: JSONObject) throws -> JSONObject {
     let operation = string(request["op"])
+    /*
+     * A window named under the wrong key is refused, not ignored.
+     *
+     * Every operation here reads `id`. A request carrying `window` instead had that key silently
+     * dropped, and the operation then fell back to the foreground window and answered about it
+     * with ok: true. A QA run spent a whole round on that: it asked `find_ui` about a small
+     * transient panel, got the main window's entire tree back, and reasonably concluded that
+     * window matching was broken. It was not — the question had never been asked.
+     *
+     * The silence costs more than a wrong answer would, because the answer looks right. A caller
+     * that clicks the elements it gets back clicks in a window it never named. And there are
+     * three ways to name a window across this protocol — `id` here, `window` inside an `act`
+     * action, `targetWindow` on an `act` request — so getting it wrong is ordinary rather than
+     * careless.
+     *
+     * `act` is exempt: it legitimately carries `targetWindow`, and its actions carry `window`.
+     */
+    if operation != "act", request["window"] != nil {
+        throw fail(
+            "BAD_REQUEST",
+            "this request names a window under `window`, but every operation reads it under `id`. " +
+                "Nothing was done. Send `id` — `window` belongs on an action inside `act`, and " +
+                "`targetWindow` on an `act` request."
+        )
+    }
+    /*
+     * An `act` request naming a key this protocol does not have is refused, not ignored.
+     *
+     * `window` above was fixed as its own case because a QA run happened to send that one key.
+     * The rule it revealed is general — an unrecognized field is silently dropped and the call
+     * still answers `ok: true` — and applying it to one key instead of as a rule meant the next
+     * one, whatever its name, would cost the same round again. It did: a later run sent
+     * `verification` (a real field, but one this helper has never implemented — that contract
+     * lives in the app layer, which turns it into ordinary `id`/`find_ui` calls before any of
+     * this runs) and a nonsense key, and both were accepted and quietly did nothing. A caller
+     * who believes an unreachable verification ran, because the call it made for it said `ok`,
+     * is worse off than one who is told plainly that it did not.
+     */
+    if operation == "act" {
+        let knownActKeys: Set<String> = ["op", "frame", "targetWindow", "actions"]
+        if let strayKey = request.keys.first(where: { !knownActKeys.contains($0) }) {
+            throw fail(
+                "BAD_REQUEST",
+                "act does not recognize `\(strayKey)`. It reads `frame`, `targetWindow` and " +
+                    "`actions` only. Nothing was done."
+            )
+        }
+    }
+    /*
+     * The same rule, on the three operations simple enough to enumerate without re-auditing
+     * every field the richer operations read.
+     *
+     * `act`'s stray-key check above was itself the second fix for this exact shape — `window`
+     * was fixed as its own case first — and a QA round measured that the rule still had not
+     * reached anywhere else: `windows`, `warm` and `cursor` took any key at all and silently
+     * did nothing with it, answering `ok: true` for a field that was never read. `warm` and
+     * `cursor` read nothing but `op`; `windows` reads one optional field besides it. Both are
+     * short enough lists to check safely here; `find_ui`, `act_ui`, `capture` and `snapshot`
+     * read enough fields, some of them forwarded between each other, that enumerating them
+     * belongs in its own change rather than being guessed at alongside this one.
+     */
+    if operation == "warm" || operation == "cursor" {
+        if let strayKey = request.keys.first(where: { $0 != "op" }) {
+            throw fail(
+                "BAD_REQUEST",
+                "\(operation) does not recognize `\(strayKey)`. It takes no fields beyond `op`. Nothing was done."
+            )
+        }
+    }
+    if operation == "windows" {
+        let knownWindowsKeys: Set<String> = ["op", "focusable"]
+        if let strayKey = request.keys.first(where: { !knownWindowsKeys.contains($0) }) {
+            throw fail(
+                "BAD_REQUEST",
+                "windows does not recognize `\(strayKey)`. It reads `focusable` only, besides `op`. Nothing was done."
+            )
+        }
+    }
     var result: JSONObject = ["ok": true]
     switch operation {
     case "warm":
@@ -1446,11 +2349,61 @@ private func handle(_ request: JSONObject) throws -> JSONObject {
     case "cursor":
         result["cursor"] = cursorObject()
         result["foreground"] = foregroundWindowID().map(Int.init) ?? 0
+        // Whether the application in front is this one. Its windows are deliberately excluded
+        // from enumeration — the model must not drive the app driving it — but that made a
+        // correct refusal look like a wrong answer: QA saw `No foreground window` while Chat On
+        // Steroids was plainly frontmost. Reported so the caller can say which it is.
+        result["foregroundIsSelf"] = frontmostPID() == getpid()
     case "windows":
         let foreground = foregroundWindowID()
-        result["windows"] = allWindowRows().map { $0.json(foreground: foreground) }
+        let rows = allWindowRows()
+        /*
+         * `focusable` is asked for, never given away.
+         *
+         * A transient panel an application draws over its own window — Chrome's omnibox container
+         * is the one everybody meets — is listed like any other window and reads like any other
+         * window, and the only thing that sets it apart is that it refuses to come to the front
+         * while its parent is there. Its size and its title cannot be used for that: real tool
+         * windows and inspectors are small and generically titled too.
+         *
+         * What does say it is whether `AXMain` can be set. Measured on macOS 27: false for the
+         * container, true for an ordinary window, both with a clean API result — and the reading
+         * itself costs about 0.05 ms, under 2 ms for a list of 26. But reaching the element to ask
+         * costs 112–117 ms for that same list, one round trip into every other application, and
+         * this call is made constantly. Paying that on every list to carry a field that says
+         * `true` for nearly every window in it is the wrong trade, so it is here and it is opt-in.
+         */
+        if request["focusable"] as? Bool == true {
+            result["windows"] = rows.map { row -> JSONObject in
+                var entry = row.json(foreground: foreground)
+                do {
+                    let window = try matchingAXWindow(row)
+                    var settable = DarwinBoolean(false)
+                    let status = AXUIElementIsAttributeSettable(window, kAXMainAttribute as CFString, &settable)
+                    // A window whose answer cannot be read is reported focusable: refusing to
+                    // drive something on a failed reading would be worse than the reading's absence.
+                    entry["focusable"] = status == .success ? settable.boolValue : true
+                } catch {
+                    /*
+                     * `null` alone was two different answers wearing one hat. It was documented as
+                     * "no element to ask", but a `try?` was also swallowing the named refusal for
+                     * windows this scan cannot tell apart — and those two call for opposite things
+                     * from the caller. Nothing can be done about an application that exposes no
+                     * accessibility window; moving or closing one of three identical windows takes
+                     * a moment. So the reason rides alongside, and only when there is one.
+                     */
+                    entry["focusable"] = NSNull()
+                    entry["focusableUnknown"] =
+                        (error as? HelperFailure)?.code == "UIA_AMBIGUOUS_WINDOW" ? "ambiguous" : "unavailable"
+                }
+                return entry
+            }
+        } else {
+            result["windows"] = rows.map { $0.json(foreground: foreground) }
+        }
         result["screen"] = rectObject(try virtualScreenRect())
     case "active":
+        result["foregroundIsSelf"] = frontmostPID() == getpid()
         let foreground = foregroundWindowID()
         result["window"] = foreground.flatMap(windowRow)?.json(foreground: foreground) ?? NSNull()
         result["screen"] = rectObject(try virtualScreenRect())
@@ -1465,9 +2418,17 @@ private func handle(_ request: JSONObject) throws -> JSONObject {
     case "capture":
         result.merge(try capture(request)) { _, new in new }
     case "snapshot":
-        let id = number(request["id"])?.uint32Value ?? foregroundWindowID()
+        let requested = number(request["id"])?.uint32Value
+        let id = requested ?? foregroundWindowID()
         guard let id, let row = windowRow(id) else {
-            throw fail("WINDOW_NOT_FOUND", "no matching visible window is available")
+            // Name the window that is gone. "No matching visible window" describes the desktop
+            // rather than the request, and a caller that asked for one window in particular is
+            // left to guess whether it closed, was never valid, or the whole desktop is empty.
+            throw fail(
+                "WINDOW_NOT_FOUND",
+                requested.map { "window \($0) is no longer on screen" }
+                    ?? "no window is in the foreground to snapshot"
+            )
         }
         result["window"] = row.json(foreground: foregroundWindowID())
         if bool(request["includeScreenshot"]) {
@@ -1479,7 +2440,10 @@ private func handle(_ request: JSONObject) throws -> JSONObject {
                 for key in ["snapshotId", "elements", "visited", "truncated"] {
                     result[key] = ui[key]
                 }
-            } catch let error as HelperFailure where error.code == "ACCESSIBILITY_PERMISSION_REQUIRED" {
+            } catch let error as HelperFailure where onlyTheTreeFailed(error.code) {
+                // Screen capture is an independent capability. If only the AX tree is
+                // unavailable/malformed/slow, keep the already-valid image and report typed
+                // semantic unavailability. Target-identity failures remain fatal.
                 result["uiUnavailable"] = ["code": error.code, "message": error.message]
             }
         }
@@ -1488,13 +2452,21 @@ private func handle(_ request: JSONObject) throws -> JSONObject {
         let frame = request["frame"] as? JSONObject
         if let frame { try validateFrame(frame) }
         let frameWindow = number(frame?["window"])?.uint32Value
-        // A successful semantic or explicit focus step becomes the authority for later
-        // keyboard input in this same batch. The later input still re-proves exact focus;
-        // carrying the id prevents a frame-less click_ref -> type sequence from degrading
-        // into an unscoped global HID event.
-        var inputWindow = frameWindow
+        let requestedTargetWindow = number(request["targetWindow"])?.uint32Value
+        if let frameWindow, let requestedTargetWindow, frameWindow != requestedTargetWindow {
+            throw fail(
+                "TARGET_WINDOW_CONFLICT",
+                "frame targets window \(frameWindow), but targetWindow is \(requestedTargetWindow)"
+            )
+        }
+        var leasedWindow = frameWindow ?? requestedTargetWindow
         let actions = request["actions"] as? [JSONObject] ?? []
         var routes: [String] = []
+        var scrollEvidence: JSONObject?
+        // Same evidence-over-acknowledgement shape as scroll's `moved`: whether a `click_ui`'s
+        // own AXPress actually changed the control's reported value, not just whether the API
+        // call was accepted. Nil when the control had nothing comparable to check.
+        var uiChanged: Bool?
         var completed = 0
         for (index, action) in actions.enumerated() {
             do {
@@ -1502,38 +2474,54 @@ private func handle(_ request: JSONObject) throws -> JSONObject {
                 switch type {
                 case "click_ui", "set_value_ui":
                     guard let actionWindow = number(action["window"])?.uint32Value else {
-                        throw fail("BAD_ACTION", "semantic action has no target window")
+                        throw fail("BAD_ACTION", "semantic action is missing its window")
                     }
-                    if let frameWindow, frameWindow != actionWindow {
+                    if let leasedWindow, leasedWindow != actionWindow {
                         throw fail(
                             "TARGET_WINDOW_CONFLICT",
-                            "semantic action targets window \(actionWindow), but frame targets window \(frameWindow)"
+                            "semantic action targets window \(actionWindow), but this batch is leased to window \(leasedWindow)"
                         )
                     }
+                    leasedWindow = actionWindow
                     var uiRequest = action
                     uiRequest["id"] = action["window"]
                     uiRequest["action"] = type == "click_ui" ? "click" : "set_value"
                     uiRequest["value"] = action["value"]
                     let reply = try actUI(uiRequest)
                     routes.append(string(reply["route"], default: "uia"))
-                    inputWindow = actionWindow
+                    if type == "click_ui", let changed = reply["changed"] as? Bool {
+                        uiChanged = changed
+                    }
                 case "move":
                     if let frame { _ = try assertFrameTarget(frame) }
-                    try movePointer(CGPoint(x: int(action["x"]), y: int(action["y"])))
+                    try movePointer(CGPoint(x: int(action["x"]), y: int(action["y"])), verify: true)
                     routes.append("sendinput")
                 case "click", "double_click":
                     if let frame { _ = try assertFrameTarget(frame) }
+                    guard let target = leasedWindow else {
+                        throw fail("INPUT_TARGET_REQUIRED", "click input requires targetWindow")
+                    }
+                    let clickRow = try assertInputTarget(target)
+                    let clickAt = CGPoint(x: int(action["x"]), y: int(action["y"]))
+                    try requirePointInWindow(clickAt, clickRow, type)
                     try click(
-                        CGPoint(x: int(action["x"]), y: int(action["y"])),
+                        clickAt,
                         button: mouseButton(string(action["button"])),
                         count: type == "double_click" ? 2 : 1,
-                        targetWindow: frameWindow
+                        targetWindow: target
                     )
                     routes.append("sendinput")
                 case "scroll":
                     if let frame { _ = try assertFrameTarget(frame) }
-                    try movePointer(CGPoint(x: int(action["x"]), y: int(action["y"])))
+                    guard let target = leasedWindow else {
+                        throw fail("INPUT_TARGET_REQUIRED", "scroll input requires targetWindow")
+                    }
+                    let scrollRow = try assertInputTarget(target)
+                    let scrollAt = CGPoint(x: int(action["x"]), y: int(action["y"]))
+                    try requirePointInWindow(scrollAt, scrollRow, "scroll")
+                    try movePointer(scrollAt)
                     if let frame { _ = try assertFrameTarget(frame) }
+                    _ = try assertInputTarget(target)
                     guard let event = CGEvent(
                         scrollWheelEvent2Source: nil,
                         units: .line,
@@ -1542,44 +2530,81 @@ private func handle(_ request: JSONObject) throws -> JSONObject {
                         wheel2: Int32(int(action["scroll_x"])),
                         wheel3: 0
                     ) else { throw fail("INPUT_FAILED", "could not create a scroll event") }
+                    let before = pointerScrollState(scrollAt)
                     event.post(tap: .cghidEventTap)
+                    let after = settledScrollState(scrollAt, startedAt: before.fraction)
+                    var evidence: JSONObject = [
+                        "targetPid": Int(scrollRow.pid),
+                        "reachedTarget": before.pid == scrollRow.pid
+                    ]
+                    evidence["hitPid"] = before.pid.map { Int($0) as Any } ?? NSNull()
+                    evidence["hitRole"] = before.role.map { $0 as Any } ?? NSNull()
+                    if let start = before.fraction, let end = after.fraction {
+                        evidence["positionBefore"] = start
+                        evidence["positionAfter"] = end
+                        evidence["moved"] = abs(end - start) > 0.0001
+                    } else {
+                        evidence["moved"] = NSNull()
+                        evidence["movedUnknown"] = before.pid == nil
+                            ? "nothing under the pointer"
+                            : "nothing scrollable under the pointer"
+                    }
+                    scrollEvidence = evidence
                     routes.append("sendinput")
                 case "drag":
                     if let frame { _ = try assertFrameTarget(frame) }
+                    guard let target = leasedWindow else {
+                        throw fail("INPUT_TARGET_REQUIRED", "drag input requires targetWindow")
+                    }
+                    _ = try assertInputTarget(target)
                     try drag(
                         action["xs"] as? [NSNumber] ?? [],
                         action["ys"] as? [NSNumber] ?? [],
                         button: mouseButton(string(action["button"])),
-                        targetWindow: frameWindow
+                        targetWindow: target,
+                        expectedDisplays: frameWindow == nil ? displayTopology(frame?["displays"]) : nil
                     )
                     routes.append("sendinput")
                 case "type":
-                    if let inputWindow { _ = try assertInputTarget(inputWindow) }
-                    try typeText(string(action["text"]), targetWindow: inputWindow)
+                    guard let target = leasedWindow else {
+                        throw fail("INPUT_TARGET_REQUIRED", "text input requires targetWindow")
+                    }
+                    _ = try assertInputTarget(target)
+                    try typeText(string(action["text"]), targetWindow: target)
                     routes.append("sendinput")
                 case "keypress":
-                    if let inputWindow { _ = try assertInputTarget(inputWindow) }
-                    try pressKeys(action["keys"] as? [String] ?? [], targetWindow: inputWindow)
+                    let keys = action["keys"] as? [String] ?? []
+                    if let target = leasedWindow {
+                        _ = try assertInputTarget(target)
+                        try pressKeys(keys, targetWindow: target)
+                    } else {
+                        // System-owned shortcuts are intentionally global; pressKeys itself
+                        // rejects ordinary application keys when no exact window is leased.
+                        try pressKeys(keys, targetWindow: nil)
+                    }
                     routes.append("sendinput")
                 case "focus":
                     let requested = CGWindowID(int(action["window"]))
-                    if let frameWindow, frameWindow != requested {
+                    if let leasedWindow, leasedWindow != requested {
                         throw fail(
                             "TARGET_WINDOW_CONFLICT",
-                            "focus targets window \(requested), but frame targets window \(frameWindow)"
+                            "focus targets window \(requested), but this batch is leased to window \(leasedWindow)"
                         )
                     }
+                    leasedWindow = requested
                     guard try focusWindow(requested) else {
-                        throw fail("FOCUS_FAILED", "the requested window could not be activated")
+                        let why = windowRow(requested).map(inputTargetRefusal) ?? "the window is gone"
+                        throw fail("FOCUS_FAILED", "the requested window could not be activated: \(why)")
                     }
                     routes.append("focus")
-                    inputWindow = requested
                 default:
                     throw fail("BAD_ACTION", "unknown action \(type)")
                 }
                 completed += 1
             } catch let error as HelperFailure {
-                return [
+                // Only when a scroll happened. A `"scroll": null` on every refused keystroke is a
+                // field that means nothing about the answer it rides on, and it rode on all of them.
+                var failure: JSONObject = [
                     "ok": false,
                     "error_code": error.code,
                     "message": error.message,
@@ -1587,12 +2612,17 @@ private func handle(_ request: JSONObject) throws -> JSONObject {
                     "failed_index": index,
                     "routes": routes
                 ]
+                if let scrollEvidence { failure["scroll"] = scrollEvidence }
+                if let uiChanged { failure["ui_changed"] = uiChanged }
+                return failure
             }
         }
         result["cursor"] = cursorObject()
         result["foreground"] = foregroundWindowID().map(Int.init) ?? 0
         result["completed_count"] = completed
         result["routes"] = routes
+        if let scrollEvidence { result["scroll"] = scrollEvidence }
+        if let uiChanged { result["ui_changed"] = uiChanged }
     default:
         throw fail("BAD_REQUEST", "unknown operation \(operation)")
     }

--- a/src/main/computer/helper.ts
+++ b/src/main/computer/helper.ts
@@ -55,6 +55,8 @@ public static class Clf {
   const uint MOUSEEVENTF_LEFTDOWN = 0x0002, MOUSEEVENTF_LEFTUP = 0x0004;
   const uint MOUSEEVENTF_RIGHTDOWN = 0x0008, MOUSEEVENTF_RIGHTUP = 0x0010;
   const uint MOUSEEVENTF_MIDDLEDOWN = 0x0020, MOUSEEVENTF_MIDDLEUP = 0x0040;
+  const uint MOUSEEVENTF_XDOWN = 0x0080, MOUSEEVENTF_XUP = 0x0100;
+  const uint XBUTTON1 = 0x0001, XBUTTON2 = 0x0002;
   const uint MOUSEEVENTF_WHEEL = 0x0800, MOUSEEVENTF_HWHEEL = 0x1000;
   // Nonzero when the user has swapped the primary and secondary mouse buttons. See ButtonFlags.
   const int SM_SWAPBUTTON = 23;
@@ -81,8 +83,16 @@ public static class Clf {
   [DllImport("user32.dll")] static extern bool AttachThreadInput(uint from, uint to, bool attach);
   [DllImport("user32.dll")] static extern bool PrintWindow(IntPtr hwnd, IntPtr hdcBlt, uint flags);
   [DllImport("kernel32.dll")] static extern uint GetCurrentThreadId();
+  [DllImport("user32.dll")] static extern bool GetCursorInfo(ref CURSORINFO ci);
+  [DllImport("user32.dll")] static extern bool GetIconInfo(IntPtr icon, out ICONINFO info);
+  [DllImport("user32.dll")] static extern bool DrawIconEx(IntPtr hdc, int x, int y, IntPtr icon, int w, int h, uint step, IntPtr brush, uint flags);
+  [DllImport("gdi32.dll")] static extern bool DeleteObject(IntPtr o);
 
   public struct POINT { public int X, Y; }
+  [StructLayout(LayoutKind.Sequential)]
+  public struct CURSORINFO { public int cbSize; public int flags; public IntPtr hCursor; public POINT ptScreenPos; }
+  [StructLayout(LayoutKind.Sequential)]
+  public struct ICONINFO { public bool fIcon; public int xHotspot; public int yHotspot; public IntPtr hbmMask; public IntPtr hbmColor; }
   public struct RECT { public int Left, Top, Right, Bottom; }
   delegate bool EnumProc(IntPtr h, IntPtr lp);
 
@@ -128,18 +138,24 @@ public static class Clf {
    *
    * Read per call rather than cached: it is a checkbox in Mouse properties and can change while
    * the app runs, and a stale answer is the same wrong-button bug with a longer fuse. Only the
-   * primary and secondary swap -- middle and the wheel are untouched.
+   * primary and secondary swap -- middle, the wheel and the side buttons are untouched.
+   *
+   * The side buttons are one event pair distinguished by mouseData, not their own flags,
+   * which is why the data word has to travel with the flags rather than being zero.
    *
    * (No backticks in this comment: the whole script is a String.raw template literal.)
    */
-  static void ButtonFlags(string button, out uint down, out uint up) {
+  static void ButtonFlags(string button, out uint down, out uint up, out uint data) {
     bool swapped = GetSystemMetrics(SM_SWAPBUTTON) != 0;
+    data = 0;
     switch (button) {
       case "right":
         down = swapped ? MOUSEEVENTF_LEFTDOWN : MOUSEEVENTF_RIGHTDOWN;
         up = swapped ? MOUSEEVENTF_LEFTUP : MOUSEEVENTF_RIGHTUP;
         break;
       case "middle": case "wheel": down = MOUSEEVENTF_MIDDLEDOWN; up = MOUSEEVENTF_MIDDLEUP; break;
+      case "back": down = MOUSEEVENTF_XDOWN; up = MOUSEEVENTF_XUP; data = XBUTTON1; break;
+      case "forward": down = MOUSEEVENTF_XDOWN; up = MOUSEEVENTF_XUP; data = XBUTTON2; break;
       default:
         down = swapped ? MOUSEEVENTF_RIGHTDOWN : MOUSEEVENTF_LEFTDOWN;
         up = swapped ? MOUSEEVENTF_RIGHTUP : MOUSEEVENTF_LEFTUP;
@@ -149,12 +165,12 @@ public static class Clf {
 
   public static void Click(int x, int y, string button, int times) {
     Move(x, y);
-    uint down, up;
-    ButtonFlags(button, out down, out up);
+    uint down, up, data;
+    ButtonFlags(button, out down, out up, out data);
     List<INPUT> batch = new List<INPUT>();
     for (int n = 0; n < times; n++) {
-      batch.Add(Mouse(down, 0, 0, 0));
-      batch.Add(Mouse(up, 0, 0, 0));
+      batch.Add(Mouse(down, 0, 0, data));
+      batch.Add(Mouse(up, 0, 0, data));
     }
     Send(batch.ToArray());
   }
@@ -169,13 +185,50 @@ public static class Clf {
     if (batch.Count > 0) Send(batch.ToArray());
   }
 
+  // Paced and interpolated for the same reason as the macOS helper: a press that moves
+  // immediately reads as a click, and two waypoints are a teleport that never crosses the
+  // system drag threshold. QA saw a Finder drag report success three times while the file
+  // stayed put; Explorer's shell drag has the same requirements.
+  const int DragPressHoldMs = 90;
+  const int DragStepMs = 8;
+  const int DragDropDwellMs = 140;
+  const double DragMaxStep = 8.0;
+  // One budget for the whole path, not per hop. Per hop, a 64-waypoint drag could post
+  // thousands of events and outlast the parent's deadline, and a helper killed mid-drag never
+  // reaches the release below — leaving the button logically held down. Longer paths take
+  // longer strides instead of more time.
+  const int DragMaxTotalSteps = 180;
+
   public static void Drag(int[] xs, int[] ys, string button) {
-    uint down, up;
-    ButtonFlags(button, out down, out up);
+    uint down, up, data;
+    ButtonFlags(button, out down, out up, out data);
+    double total = 0.0;
+    for (int i = 1; i < xs.Length; i++) {
+      double hx = xs[i] - xs[i - 1], hy = ys[i] - ys[i - 1];
+      total += System.Math.Sqrt(hx * hx + hy * hy);
+    }
     Move(xs[0], ys[0]);
-    Send(new INPUT[] { Mouse(down, 0, 0, 0) });
-    for (int i = 1; i < xs.Length; i++) { Move(xs[i], ys[i]); System.Threading.Thread.Sleep(12); }
-    Send(new INPUT[] { Mouse(up, 0, 0, 0) });
+    Send(new INPUT[] { Mouse(down, 0, 0, data) });
+    System.Threading.Thread.Sleep(DragPressHoldMs);
+    int cx = xs[0], cy = ys[0];
+    for (int i = 1; i < xs.Length; i++) {
+      double dx = xs[i] - cx, dy = ys[i] - cy;
+      double distance = System.Math.Sqrt(dx * dx + dy * dy);
+      int steps = (int)System.Math.Ceiling(distance / DragMaxStep);
+      if (total > 0.0 && total / DragMaxStep > DragMaxTotalSteps) {
+        steps = (int)System.Math.Round(DragMaxTotalSteps * distance / total);
+      }
+      if (steps < 1) steps = 1;
+      for (int s = 1; s <= steps; s++) {
+        double progress = (double)s / (double)steps;
+        Move((int)System.Math.Round(cx + dx * progress), (int)System.Math.Round(cy + dy * progress));
+        System.Threading.Thread.Sleep(DragStepMs);
+      }
+      cx = xs[i]; cy = ys[i];
+    }
+    Move(xs[xs.Length - 1], ys[ys.Length - 1]);
+    System.Threading.Thread.Sleep(DragDropDwellMs);
+    Send(new INPUT[] { Mouse(up, 0, 0, data) });
   }
 
   static INPUT Key(ushort vk, bool up) {
@@ -341,10 +394,48 @@ public static class Clf {
     return outW + "," + outH;
   }
 
+  /**
+   * Paints the live pointer into a shot whose top-left is at screen (originX, originY).
+   *
+   * Neither CopyFromScreen nor PrintWindow composites the cursor, while ScreenCaptureKit does
+   * it for us on macOS. Without this the model cannot see where the pointer is, cannot read a
+   * hover state, and cannot confirm from the picture that a move actually landed.
+   *
+   * Drawn at the hotspot rather than the icon origin, because the hotspot is the pixel the
+   * pointer actually addresses — an I-beam or a resize arrow is centred, not top-left, and
+   * drawing at the raw position would put the tip a few pixels off exactly when a coordinate
+   * is being read off the image. Failure here is never fatal: a screenshot without the
+   * pointer is still a screenshot.
+   */
+  static void PaintCursor(Graphics g, int originX, int originY, int w, int h) {
+    CURSORINFO ci = new CURSORINFO();
+    ci.cbSize = Marshal.SizeOf(typeof(CURSORINFO));
+    if (!GetCursorInfo(ref ci)) return;
+    // CURSOR_SHOWING. A hidden pointer — full-screen video, a text field mid-typing — must
+    // not be invented into the picture.
+    if ((ci.flags & 0x00000001) == 0 || ci.hCursor == IntPtr.Zero) return;
+    ICONINFO info;
+    if (!GetIconInfo(ci.hCursor, out info)) return;
+    try {
+      int x = ci.ptScreenPos.X - originX - info.xHotspot;
+      int y = ci.ptScreenPos.Y - originY - info.yHotspot;
+      // Cheap reject only for a pointer nowhere near the shot; DrawIconEx clips the rest.
+      if (x < -256 || y < -256 || x > w + 256 || y > h + 256) return;
+      IntPtr dc = g.GetHdc();
+      try { DrawIconEx(dc, x, y, ci.hCursor, 0, 0, 0, IntPtr.Zero, 0x0003); }
+      finally { g.ReleaseHdc(dc); }
+    } finally {
+      // GetIconInfo hands over two bitmap copies; hCursor itself is shared and is not ours.
+      if (info.hbmMask != IntPtr.Zero) DeleteObject(info.hbmMask);
+      if (info.hbmColor != IntPtr.Zero) DeleteObject(info.hbmColor);
+    }
+  }
+
   public static string Capture(int x, int y, int w, int h, int maxW, string file) {
     using (Bitmap shot = new Bitmap(w, h))
     using (Graphics g = Graphics.FromImage(shot)) {
       g.CopyFromScreen(x, y, 0, 0, new Size(w, h), CopyPixelOperation.SourceCopy);
+      PaintCursor(g, x, y, w, h);
       return SavePng(shot, maxW, file);
     }
   }
@@ -363,6 +454,9 @@ public static class Clf {
       try { ok = PrintWindow(h, dc, 2); }
       finally { g.ReleaseHdc(dc); }
       if (!ok) return "";
+      // The window was rendered off-screen, so the pointer is placed by the window's own
+      // screen rect. Outside it, PaintCursor's bounds check drops it.
+      PaintCursor(g, r.Left, r.Top, w, height);
       return SavePng(shot, maxW, file);
     }
   }
@@ -377,15 +471,21 @@ public static class Clf {
 function Vk([string]$name) {
   $n = $name.ToUpperInvariant()
   $map = @{
-    'CTRL'=0x11; 'CONTROL'=0x11; 'ALT'=0x12; 'SHIFT'=0x10; 'WIN'=0x5B; 'SUPER'=0x5B; 'CMD'=0x5B;
+    'CTRL'=0x11; 'CONTROL'=0x11; 'ALT'=0x12; 'OPTION'=0x12; 'SHIFT'=0x10;
+    'WIN'=0x5B; 'SUPER'=0x5B; 'CMD'=0x5B; 'META'=0x5B;
     'ENTER'=0x0D; 'RETURN'=0x0D; 'TAB'=0x09; 'ESC'=0x1B; 'ESCAPE'=0x1B; 'SPACE'=0x20;
     'BACKSPACE'=0x08; 'DELETE'=0x2E; 'DEL'=0x2E; 'INSERT'=0x2D; 'HOME'=0x24; 'END'=0x23;
     'PAGEUP'=0x21; 'PAGEDOWN'=0x22; 'UP'=0x26; 'DOWN'=0x28; 'LEFT'=0x25; 'RIGHT'=0x27;
+    # The DOM names for the same four keys, which is what browser key vocabulary emits.
+    'ARROWUP'=0x26; 'ARROWDOWN'=0x28; 'ARROWLEFT'=0x25; 'ARROWRIGHT'=0x27;
     'F1'=0x70;'F2'=0x71;'F3'=0x72;'F4'=0x73;'F5'=0x74;'F6'=0x75;
     'F7'=0x76;'F8'=0x77;'F9'=0x78;'F10'=0x79;'F11'=0x7A;'F12'=0x7B;
     'PRINTSCREEN'=0x2C; 'CAPSLOCK'=0x14;
-    'PGUP'=0x21; 'PGDN'=0x22; 'ARROWUP'=0x26; 'ARROWDOWN'=0x28; 'ARROWLEFT'=0x25; 'ARROWRIGHT'=0x27;
-    'META'=0x5B; 'COMMAND'=0x5B; 'OPTION'=0x12; 'INS'=0x2D; 'BKSP'=0x08; 'PAUSE'=0x13;
+    # ARROWUP/DOWN/LEFT/RIGHT, META and OPTION are already keyed above; a hashtable literal
+    # with the same key twice is a PowerShell parse error (DuplicateKeyInHashLiteral), not a
+    # last-write-wins override, so this line only adds what those did not already cover.
+    'PGUP'=0x21; 'PGDN'=0x22;
+    'COMMAND'=0x5B; 'INS'=0x2D; 'BKSP'=0x08; 'PAUSE'=0x13;
     'NUMLOCK'=0x90; 'SCROLLLOCK'=0x91; 'MENU'=0x5D; 'APPS'=0x5D;
     'F13'=0x7C;'F14'=0x7D;'F15'=0x7E;'F16'=0x7F;'F17'=0x80;'F18'=0x81;
     'F19'=0x82;'F20'=0x83;'F21'=0x84;'F22'=0x85;'F23'=0x86;'F24'=0x87;

--- a/src/main/computer/index.ts
+++ b/src/main/computer/index.ts
@@ -134,6 +134,29 @@ export interface ActionResult {
   clipboard: string[];
   completedCount: number;
   routes: ActionRoute[];
+  /** Exact single-window lease proven before this batch, when one exists. */
+  targetWindow: number | null;
+  /**
+   * What became of a scroll: which window the wheel actually reached, and whether anything moved.
+   *
+   * A wheel is delivered by the window server to whatever is under the pointer, not to whatever
+   * holds the lease — so "sent" and "scrolled" are different claims, and a reply that only made the
+   * first one could not be told apart from an application ignoring the wheel. Absent for a batch
+   * with no scroll in it, and on platforms whose helper does not report it.
+   */
+  scroll: Record<string, unknown> | null;
+  /**
+   * Whether a `click_ref` on a semantic control actually changed the value it reports, when
+   * that could be checked.
+   *
+   * `AXUIElementPerformAction` returning success is the OS saying the message was accepted, not
+   * that anything happened — measured directly: a System Settings toggle answered success and
+   * stayed exactly where it was, while a coordinate click on the same spot moved it. This is the
+   * same claim as `scroll`'s `moved` for the semantic path. Null when the control has nothing
+   * comparable to check (an ordinary button) or no click_ref ran; that is a different fact from
+   * "unchanged" and must not collapse into it.
+   */
+  uiChanged: boolean | null;
 }
 
 export type VerificationSpec =
@@ -264,13 +287,26 @@ export function helperTimeoutMs(
       return platform === 'darwin' ? 120_000 : 10_000;
     case 'warm':
       return 10_000;
-    case 'act':
-      if (platform !== 'darwin') return 15_000;
+    case 'act': {
+      // A drag is paced on purpose — held, travelled and dwelt on — so it costs real time a
+      // click does not. Each is bounded to about 1.7s by the helpers' own step budget, but the
+      // parent must still allow for them: a deadline that fires mid-drag kills the helper
+      // before it releases the button.
+      const drags = Array.isArray(request['actions'])
+        ? (request['actions'] as Array<Record<string, unknown>>).filter((a) => a?.['type'] === 'drag').length
+        : 0;
+      const dragAllowance = Math.min(8, drags) * 2_500;
+      if (platform !== 'darwin') return 15_000 + dragAllowance;
       // Every macOS physical mutation can now re-prove the exact AX/WindowServer input
       // target, and an explicit focus may spend up to two seconds in its bounded poll. Size
       // the parent deadline for the whole permitted batch so the helper can return partial
       // completion evidence instead of being killed after earlier actions already landed.
-      return 15_000 + Math.min(20, Array.isArray(request['actions']) ? request['actions'].length : 1) * 2_100;
+      return (
+        15_000 +
+        Math.min(20, Array.isArray(request['actions']) ? request['actions'].length : 1) * 2_100 +
+        dragAllowance
+      );
+    }
     default:
       return HELPER_TIMEOUT_MS;
   }
@@ -545,8 +581,33 @@ function completedHelperRoutes(reply: Record<string, any>, completed: number): A
   return routes as ActionRoute[];
 }
 
+/**
+ * A refusal the operating system just made is better evidence than a verdict we polled.
+ *
+ * The permission rows are fed by CGPreflightScreenCaptureAccess and AXIsProcessTrusted, asked on
+ * a timer. QA revoked Screen Recording and watched the row stay green for over forty seconds
+ * while capture was already failing with a TCC denial — so the answer those calls give a running
+ * process does not track a revocation, and no polling interval will fix that.
+ *
+ * A failed operation does track it. When the helper refuses for want of a permission, that is
+ * the operating system speaking about this process right now, and the row is corrected from it
+ * immediately. Nothing is inferred in the other direction: a success does not restore a row,
+ * because macOS caches a grant for the life of a process and a stale success would say the
+ * permission is back when only the cache is.
+ */
+function notePermissionRefusal(code: string): void {
+  const current = macOSDesktopAccess;
+  if (!current) return;
+  if (code === 'SCREEN_PERMISSION_REQUIRED' && current.screen !== 'missing') {
+    publishMacOSDesktopAccess({ ...current, screen: 'missing' });
+  } else if (code === 'ACCESSIBILITY_PERMISSION_REQUIRED' && current.accessibility !== 'missing') {
+    publishMacOSDesktopAccess({ ...current, accessibility: 'missing' });
+  }
+}
+
 function protocolFailure(reply: Record<string, any>): ComputerError | null {
   if (reply['ok'] !== false) return null;
+  notePermissionRefusal(String(reply['error_code'] ?? ''));
   const completed = Number(reply['completed_count']);
   const failed = Number(reply['failed_index']);
   const completedRoutes = completedHelperRoutes(reply, completed);
@@ -845,12 +906,12 @@ function uiTarget(ref: string): { window: number; runtimeKey: string; snapshotId
   const target = uiRefs.get(ref);
   if (!target) {
     throw new ComputerError(
-      `UNKNOWN_UI_REF: ${ref}. Call get_window_state or find_ui again and use a ref from that reply.`
+      `UNKNOWN_UI_REF: ${ref}. Call observe on the window again and use a ref from that reply.`
     );
   }
   if (!isHelperGenerationActive(target.generation)) {
     throw new ComputerError(
-      `STALE_REF: ${ref} was issued by a desktop helper that is no longer active, so it no longer identifies anything. Call get_window_state again and use a ref from that reply.`
+      `STALE_REF: ${ref} was issued by a desktop helper that is no longer active, so it no longer identifies anything. Call observe on the window again and use a ref from that reply.`
     );
   }
   return target;
@@ -884,11 +945,16 @@ export async function focusWindow(id: number): Promise<boolean> {
   return reply['focused'] === true;
 }
 
-export async function activeWindow(): Promise<{ window: WindowInfo | null; screen: Rect }> {
+export async function activeWindow(): Promise<{
+  window: WindowInfo | null;
+  screen: Rect;
+  /** The frontmost application is Chat On Steroids, whose windows are never automatable. */
+  foregroundIsSelf: boolean;
+}> {
   const reply = await runHelper({ op: 'active' });
   const value = reply['window'];
   const window = value && typeof value === 'object' ? (value as WindowInfo) : null;
-  return { window, screen: reply['screen'] as Rect };
+  return { window, screen: reply['screen'] as Rect, foregroundIsSelf: reply['foregroundIsSelf'] === true };
 }
 
 export async function findUi(opts: {
@@ -1019,7 +1085,15 @@ export async function getWindowState(opts: {
       });
       const value = reply['window'];
       const window = value && typeof value === 'object' ? (value as WindowInfo) : null;
-      if (!window) throw new ComputerError('WINDOW_NOT_FOUND: no matching visible window is available');
+      // Name it. A caller that asked for one window in particular should not have to guess whether
+      // it closed, was never valid, or the desktop is empty.
+      if (!window) {
+        throw new ComputerError(
+          opts.window === undefined
+            ? 'WINDOW_NOT_FOUND: no window is in the foreground to read'
+            : `WINDOW_NOT_FOUND: window ${opts.window} is no longer on screen`
+        );
+      }
       const shot = file ? await screenshotFromReply(reply, file, window.id) : null;
       const frame = shot ? frameById(shot.frameId) : null;
       const unavailableValue = reply['uiUnavailable'];
@@ -1175,8 +1249,16 @@ async function screenshotFromReply(
   rememberFrame(frame);
   const encodeStartedAt = Date.now();
   const data = png.toString('base64');
+  // The pointer note rides along here rather than in the Screenshot contract: it answers one
+  // question, and only for a person reading a log. A pointer missing from a macOS window
+  // capture looks identical whether the system would not describe a cursor, the pointer was
+  // outside the window, or the buffer failed, and telling those apart from the picture alone
+  // is impossible — which has already cost one round of guessing. Windows and older helpers
+  // that do not report it log "unreported" rather than inventing a verdict.
+  const pointerNote = typeof reply['pointer'] === 'string' ? reply['pointer'] : 'unreported';
   logInfo(
-    `desktop timing screenshot_read_ms=${readMs} screenshot_base64_ms=${Date.now() - encodeStartedAt} screenshot_bytes=${png.length}`
+    `desktop timing screenshot_read_ms=${readMs} screenshot_base64_ms=${Date.now() - encodeStartedAt} ` +
+      `screenshot_bytes=${png.length} pointer=${pointerNote}`
   );
   return {
     data,
@@ -1185,9 +1267,9 @@ async function screenshotFromReply(
     height: frame.height,
     region: frame.region,
     scale: frame.scale,
-    focused: requestedWindow === null ? null : reply['focused'] === true,
+    focused: frameWindow === null ? null : reply['focused'] === true,
     captureMode,
-    windowId: frame.windowId
+    windowId: frameWindow
   };
 }
 
@@ -1293,7 +1375,7 @@ export interface PointerResult {
 
 export async function act(
   actions: Action[],
-  opts: { frameId?: number } = {}
+  opts: { frameId?: number; targetWindow?: number } = {}
 ): Promise<ActionResult> {
   return exclusive(() => actLocked(actions, opts));
 }
@@ -1311,6 +1393,7 @@ export async function actAndCapture(
   actions: Action[],
   opts: {
     frameId?: number;
+    targetWindow?: number;
     capture?: {
       window?: number;
       full?: boolean;
@@ -1321,7 +1404,7 @@ export async function actAndCapture(
     };
     verify?: VerificationSpec;
   } = {}
-): Promise<ActionResult & { screenshot: Screenshot | null; verification: VerificationResult | null }> {
+): Promise<ActionResult & { screenshot: Screenshot | null; verification: VerificationResult | null; captureFallback: string | null }> {
   return exclusive(async () => {
     const before = opts.frameId === undefined ? qualifiedFrame(lastFrame) : frameById(opts.frameId);
     // capture.crop is expressed in pixels of the screenshot the caller saw, exactly like a
@@ -1353,18 +1436,66 @@ export async function actAndCapture(
         );
       }
     }
-    if (!opts.capture) return { ...result, screenshot: null, verification };
+    if (!opts.capture) return { ...result, screenshot: null, verification, captureFallback: null };
 
     const { preferActiveWindow, ...capture } = opts.capture;
+    if (capture.window === undefined && capture.full !== true && capture.crop === undefined && result.targetWindow !== null) {
+      capture.window = result.targetWindow;
+    }
     // Resolved here rather than by the caller: the actions may have changed which window
     // is in front, and resolving it outside the lock would reopen the gap this closes.
     if (preferActiveWindow && capture.window === undefined && capture.full !== true && capture.crop === undefined) {
       capture.window = (await activeWindow()).window?.id;
     }
+    let resultScreenshot: Screenshot;
+    let captureFallback: string | null = null;
+    try {
+      resultScreenshot = await screenshotLocked(capture, before);
+    } catch (err) {
+      const targetUnavailable =
+        capture.window !== undefined &&
+        err instanceof ComputerError &&
+        /WINDOW_NOT_FOUND|STALE_FRAME/.test(err.message);
+      if (!targetUnavailable) throw err;
+
+      const active = (await activeWindow()).window;
+      if (active) {
+        resultScreenshot = await screenshotLocked({ window: active.id, maxWidth: capture.maxWidth });
+        captureFallback = `target window ${capture.window} closed or changed before result capture; captured active window ${active.id} instead`;
+      } else {
+        resultScreenshot = await screenshotLocked({ maxWidth: capture.maxWidth });
+        captureFallback = `target window ${capture.window} closed or changed before result capture; captured the primary display instead`;
+      }
+    }
+    // Describe the pointer against the picture that is going back, not the one that was current
+    // before the actions ran. The cursor was computed inside actLocked, so a call that moved the
+    // pointer and then captured a window reported an image coordinate belonging to some earlier
+    // frame — true, and about a different image than the one in the caller's hands. QA read that
+    // as a regression, and it is at least an ambiguity worth removing.
+    const shotFrame = result.cursor ? frameById(resultScreenshot.frameId) : null;
+    const previous = result.cursor;
+    const cursor = shotFrame && previous
+      ? (() => {
+          const inFrame = {
+            x: Math.round((previous.screen.x - shotFrame.region.x) * shotFrame.scale),
+            y: Math.round((previous.screen.y - shotFrame.region.y) * shotFrame.scale)
+          };
+          const inside =
+            inFrame.x >= 0 && inFrame.y >= 0 && inFrame.x < shotFrame.width && inFrame.y < shotFrame.height;
+          return {
+            screen: previous.screen,
+            image: inside ? inFrame : null,
+            frameId: shotFrame.id,
+            imageSize: { width: shotFrame.width, height: shotFrame.height }
+          };
+        })()
+      : result.cursor;
     return {
       ...result,
-      screenshot: await screenshotLocked(capture, before),
-      verification
+      cursor,
+      screenshot: resultScreenshot,
+      verification,
+      captureFallback
     };
   });
 }
@@ -1445,7 +1576,7 @@ async function verifyDesktopLocked(spec: VerificationSpec): Promise<Verification
 
 async function actLocked(
   actions: Action[],
-  opts: { frameId?: number }
+  opts: { frameId?: number; targetWindow?: number }
 ): Promise<ActionResult> {
   const pointing = new Set(['move', 'click', 'double_click', 'scroll', 'drag']);
   const needsFrame = actions.some((a) => pointing.has(a.type));
@@ -1467,7 +1598,7 @@ async function actLocked(
   // immediately before input, so retaining it does not turn old pixels into blind clicks.
   if (needsFrame && !requestedFrame) {
     throw new ComputerError(
-      `STALE_FRAME: frame ${opts.frameId} is no longer retained. Take a screenshot or call get_window_state again and point at the new frame.`
+      `STALE_FRAME: frame ${opts.frameId} is no longer retained. Call observe again and point at the frameId from that reply's screenshot.`
     );
   }
   const frame =
@@ -1528,6 +1659,47 @@ async function actLocked(
     if (!uiTargets.has(action.ref)) uiTargets.set(action.ref, uiTarget(action.ref));
   }
 
+  const targetCandidates = new Set<number>();
+  if (requestedFrame?.windowId !== null && requestedFrame?.windowId !== undefined) {
+    targetCandidates.add(requestedFrame.windowId);
+  }
+  for (const target of uiTargets.values()) targetCandidates.add(target.window);
+  for (const action of actions) if (action.type === 'focus') targetCandidates.add(action.window);
+  if (targetCandidates.size > 1) {
+    throw new ComputerError(
+      `TARGET_WINDOW_CONFLICT: this batch spans windows ${[...targetCandidates].join(', ')}. Split cross-window work into separate computer calls.`
+    );
+  }
+  if (opts.targetWindow !== undefined) {
+    for (const candidate of targetCandidates) {
+      if (candidate !== opts.targetWindow) {
+        throw new ComputerError(
+          `TARGET_WINDOW_CONFLICT: this batch is pinned to window ${opts.targetWindow}, but an action/frame targets window ${candidate}. Split cross-window work into separate computer calls.`
+        );
+      }
+    }
+  }
+  const inferredTargetWindow =
+    opts.targetWindow ?? (targetCandidates.size === 1 ? [...targetCandidates][0] : undefined);
+  const requiresWindowLease = actions.some((action) =>
+    action.type === 'click' ||
+    action.type === 'double_click' ||
+    action.type === 'scroll' ||
+    action.type === 'drag' ||
+    action.type === 'type'
+  );
+  if (requiresWindowLease && inferredTargetWindow === undefined) {
+    throw new ComputerError(
+      'INPUT_TARGET_REQUIRED: physical pointer and application text mutations require targetWindow, a window-bound frame, a semantic ref, or focus(window) in the same batch.'
+    );
+  }
+
+  if (needsFrame && frame.captureMode === 'screen_fallback' && inferredTargetWindow !== undefined) {
+    throw new ComputerError(
+      'INPUT_TARGET_UNPROVEN: visible screen_fallback pixels cannot authorize window-bound coordinate input. Focus the target and observe it again before pointing.'
+    );
+  }
+
   const mapOne = (action: Action): Record<string, unknown> => {
     switch (action.type) {
       case 'click_ref': {
@@ -1568,13 +1740,28 @@ async function actLocked(
           scroll_x: action.scroll_x ?? 0,
           scroll_y: action.scroll_y ?? 0
         };
-      case 'drag':
-        return {
-          type: 'drag',
-          xs: action.path.map((p) => toScreenX(p.x)),
-          ys: action.path.map((p) => toScreenY(p.y)),
-          button: action.button ?? 'left'
-        };
+      case 'drag': {
+        const xs = action.path.map((p) => toScreenX(p.x));
+        const ys = action.path.map((p) => toScreenY(p.y));
+        // A drag that goes nowhere is not a drag, and must not be reported as one.
+        //
+        // Points are already checked against the frame above, so an out-of-frame route is
+        // refused before it reaches here. What survives that and still collapses is a path too
+        // short to survive the scale: a screenshot of a Retina display is larger than the region
+        // it shows, so image pixels divide down, and a drag of a pixel or two lands on one
+        // screen point. Nothing crosses the drag threshold, no session begins, and the helper
+        // answers ok because every event it was asked to post was posted — the "success with no
+        // effect" a caller cannot tell from a real drag.
+        const distinct = xs.some((x, index) => x !== xs[0] || ys[index] !== ys[0]);
+        if (!distinct) {
+          throw new ComputerError(
+            `DRAG_PATH_COLLAPSED: every point of this drag lands on ${xs[0]},${ys[0]} on screen. The ` +
+              `image is ${frame.scale > 1 ? `${frame.scale}x` : 'not'} scaled relative to the desktop, so a path ` +
+              'this short covers no distance there. Nothing was sent — use endpoints further apart.'
+          );
+        }
+        return { type: 'drag', xs, ys, button: action.button ?? 'left' };
+      }
       case 'type':
         return { type: 'type', text: action.text };
       case 'keypress':
@@ -1592,6 +1779,8 @@ async function actLocked(
   // lock in between, which a second call from the tool layer would have done.
   const clipboard: string[] = [];
   const routes: ActionResult['routes'] = [];
+  let scrollEvidence: ActionResult['scroll'] = null;
+  let uiChanged: ActionResult['uiChanged'] = null;
   let completedCount = 0;
   // Validation above is synchronous; pin its helper through every queued native segment,
   // including a segment reached after a local wait or clipboard operation.
@@ -1612,6 +1801,7 @@ async function actLocked(
       reply = await runHelper({
         op: 'act',
         actions: sending,
+        ...(inferredTargetWindow === undefined ? {} : { targetWindow: inferredTargetWindow }),
         ...(needsFrame
           ? {
               frame: {
@@ -1626,6 +1816,12 @@ async function actLocked(
           : {})
       }, expected);
       helperUsed = true;
+      if (reply['scroll'] && typeof reply['scroll'] === 'object') {
+        scrollEvidence = reply['scroll'] as Record<string, unknown>;
+      }
+      if (typeof reply['ui_changed'] === 'boolean') {
+        uiChanged = reply['ui_changed'];
+      }
       const helperRoutes = Array.isArray(reply['routes']) ? reply['routes'].map(String) : [];
       for (let index = 0; index < sending.length; index++) {
         const route = helperRoutes[index];
@@ -1701,7 +1897,17 @@ async function actLocked(
     reply = await runHelper({ op: 'cursor' });
   }
 
-  if (reply === null) return { cursor: null, clipboard, completedCount, routes };
+  if (reply === null) {
+    return {
+      cursor: null,
+      clipboard,
+      completedCount,
+      routes,
+      targetWindow: inferredTargetWindow ?? null,
+      scroll: scrollEvidence,
+      uiChanged
+    };
+  }
 
   const raw = reply['cursor'] as { x?: unknown; y?: unknown } | undefined;
   const sx = Number(raw?.x);
@@ -1709,13 +1915,28 @@ async function actLocked(
   if (!Number.isFinite(sx) || !Number.isFinite(sy)) {
     throw new ComputerError('The desktop helper returned an invalid pointer position.');
   }
+  // Both halves of this line have a reason, and they are about different things.
+  //
+  // `qualifiedFrame(..., generationOfReply(reply))` is upstream's: a frame from an older capture
+  // generation no longer describes what the helper just answered about, so it must not be used to
+  // place a point at all.
   const current = qualifiedFrame(requestedFrame ?? lastFrame, generationOfReply(reply));
-  const image = current
+  // And the bounds check below is ours. The conversion is arithmetic and answers for any point on
+  // the desktop, including points the frame does not contain — so a pointer below a captured
+  // window produced "875,754" for an image 646 tall, a coordinate that cannot exist. QA caught it,
+  // and a caller reading that as an image position would address a pixel that is not there.
+  // Outside the frame there is no image coordinate to give; `screen` still says where the pointer
+  // is. A right frame and a point inside it are separate questions, so both are asked.
+  const inFrame = current
     ? {
         x: Math.round((sx - current.region.x) * current.scale),
         y: Math.round((sy - current.region.y) * current.scale)
       }
     : null;
+  const image =
+    inFrame && current && inFrame.x >= 0 && inFrame.y >= 0 && inFrame.x < current.width && inFrame.y < current.height
+      ? inFrame
+      : null;
   return {
     cursor: {
       screen: { x: sx, y: sy },
@@ -1725,7 +1946,10 @@ async function actLocked(
     },
     clipboard,
     completedCount,
-    routes
+    routes,
+    targetWindow: inferredTargetWindow ?? null,
+    scroll: scrollEvidence,
+    uiChanged
   };
 }
 

--- a/src/main/mcp/instructions.ts
+++ b/src/main/mcp/instructions.ts
@@ -197,7 +197,11 @@ function desktopInstructions(ctx: ToolContext, platform: NodeJS.Platform): strin
     'observe never needs a window to be in front and never fails for lack of focus. Only computer does, and',
     'only for its focus action — so when something steals focus, look first and act on what you see.',
     'Coordinates are pixels of a screenshot frame. Coordinate actions require frameId so a click cannot land on a screen',
-    'that has since changed. Batch the actions that belong together and use captureAfter to verify the result.',
+    'that has since changed. For physical pointer or application keyboard input, pass the observed window id as targetWindow; system-owned shortcuts remain global. targetWindow is a fail-closed assertion, not permission to guess a different focus.',
+    'Keep a computer call on one target window and one UI-changing decision. focus/move/wait/clipboard setup may accompany it; inspect the returned capture before deciding the next action.',
+    'Mutating computer calls return a fresh result screenshot by default when screen access is available. Set captureAfter=false only when the result genuinely does not need visual verification.',
+    'When a small Retina control is visually ambiguous, observe it again with a larger max_width instead of guessing a pixel.',
+    'Prefer focus(window) over command+tab/alt+tab when the destination window id is known. Never use a fixed sleep as proof that an app switch finished.',
     // Waiting was the single most repeated desktop pattern in the recorded sessions: a batch of
     // nothing but a fixed sleep plus a screenshot, over and over, because the model had no way to
     // say what it was waiting *for*. verify is that way, and it waits inside the one call.

--- a/src/main/mcp/kernel.ts
+++ b/src/main/mcp/kernel.ts
@@ -25,7 +25,8 @@ import { rawPromises as fs } from '../rawfs.js';
 import { inboundRequestId } from './inbound.js';
 import { McpServer, type ServerContext } from '@modelcontextprotocol/server';
 import { z } from 'zod';
-import type { Capabilities, Root } from '../../shared/types.js';
+import type { Capabilities, Capability, Root } from '../../shared/types.js';
+import { CAPABILITY_LABELS, WRITE_CAPABILITIES } from '../../shared/types.js';
 import { FsOpError, formatBytes, type FileInfo } from '../fsops.js';
 import { logInfo, logWarn } from '../logger.js';
 import {
@@ -136,6 +137,45 @@ export type ToolResult = { content: ToolContent[]; structuredContent?: Record<st
 
 export const ok = (text: string): ToolResult => ({ content: [{ type: 'text', text }] });
 export const fail = (text: string): ToolResult => ({ content: [{ type: 'text', text }], isError: true });
+
+/**
+ * Why a capability is off, in words that name the actual switch to flip.
+ *
+ * `caps[cap]` being false has two different causes that read identically from inside a tool
+ * handler: the individual permission is unchecked, or Read-only zeroed every write capability
+ * regardless of what is individually checked. A refusal that always says "enable the permission"
+ * is wrong for the second case — it blames a checkbox that may already be on, sends the user
+ * looking for the wrong control, and (with browser, command and desktop control all withdrawn at
+ * once) can leave nothing left to reach the one control that actually fixes it. QA hit exactly
+ * that: Read-only disabled Core, browser and desktop input, and every refusal blamed its own
+ * individual permission instead of naming Read-only, the one setting that explains all three.
+ *
+ * The other half of that same defect survived one round longer than the Read-only case: a
+ * caller that passed no `settingLabel` at all — `guarded()` below is the one call site that
+ * never did — fell back to "the permission", naming nothing. QA measured it on `observe` with
+ * Desktop switched off: `TOOL_DISABLED: observe is disabled by the current Chat On Steroids
+ * permissions. Ask the user to enable the permission in the app`, which does not say which one.
+ * `settingLabel` now defaults to the capability's own row label from Settings — the same text
+ * `CAPABILITY_LABELS` already renders beside its checkbox — so a caller only has to override it
+ * for a tool whose name does not match its capability one-to-one (`create` behind `apply_patch`,
+ * for instance); every plain `guarded()` call gets a correct, specific label for free.
+ */
+export function toolDisabledMessage(readOnly: boolean, cap: Capability, name: string, settingLabel?: string): string {
+  if (readOnly && (WRITE_CAPABILITIES as readonly Capability[]).includes(cap)) {
+    return (
+      `TOOL_DISABLED: ${name} is disabled because Read-only mode is on. Read-only turns off every ` +
+      'write capability at once — file changes, commands, browser control, mouse/keyboard input and ' +
+      'clipboard writes — regardless of what is individually checked; screenshots and reads still work. ' +
+      'Ask the user to turn Read-only off in the app, then retry.'
+    );
+  }
+  const label = settingLabel ?? CAPABILITY_LABELS[cap];
+  return (
+    `TOOL_DISABLED: ${name} is disabled by the current Chat On Steroids permissions. ` +
+    `Ask the user to enable "${label}" in the app, then retry. ` +
+    'If the tool list in this conversation is stale, start a new chat.'
+  );
+}
 
 /** Maps runtime errors to short model-facing text without ever exposing real paths. */
 export function friendlyError(err: unknown): string {
@@ -915,9 +955,32 @@ export async function resolveCwd(ctx: ToolContext, virtualPath: string | undefin
   const workspace = await validatedWorkspace();
   // Codex treats an explicitly empty workdir exactly like an omitted one.
   const provided = virtualPath !== undefined && virtualPath !== '';
-  if (!provided && !workspace && swarmRunning()) {
+  // `swarmRunning()` used to gate this — whether *any* run exists anywhere in the app, not
+  // whether this call's own conversation is part of one. QA hit it on the very first command
+  // of an entirely ordinary, single-chat session, over and over, because some unrelated swarm
+  // happened to be alive elsewhere — the message says "this multi-agent chat" but nothing had
+  // checked whether it actually was one. `ctx.roots[0]` is the same shared default every
+  // ordinary chat has always defaulted to; a conversation with no swarm membership at all
+  // defaults to it exactly as safely whether some other swarm exists or not. `context.agent` is
+  // resolved once per call, before any handler runs, from this exact conversation's identity
+  // (`agentForCaller`/`resolve()` in agents.ts) — non-null only when *this* call is genuinely a
+  // member of the active run, which is the one case defaulting could reach the wrong project.
+  // Not narrowed to "more than one approved root", though that looks tempting and was tried.
+  //
+  // The reasoning would be that with a single root there is nothing to get wrong, so `roots[0]`
+  // is the only thing the call could mean. The measured failure says otherwise: the run that
+  // meant `…/minecraft-web-demo` and rebuilt the parent Electron app instead was inside one root.
+  // The ambiguity is *which project within* the approved folder, so a root count cannot see it.
+  if (!provided && !workspace && currentCall()?.agent) {
+    // Name the folders. A caller told only that it needs "an explicit approved workdir" has to
+    // guess what one looks like, and a worker meets this on its very first command — the second
+    // thing that ever happens in its chat. Saying which folders exist turns the guess into a
+    // choice, the same way naming a select's options did.
+    const approved = ctx.roots.map((root) => `/${root.name}`).join(', ');
     throw new SandboxError(
-      'WORKSPACE_REQUIRED: this multi-agent chat has no proven workspace. Supply an explicit approved workdir before running a command.'
+      'WORKSPACE_REQUIRED: this multi-agent chat has no proven workspace. Supply an explicit ' +
+        'approved workdir before running a command' +
+        (approved ? `. Approved roots: ${approved}` : '.')
     );
   }
   const target = provided ? virtualPath : (workspace?.virtual ?? (ctx.roots[0] ? `/${ctx.roots[0].name}` : ''));
@@ -946,7 +1009,7 @@ export const cropArg = z
     height: z.number().int().min(1).max(100_000)
   })
   .strict();
-export const mouseButtonArg = z.enum(['left', 'right', 'middle']);
+export const mouseButtonArg = z.enum(['left', 'right', 'middle', 'wheel', 'back', 'forward']);
 // ------------------------------------------------------------------ registration
 
 export interface ToolAnnotations {
@@ -1038,10 +1101,7 @@ export function createRegistrar(server: McpServer, ctx: ToolContext, surface: Su
     guarded(cap, name, fn) {
       return guard(name, async () => {
         if (!caps[cap]) {
-          return fail(
-            `TOOL_DISABLED: ${name} is disabled by the current Chat On Steroids permissions. ` +
-              'Ask the user to enable the permission in the app, then retry. If the tool list in this conversation is stale, start a new chat.'
-          );
+          return fail(toolDisabledMessage(ctx.readOnly, cap, name));
         }
         return fn();
       });

--- a/src/main/mcp/tools-desktop.ts
+++ b/src/main/mcp/tools-desktop.ts
@@ -40,6 +40,7 @@ import {
   mouseButtonArg,
   ok,
   pointArg,
+  toolDisabledMessage,
   windowIdArg,
   type SurfaceRegistrar,
   type ToolContent
@@ -60,6 +61,92 @@ function newBrowserWindowHint(): string {
   return process.platform === 'darwin'
     ? 'open -na "Google Chrome" --args --new-window "$url"'
     : "Start-Process chrome.exe -ArgumentList '--new-window', $url";
+}
+
+/**
+ * The sentence a caller fenced out of a browser window most needs, and never saw.
+ *
+ * `computer` cannot click *into* a web page that has nothing focused yet: the fence asks the
+ * application which control has keyboard focus, a browser answers only when the page exposes one,
+ * and the click that would create that focus is itself what is being fenced. That is the fence
+ * failing closed on honest ignorance of where input would land, which is what it is for — the
+ * macOS helper carries a long note saying so and warning the next reader not to file it as a bug.
+ *
+ * The note is right and the refusal is correct. What neither said is the way out, which exists
+ * and is one tool away: `browser` speaks CDP and needs none of this. A QA run met these refusals
+ * five times in a row against a browser window, re-observing and retrying between each, and the
+ * report's closing judgement was that the app's failures are loud, correct, and read as a pattern
+ * of not working. A refusal that names its own remedy is the cheapest answer to that, and it
+ * costs no fence — this only appends a sentence to a refusal that has already happened.
+ *
+ * Best effort by construction: it runs only on the failure path, and any error looking up the
+ * window is swallowed, because failing to enrich a message is no reason to replace the real
+ * refusal with a worse one.
+ */
+async function browserInputHint(actions: Action[], targetWindow: number | undefined): Promise<string> {
+  try {
+    let focused: number | null = targetWindow ?? null;
+    for (const action of actions) if (action.type === 'focus') focused = action.window;
+    const target =
+      focused === null
+        ? (await activeWindow()).window
+        : ((await listWindows()).windows.find((window) => window.id === focused) ?? null);
+    if (!target || !isBrowserProcess(target.process)) return '';
+    return (
+      ` The window is a browser ("${target.title}"), and desktop input cannot reach a web page ` +
+      'that has no focused control yet — the click that would give it one is the click being ' +
+      'refused. Use the browser tool for the page itself: it drives Chrome directly and needs ' +
+      'no desktop focus.'
+    );
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Refusals that mean "desktop input could not be aimed", which is the browser case above.
+ *
+ * `INPUT_TARGET_REQUIRED` joined them after a QA round hit it twice in four minutes while trying
+ * to drive a browser window. It already names its own remedy and names it well — supply
+ * targetWindow, a window-bound frame, a semantic ref, or focus in the batch — but every one of
+ * those is a way to aim desktop input at a page, and against a browser the better answer is not
+ * to aim desktop input at all.
+ *
+ * `STALE_FRAME` is deliberately absent. That one is about a capture whose geometry moved, which
+ * is a real answer about the screenshot rather than about where input would land, and it says so.
+ */
+const INPUT_FENCE_CODES = [
+  'INPUT_TARGET_LOST',
+  'INPUT_TARGET_REQUIRED',
+  'STALE_UI_SNAPSHOT',
+  'FOCUS_FAILED'
+];
+
+/**
+ * Runs the batch, and on an input-fence refusal against a browser adds the way out.
+ *
+ * A rethrow rather than a mutation, because `ComputerError` carries the partial-batch accounting
+ * a caller needs to know how far it got — losing `completedCount` to improve a sentence would
+ * trade a fact for a nicety. Anything that is not one of those refusals is rethrown untouched.
+ */
+async function withBrowserInputHint<T>(
+  actions: Action[],
+  targetWindow: number | undefined,
+  run: () => Promise<T>
+): Promise<T> {
+  try {
+    return await run();
+  } catch (err) {
+    if (!(err instanceof ComputerError)) throw err;
+    if (!INPUT_FENCE_CODES.some((code) => err.message.includes(code))) throw err;
+    const hint = await browserInputHint(actions, targetWindow);
+    if (!hint) throw err;
+    throw new ComputerError(`${err.message}${hint}`, {
+      ...(typeof err.completedCount === 'number' ? { completedCount: err.completedCount } : {}),
+      ...(typeof err.failedIndex === 'number' ? { failedIndex: err.failedIndex } : {}),
+      ...(Array.isArray(err.completedRoutes) ? { completedRoutes: err.completedRoutes } : {})
+    });
+  }
 }
 
 async function browserChordRefusal(actions: Action[]): Promise<string | null> {
@@ -111,6 +198,24 @@ function desktopImageResult(text: string, data: string): { content: ToolContent[
   return result;
 }
 
+/**
+ * Web-page control, which is a different problem from desktop control.
+ *
+ * The desktop driver can already click anywhere in a browser window, but it cannot see a web
+ * page: Chromium keeps its renderer accessibility tree off until a real assistive client asks
+ * for it, so a UIA/AX walk returns the toolbar and one opaque pane. Inside a page the desktop
+ * driver has pixels and nothing else — which is exactly where refs stop being available.
+ *
+ * So this addresses elements by ref from `observe`, and the driver re-resolves a ref against
+ * the live document immediately before acting on it. Coordinates remain available for the
+ * cases refs cannot express, and they are in the screenshot's own pixels: the driver captures
+ * at a scale where one image pixel is one CSS pixel is one input unit.
+ */
+/** One scroll step, bounded the same on both surfaces: the two disagreed, and a page
+ * coordinate is a page coordinate whichever driver moves the pointer. */
+
+const scrollDeltaArg = z.number().int().min(-10_000).max(10_000);
+
 const computerActionArg = z.discriminatedUnion('type', [
   z.object({ type: z.literal('click_ref'), ref: z.string().min(1).max(64) }).strict().describe('Click a control by ref from observe.'),
   z
@@ -141,11 +246,11 @@ const computerActionArg = z.discriminatedUnion('type', [
       x: imageCoordinateArg,
       y: imageCoordinateArg,
       scroll_x: z.number().int().min(-10_000).max(10_000).optional(),
-      scroll_y: z.number().int().min(-10_000).max(10_000).optional()
+      scroll_y: scrollDeltaArg.optional()
     })
     .strict()
     .describe('Scroll at a point.'),
-  z.object({ type: z.literal('type'), text: z.string().max(4000) }).strict().describe('Type text into whatever has focus.'),
+  z.object({ type: z.literal('type'), text: z.string().max(4000) }).strict().describe('Type text into target.'),
   z
     .object({ type: z.literal('keypress'), keys: z.array(z.string().max(20)).min(1).max(6) })
     .strict()
@@ -302,8 +407,17 @@ export function registerDesktopTools(reg: SurfaceRegistrar): void {
           // A bare "what is on screen right now" with no window at all: cheapest possible
           // answer, and the only one that still works when there is no foreground window.
           if (what === 'active' && target === undefined && input.screenshot === false) {
-            const { window, screen } = await activeWindow();
-            if (!window) return ok(prefix(waited, `Desktop ${screen.width}x${screen.height}\nNo foreground window.`));
+            const { window, screen, foregroundIsSelf } = await activeWindow();
+            if (!window) {
+              // "None" and "this app" are different answers, and reporting the second as the
+              // first made a deliberate refusal look like a defect. Chat On Steroids hides its
+              // own windows from everything the model can see, on purpose: it must not be able
+              // to drive the app that is driving it.
+              const reason = foregroundIsSelf
+                ? 'Chat On Steroids itself is in front. Its own windows are never exposed, so there is nothing here to act on — switch to another application first.'
+                : 'No foreground window.';
+              return ok(prefix(waited, `Desktop ${screen.width}x${screen.height}\n${reason}`));
+            }
             return ok(prefix(waited, describeWindow(window)));
           }
 
@@ -329,10 +443,20 @@ export function registerDesktopTools(reg: SurfaceRegistrar): void {
               throw err;
             }
             const shot = await screenshot({ maxWidth: input.max_width });
+            // Why there is no window matters here as much as on the bare query, and this
+            // path was missed when that one was fixed — which is why QA still saw the old
+            // wording. Asked separately because the failure above tells us nothing about it.
+            let selfInFront = false;
+            try {
+              selfInFront = (await activeWindow())?.foregroundIsSelf === true;
+            } catch {
+              // Best effort. This only chooses between two ways of saying the same fallback, and
+              // failing to learn which would be a poor reason to fail the screenshot itself.
+            }
             return desktopImageResult(
               prefix(
                 waited,
-                `No foreground window, so this is the whole primary monitor.\nframe: ${shot.frameId}  ${shot.width}x${shot.height} — pass frameId ${shot.frameId} with any coordinates you read off it`
+                `${selfInFront ? 'Chat On Steroids itself is in front and its own windows are never exposed, so this is the whole primary monitor.' : 'No foreground window, so this is the whole primary monitor.'}\nframe: ${shot.frameId}  ${shot.width}x${shot.height} — pass frameId ${shot.frameId} with any coordinates you read off it`
               ),
               shot.data
             );
@@ -386,19 +510,25 @@ export function registerDesktopTools(reg: SurfaceRegistrar): void {
       {
         title: 'Control mouse and keyboard',
         description:
-          'Run ordered desktop actions. Prefer refs from observe; pixels require frameId and target geometry is rechecked. ' +
-          'verify waits for a postcondition. Capture and clipboard steps stay in the batch.',
+          'One desktop decision. Prefer refs; pixels need frameId. Pointer/text needs a target; system keys stay global.',
         inputSchema: z
           .object({
-            actions: z.array(computerActionArg).min(1).max(20),
+            actions: z
+              .array(computerActionArg)
+              .min(1)
+              .max(20)
+              // Stated here rather than only in the rejection below: a run was spent discovering
+              // this rule by being refused. Kept terse — this surface has a discovery budget.
+              .describe('One UI-changing action per call; focus/move/wait/clipboard may accompany it.'),
             frameId: z
               .number()
               .int()
               .min(1)
               .optional()
               .describe('Required for coordinate actions or captureCrop.'),
+            targetWindow: windowIdArg.optional(),
             verify: verificationArg.optional(),
-            captureAfter: z.boolean().optional().describe('Return a fresh screenshot after the actions. Default false.'),
+            captureAfter: z.boolean().optional().describe('Capture result; default on for mutations.'),
             captureWindow: windowIdArg.optional().describe('Result capture: this window.'),
             captureFull: z.boolean().optional().describe('Result capture: all monitors.'),
             captureMaxWidth: z
@@ -411,6 +541,20 @@ export function registerDesktopTools(reg: SurfaceRegistrar): void {
             captureCrop: cropArg.optional().describe('Result crop in the input frame.')
           })
           .superRefine((input, ctx) => {
+            const decisionActions = input.actions.filter((action) =>
+              action.type !== 'wait' &&
+              action.type !== 'read_clipboard' &&
+              action.type !== 'write_clipboard' &&
+              action.type !== 'move' &&
+              action.type !== 'focus'
+            );
+            if (decisionActions.length > 1) {
+              ctx.addIssue({
+                code: 'custom',
+                path: ['actions'],
+                message: 'Use one UI-changing decision per computer call; focus/move/wait/clipboard setup may accompany it.'
+              });
+            }
             if (input.verify) {
               const needsWindow = input.verify.until === 'foreground';
               const needsMatch = input.verify.until !== 'foreground';
@@ -432,7 +576,13 @@ export function registerDesktopTools(reg: SurfaceRegistrar): void {
               }
             }
             const verifyCapture = input.verify?.capture === 'always' || input.verify?.capture === 'on_change';
-            const willCapture = input.captureAfter === true || verifyCapture;
+            const autoCapture =
+              caps.screen &&
+              input.captureAfter !== false &&
+              input.actions.some((action) =>
+                action.type !== 'wait' && action.type !== 'read_clipboard' && action.type !== 'write_clipboard' && action.type !== 'move'
+              );
+            const willCapture = input.captureAfter === true || verifyCapture || autoCapture;
             const captureFields = ['captureWindow', 'captureFull', 'captureMaxWidth', 'captureCrop'] as const;
             if (!willCapture) {
               for (const field of captureFields) {
@@ -457,16 +607,13 @@ export function registerDesktopTools(reg: SurfaceRegistrar): void {
           .strict(),
         annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }
       },
-      async ({ actions, frameId, verify, captureAfter, captureWindow, captureFull, captureMaxWidth, captureCrop }) =>
+      async ({ actions, frameId, targetWindow, verify, captureAfter, captureWindow, captureFull, captureMaxWidth, captureCrop }) =>
         guard('computer', async () => {
           // Not reg.guarded: this tool covers two permissions. Pointer and keyboard steps
           // need "control", the clipboard steps need their own, and one blanket refusal
           // would hide which of them the user actually has to switch on.
           if (!caps.control && actions.some((a) => a.type !== 'wait' && !a.type.endsWith('_clipboard'))) {
-            return fail(
-              'TOOL_DISABLED: mouse and keyboard control is disabled by the current Chat On Steroids permissions. ' +
-                'Ask the user to enable "Control mouse and keyboard" in the app, then retry.'
-            );
+            return fail(toolDisabledMessage(ctx.readOnly, 'control', 'mouse and keyboard control', 'Control mouse and keyboard'));
           }
           const parsed: Action[] = [];
           for (const a of actions) {
@@ -507,13 +654,13 @@ export function registerDesktopTools(reg: SurfaceRegistrar): void {
                 // schema is cached by ChatGPT, and a tool that quietly changes shape when
                 // a checkbox moves is worse than one that says plainly it is switched off.
                 if (!caps.clipboardRead) {
-                  return fail('TOOL_DISABLED: read_clipboard needs the Read the clipboard permission.');
+                  return fail(toolDisabledMessage(ctx.readOnly, 'clipboardRead', 'read_clipboard', 'Read the clipboard'));
                 }
                 parsed.push({ type: 'read_clipboard' });
                 break;
               case 'write_clipboard':
                 if (!caps.clipboardWrite) {
-                  return fail('TOOL_DISABLED: write_clipboard needs the Replace clipboard text permission.');
+                  return fail(toolDisabledMessage(ctx.readOnly, 'clipboardWrite', 'write_clipboard', 'Replace clipboard text'));
                 }
                 parsed.push({ type: 'write_clipboard', text: a.text });
                 break;
@@ -524,7 +671,11 @@ export function registerDesktopTools(reg: SurfaceRegistrar): void {
           logInfo(`tool computer ${parsed.map((a) => a.type).join(', ')}`);
           noteDetail(parsed.map((a) => a.type).join(', '));
           const verifyCapture = verify?.capture === 'always' || verify?.capture === 'on_change';
-          const wantsCapture = captureAfter === true || verifyCapture;
+          const mutatesDesktop = parsed.some((action) =>
+            action.type !== 'wait' && action.type !== 'read_clipboard' && action.type !== 'write_clipboard' && action.type !== 'move'
+          );
+          const autoCapture = caps.screen && captureAfter !== false && mutatesDesktop;
+          const wantsCapture = captureAfter === true || verifyCapture || autoCapture;
           if ((verify || wantsCapture) && !caps.screen) {
             return fail('TOOL_DISABLED: verification and result capture need the See the screen permission.');
           }
@@ -543,25 +694,30 @@ export function registerDesktopTools(reg: SurfaceRegistrar): void {
             : undefined;
           // One lock, one operation: the picture that verifies these actions must be taken
           // before anyone else can touch the desktop.
-          const result = await actAndCapture(parsed, {
+          const result = await withBrowserInputHint(parsed, targetWindow, () => actAndCapture(parsed, {
             frameId,
+            targetWindow,
             verify: parsedVerify,
             capture:
               wantsCapture
                 ? {
-                    window: captureWindow,
+                    window: captureWindow ?? (captureFull === true || captureCrop !== undefined ? undefined : targetWindow),
                     full: captureFull,
-                    maxWidth: captureMaxWidth,
+                    maxWidth: captureMaxWidth ?? (autoCapture ? 1600 : undefined),
                     crop: captureCrop,
-                    preferActiveWindow: ctx.privacyScreenshots
+                    preferActiveWindow:
+                      ctx.privacyScreenshots ||
+                      (autoCapture && captureWindow === undefined && targetWindow === undefined && captureFull !== true && captureCrop === undefined)
                   }
                 : undefined
-          });
+          }));
           const cursor = result.cursor;
           const pointer = cursor
             ? cursor.image
               ? `Pointer image: ${cursor.image.x},${cursor.image.y} (frame ${cursor.frameId}, ${cursor.imageSize?.width}x${cursor.imageSize?.height}); desktop: ${cursor.screen.x},${cursor.screen.y}.`
-              : `Pointer desktop: ${cursor.screen.x},${cursor.screen.y}. No screenshot frame is active.`
+              : cursor.frameId === null
+                ? `Pointer desktop: ${cursor.screen.x},${cursor.screen.y}. No screenshot frame is active.`
+                : `Pointer desktop: ${cursor.screen.x},${cursor.screen.y}. It is outside frame ${cursor.frameId}, so it has no position in that image.`
             : 'Pointer position was not queried because this batch used only local wait/clipboard actions.';
           // Clipboard reads are the one action that returns something, so they are quoted
           // back in order rather than folded into the "Done:" line.
@@ -588,7 +744,36 @@ export function registerDesktopTools(reg: SurfaceRegistrar): void {
           const verified = result.verification
             ? `\nVerified ${result.verification.until} in ${result.verification.elapsedMs} ms: ${result.verification.detail}.`
             : '';
-          const done = `Done ${result.completedCount}/${parsed.length} via ${routeSummary}: ${parsed.map((a) => a.type).join(', ')}. ${pointer}${clipboard ? `\n${clipboard}` : ''}${verified}`;
+          const captureFallback = result.captureFallback ? `\nCapture note: ${result.captureFallback}.` : '';
+          // A scroll that reports only "sent" cannot be told apart from an application ignoring
+          // the wheel — and the window server delivers a wheel to whatever is under the pointer,
+          // which need not be the leased window. So say where it landed and whether it travelled.
+          const scroll = result.scroll
+            ? `
+Scroll: ${
+                result.scroll['reachedTarget'] === false
+                  ? `the wheel went to another window (${String(result.scroll['hitRole'] ?? 'unknown role')}, pid ${String(result.scroll['hitPid'] ?? '?')}), not the one leased`
+                  : `reached the leased window (${String(result.scroll['hitRole'] ?? 'unknown role')})`
+              }; ${
+                result.scroll['moved'] === true
+                  ? `it moved, ${String(result.scroll['positionBefore'])} → ${String(result.scroll['positionAfter'])}`
+                  : result.scroll['moved'] === false
+                    ? `nothing moved, still at ${String(result.scroll['positionAfter'])}`
+                    : `whether it moved is unreadable (${String(result.scroll['movedUnknown'] ?? 'no scroller')})`
+              }. ${JSON.stringify(result.scroll)}`
+            : '';
+          // Same reasoning as scroll's `moved`: a click_ref's semantic press can report success
+          // at the accessibility-API level while the control it named never actually changed —
+          // measured against a real System Settings toggle that answered success and stayed put
+          // until a coordinate click on the same spot moved it. Silence here would let that
+          // recur unnoticed on every other control shaped like it.
+          const uiChange =
+            result.uiChanged === true
+              ? '\nClick: the control’s reported value changed.'
+              : result.uiChanged === false
+                ? '\nClick: the accessibility action reported success, but the control’s reported value did not change. Try clicking the same coordinates instead.'
+                : '';
+          const done = `Done ${result.completedCount}/${parsed.length} via ${routeSummary}: ${parsed.map((a) => a.type).join(', ')}. ${pointer}${clipboard ? `\n${clipboard}` : ''}${verified}${captureFallback}${scroll}${uiChange}`;
           const shot = result.screenshot;
           if (shot) {
             return desktopImageResult(
@@ -599,8 +784,10 @@ export function registerDesktopTools(reg: SurfaceRegistrar): void {
           return ok(done);
         })
     );
+
   }
 }
+
 
 function prefix(note: string | null, body: string): string {
   return note ? `${note}\n\n${body}` : body;

--- a/test/computer-generation.test.ts
+++ b/test/computer-generation.test.ts
@@ -135,7 +135,14 @@ describe.each(['stdio', 'addon'] as const)('Desktop reply provenance (%s)', (tra
     await computer.screenshot({ window: 77 });
     await replace();
     expect((await computer.findUi({ window: 77 })).elements[0]).toMatchObject({ imageBounds: null, imageCenter: null });
-    expect((await computer.act([{ type: 'type', text: 'example' }])).cursor).toMatchObject({ image: null, frameId: null });
+    // `targetWindow` is this branch's addition, not upstream's. Physical pointer and application
+    // text mutations require a proven destination here — INPUT_TARGET_REQUIRED — so a bare `type`
+    // is refused before it reaches the code this test is about. The subject is the pointer
+    // report's frame binding, and the action is only a way to get a cursor back, so naming the
+    // window the screenshot above already used keeps the subject intact rather than weakening a
+    // fence to suit a test.
+    expect((await computer.act([{ type: 'type', text: 'example' }], { targetWindow: 77 })).cursor)
+      .toMatchObject({ image: null, frameId: null });
   });
 
   it('refuses crops expressed in an earlier helper frame', async () => {

--- a/test/computer-partial-batch.test.ts
+++ b/test/computer-partial-batch.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const fake = vi.hoisted(() => {
+  // The desktop helper process is fully mocked in this unit test. On a real macOS
+  // runner the production locator still requires an existing executable before it
+  // reaches mocked spawn(), so point the explicit test override at Node itself.
+  // Production behavior is unchanged: packaged/dev helpers must still exist.
+  process.env.COS_MACOS_DESKTOP_HELPER = process.execPath;
   type Listener = { fn: (...args: any[]) => void; once: boolean };
   class Emitter {
     private readonly listeners = new Map<string, Listener[]>();
@@ -90,7 +95,7 @@ describe('desktop partial batch result', () => {
       act([
         { type: 'type', text: 'first' },
         { type: 'type', text: 'second' }
-      ])
+      ], { targetWindow: 42 })
     ).rejects.toMatchObject({
       completedCount: 1,
       failedIndex: 1,
@@ -113,7 +118,7 @@ describe('desktop partial batch result', () => {
       act([
         { type: 'type', text: 'first' },
         { type: 'type', text: 'second' }
-      ])
+      ], { targetWindow: 42 })
     ).rejects.toMatchObject({
       completedCount: 1,
       failedIndex: 1,

--- a/test/computer-swapped-buttons.test.ts
+++ b/test/computer-swapped-buttons.test.ts
@@ -68,8 +68,11 @@ describe('a swapped-button mouse still gets a primary click (issue #76)', () => 
       const start = HELPER_SCRIPT.indexOf(caller);
       expect(start, `${caller} should still exist`).toBeGreaterThan(-1);
       const body = HELPER_SCRIPT.slice(start, start + 600);
+      // The trailing out-param is optional on purpose: the side buttons (back/forward) are one
+      // event pair distinguished by mouseData, so ButtonFlags also hands back that word. What is
+      // being asserted is the delegation, not the arity.
       expect(body, `${caller} should ask ButtonFlags rather than choosing flags itself`)
-        .toMatch(/ButtonFlags\(button, out down, out up\)/);
+        .toMatch(/ButtonFlags\(button, out down, out up(?:, out data)?\)/);
     }
     // And the click_ref fallback goes through Click, so it inherits the same decision.
     expect(HELPER_SCRIPT).toMatch(/\[Clf\]::Click\(/);

--- a/test/computer.test.ts
+++ b/test/computer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import {
   act,
   actAndCapture,
@@ -13,6 +13,34 @@ import {
 import { IS_WINDOWS } from './helpers.js';
 
 describe.runIf(IS_WINDOWS)('desktop helper', () => {
+  /**
+   * Pay the helper's cold start once, outside any test that is measured.
+   *
+   * Starting it is a process launch on a hosted Windows runner, behind whatever antivirus that
+   * image runs, and it is not the subject of a single test here. It overran the 15 s default on
+   * one CI run and failed exactly the first two tests in this block, while the other eighteen —
+   * which found the helper already warm — passed. Raising each test's limit would have hidden
+   * that; taking the launch out of the measured region means every test below still asserts
+   * against the default, about its own subject.
+   */
+  beforeAll(async () => {
+    // The helper's own deadline is shorter than this hook's budget, so a cold start that
+    // overruns it rejects here while most of the 120 s is still unspent — and a failed
+    // beforeAll skips all twenty tests and reports the block as failed, which is how a slow
+    // runner turned into a red check with nothing actually broken. Keep launching while the
+    // budget lasts, and only for the timeout: any other answer is real and still fails at once.
+    const deadline = Date.now() + 90_000;
+    for (;;) {
+      try {
+        await listWindows();
+        return;
+      } catch (error) {
+        const timedOut = /did not answer in time/i.test(String((error as Error)?.message ?? error));
+        if (!timedOut || Date.now() >= deadline) throw error;
+      }
+    }
+  }, 120_000);
+
   // A hosted runner can have no visible desktop window at all, and getWindowState is right
   // to answer that with WINDOW_NOT_FOUND — that is the production semantic, not a bug to
   // work around here. The tests below are about what a window state *says* once there is a
@@ -97,7 +125,18 @@ describe.runIf(IS_WINDOWS)('desktop helper', () => {
   });
 
   it('queries Windows UI Automation without requiring a screenshot', async () => {
-    const result = await findUi({ role: 'Button', maxResults: 5 });
+    // A cold, loaded build machine can spend longer walking the UI Automation tree than the
+    // product allows find_ui — eight seconds, plus ten while the helper is still starting. The
+    // same commit passed on the Windows arm64 runner and timed out on the x64 one within one
+    // release build, which is a statement about the machine, not the code. This test is about
+    // the shape of the answer, so it retries the timeout and only the timeout; anything else
+    // still fails immediately. Raising the product's budget to suit a build machine would make
+    // every real user wait longer for a list of controls.
+    const query = () => findUi({ role: 'Button', maxResults: 5 });
+    const result = await query().catch((error: unknown) => {
+      if (!/did not answer in time/i.test(String((error as Error)?.message ?? error))) throw error;
+      return query();
+    });
     expect(result.window).toBeGreaterThan(0);
     expect(Array.isArray(result.elements)).toBe(true);
     expect(result.elements.length).toBeLessThanOrEqual(5);

--- a/test/kernel-tool-disabled-message.test.ts
+++ b/test/kernel-tool-disabled-message.test.ts
@@ -1,0 +1,32 @@
+/**
+ * `toolDisabledMessage` naming the actual switch to flip.
+ *
+ * QA measured `observe` refused with Desktop switched off — `guarded()` is the one call site
+ * that has never passed a `settingLabel` — and got "is disabled by the current Chat On Steroids
+ * permissions. Ask the user to enable the permission in the app", which names nothing. Read-only
+ * already gets a message that names itself; the plain-capability branch did not.
+ */
+import { describe, expect, it } from 'vitest';
+import { toolDisabledMessage } from '../src/main/mcp/kernel.js';
+
+describe('toolDisabledMessage', () => {
+  it("names the capability's own Settings label when the caller supplies none", () => {
+    const message = toolDisabledMessage(false, 'screen', 'observe');
+    expect(message).toContain('enable "See the screen"');
+    expect(message).not.toContain('enable the permission');
+  });
+
+  it('still honours an explicit label over the capability default', () => {
+    // apply_patch's own call site passes 'changing files' deliberately, since the tool
+    // covers create/edit/move/delete together and 'create files' alone would be too narrow.
+    const message = toolDisabledMessage(false, 'create', 'apply_patch', 'changing files');
+    expect(message).toContain('enable "changing files"');
+    expect(message).not.toContain('Create files');
+  });
+
+  it('keeps naming Read-only, not the individual capability, when Read-only is what disabled it', () => {
+    const message = toolDisabledMessage(true, 'control', 'browser');
+    expect(message).toContain('Read-only mode is on');
+    expect(message).not.toContain('Control mouse and keyboard');
+  });
+});

--- a/test/macos-desktop-hardening.test.ts
+++ b/test/macos-desktop-hardening.test.ts
@@ -8,6 +8,48 @@ const computer = readFileSync(path.join(process.cwd(), 'src/main/computer/index.
 const desktopTools = readFileSync(path.join(process.cwd(), 'src/main/mcp/tools-desktop.ts'), 'utf8');
 
 describe('macOS desktop safety hardening', () => {
+  /**
+   * A window in motion is told it is moving, not that it has no accessibility representation.
+   *
+   * Accessibility windows are matched to screen windows by geometry when the exact id is not
+   * offered. The row is scanned at one instant and the AX bounds are read at another, so a window
+   * being dragged between the two matches nothing — the rectangles describe it at different
+   * moments. QA reached this by capturing a window while moving it and was told "no accessibility
+   * window convincingly matches", which reads as a window that has no accessibility tree at all
+   * and sends someone to check a permission that was never involved.
+   *
+   * The second read is the fix, not the message: a window that has come to rest matches on it and
+   * the caller never learns there was a race at all.
+   */
+  it('looks again with the bounds a moved window has now', () => {
+    expect(swift).toMatch(/if let fresh = windowRow\(row\.id\), fresh\.bounds != row\.bounds \{/);
+    expect(swift).toContain('"WINDOW_MOVING"');
+    expect(swift).toMatch(/WINDOW_MOVING[\s\S]{0,200}moved while its accessibility tree was being read/);
+    // And the old answer survives for the case it was actually about: no match, no movement.
+    expect(swift).toContain('no accessibility window convincingly matches window');
+  });
+
+  /**
+   * A refusal to focus says which of the three facts disagreed.
+   *
+   * "the requested window could not be activated" is a sentence with no next step in it. QA hit
+   * it against a Chrome window plainly on screen, and answering why would have meant an
+   * instrumented build on the one machine that could reproduce it — for a fact the helper had
+   * already computed and discarded.
+   *
+   * The diagnostic is deliberately a separate function. The fence stays exactly as it is,
+   * because it is what physical input is judged by and every clause of it is asserted above;
+   * a message must never be the thing deciding whether input is sent.
+   */
+  it('names the clause that refused a focus request', () => {
+    expect(swift).toContain('private func inputTargetRefusal');
+    // The reason is read first and then quoted into the message, so it precedes it.
+    expect(swift).toMatch(/inputTargetRefusal\)[\s\S]{0,200}FOCUS_FAILED/);
+    // The fence still decides; the diagnostic only explains.
+    expect(swift).toMatch(/guard try focusWindow\(requested\) else \{/);
+    expect(swift).not.toMatch(/if inputTargetRefusal\([\s\S]{0,60}== nil/);
+  });
+
   it('requires exact Workspace, WindowServer and AX agreement for physical input', () => {
     expect(swift).toContain('private func windowServerFrontWindowID');
     expect(swift).toContain('private func focusedAXWindowID');
@@ -15,16 +57,92 @@ describe('macOS desktop safety hardening', () => {
     expect(swift).toContain('private func assertInputTarget');
     expect(swift).toContain('private func assertFrameTarget');
     expect(swift).toMatch(/private func inputTargetMatches[\s\S]*frontmostPID\(\) == row\.pid/);
-    expect(swift).toMatch(/private func inputTargetMatches[\s\S]*windowServerFrontWindowID\(rows: rows\) == row\.id/);
-    expect(swift).toMatch(/private func inputTargetMatches[\s\S]*focusedAXWindowID\(for: row\.pid, rows: rows\) == row\.id/);
-    expect(swift).toMatch(/private func inputTargetMatches[\s\S]*focusedAXElementWindowID\(for: row\.pid, rows: rows\) == row\.id/);
+    expect(swift).toMatch(
+      /private func inputTargetMatches[\s\S]*frontWindowID\(rows: rows, focusedWindow: focused\) == row\.id/
+    );
+    expect(swift).toMatch(/private func inputTargetMatches[\s\S]*guard focused == row\.id else \{ return false \}/);
+    expect(swift).toMatch(/private func inputTargetMatches[\s\S]*guard focusedAXElementWindowID\(for: row\.pid, rows: rows\) == row\.id/);
+    // frontWindowID is still WindowServer z-order; it only resolves which of one app's own
+    // windows is front. All four clauses above still have to agree.
+    expect(swift).toMatch(/private func frontWindowID[\s\S]*windowServerFrontWindowID\(rows: rows\)/);
+  });
+
+  /**
+   * QA hit `No foreground window` while Chrome was plainly the active application, twice in a
+   * row, with Chrome's link-preview bubble (`175x22` at the screen edge) and its omnibox popup
+   * on top. Both are ordinary layer-0 windows of the browser, so WindowServer's topmost window
+   * was the bubble while AX focus — and the user's typing — was the real window. The mismatch
+   * was read as "an app transition is in flight" and everything was refused, which also made
+   * `focusWindow` poll `inputTargetMatches` for a condition it could never satisfy.
+   *
+   * Only that intra-application case is resolved, and only in the frontmost application:
+   * a covering window owned by *another* process must still refuse.
+   */
+  it('resolves one app\'s transient child windows without relaxing cross-app refusal', () => {
+    expect(swift).toContain(
+      'private func frontWindowID(rows: [WindowRow], focusedWindow: CGWindowID? = nil) -> CGWindowID?'
+    );
+    // Another app on top: returned as-is, so the caller's frontmostPID check still refuses.
+    expect(swift).toContain(
+      'guard let topRow = rows.first(where: { $0.id == top }), frontmostPID() == topRow.pid else { return top }'
+    );
+    // AX only wins when it names a different window this same scan already saw and admitted.
+    // A caller that has already read the focused window hands it in, so the two of them cannot
+    // reach different conclusions from two reads taken moments apart — see the race below.
+    expect(swift).toContain(
+      'guard let focused = focusedWindow ?? focusedAXWindowID(for: topRow.pid, rows: rows),'
+    );
+    expect(swift).toContain(
+      'guard rows.contains(where: { $0.id == focused && $0.pid == topRow.pid }) else { return top }'
+    );
+    // Both readers go through it, so observation and input can never disagree about which
+    // window is front.
+    expect(swift).toMatch(/private func foregroundWindowID[\s\S]*guard let frontID = frontWindowID\(rows: rows, focusedWindow: focused\)/);
+    expect(swift).toMatch(/private func inputTargetMatches[\s\S]*guard frontWindowID\(rows: rows, focusedWindow: focused\) == row\.id/);
+    expect(swift).not.toMatch(/private func inputTargetMatches[\s\S]{0,200}windowServerFrontWindowID/);
+  });
+
+  /**
+   * QA hit `No foreground window` while Chrome was plainly the active application, twice in a
+   * row, with Chrome's link-preview bubble (`175x22` at the screen edge) and its omnibox popup
+   * on top. Both are ordinary layer-0 windows of the browser, so WindowServer's topmost window
+   * was the bubble while AX focus — and the user's typing — was the real window. The mismatch
+   * was read as "an app transition is in flight" and everything was refused, which also made
+   * `focusWindow` poll `inputTargetMatches` for a condition it could never satisfy.
+   *
+   * Only that intra-application case is resolved, and only in the frontmost application:
+   * a covering window owned by *another* process must still refuse.
+   */
+  it('resolves one app\'s transient child windows without relaxing cross-app refusal', () => {
+    expect(swift).toContain(
+      'private func frontWindowID(rows: [WindowRow], focusedWindow: CGWindowID? = nil) -> CGWindowID?'
+    );
+    // Another app on top: returned as-is, so the caller's frontmostPID check still refuses.
+    expect(swift).toContain(
+      'guard let topRow = rows.first(where: { $0.id == top }), frontmostPID() == topRow.pid else { return top }'
+    );
+    // AX only wins when it names a different window this same scan already saw and admitted.
+    // AX only wins when it names a different window this same scan already saw and admitted.
+    // A caller that has already read the focused window hands it in, so the two of them cannot
+    // reach different conclusions from two reads taken moments apart — see the race below.
+    expect(swift).toContain(
+      'guard let focused = focusedWindow ?? focusedAXWindowID(for: topRow.pid, rows: rows),'
+    );
+    expect(swift).toContain(
+      'guard rows.contains(where: { $0.id == focused && $0.pid == topRow.pid }) else { return top }'
+    );
+    // Both readers go through it, so observation and input can never disagree about which
+    // window is front.
+    expect(swift).toMatch(/private func foregroundWindowID[\s\S]*guard let frontID = frontWindowID\(rows: rows, focusedWindow: focused\)/);
+    expect(swift).toMatch(/private func inputTargetMatches[\s\S]*guard frontWindowID\(rows: rows, focusedWindow: focused\) == row\.id/);
+    expect(swift).not.toMatch(/private func inputTargetMatches[\s\S]{0,200}windowServerFrontWindowID/);
   });
 
   it('revalidates a window-bound frame at every physical mutation boundary', () => {
     expect(swift).toMatch(/case "move":[\s\S]*assertFrameTarget\(frame\)[\s\S]*movePointer/);
-    expect(swift).toMatch(/case "click", "double_click":[\s\S]*assertFrameTarget\(frame\)[\s\S]*targetWindow: frameWindow/);
+    expect(swift).toMatch(/case "click", "double_click":[\s\S]*assertFrameTarget\(frame\)[\s\S]*guard let target = leasedWindow[\s\S]*targetWindow: target/);
     expect(swift).toMatch(/case "scroll":[\s\S]*assertFrameTarget\(frame\)[\s\S]*event\.post/);
-    expect(swift).toMatch(/case "drag":[\s\S]*assertFrameTarget\(frame\)[\s\S]*targetWindow: frameWindow/);
+    expect(swift).toMatch(/case "drag":[\s\S]*assertFrameTarget\(frame\)[\s\S]*guard let target = leasedWindow[\s\S]*targetWindow: target/);
     expect(swift).toMatch(/private func click[\s\S]*assertInputTarget\(targetWindow\)/);
     expect(swift).toMatch(/private func drag[\s\S]*assertInputTarget\(targetWindow\)/);
   });
@@ -53,7 +171,11 @@ describe('macOS desktop safety hardening', () => {
     expect(swift).toContain('if globalShortcut { event.post(tap: .cghidEventTap) }');
     expect(swift).toContain('UI_ACTION_DISABLED');
     expect(swift).toContain('the referenced accessibility control is disabled');
-    expect(swift).toContain('axBool(element, kAXEnabledAttribute as CFString, default: false)');
+    // An explicit AXEnabled=false refuses every action. Silence defers to whether the value
+    // can be written, which is the same evidence for a click as for a write — see the dedicated
+    // test below for why the click half had to change.
+    expect(swift).toContain('let enabled = axOptionalBool(element, kAXEnabledAttribute as CFString)');
+    expect(swift).toContain('let permitted = enabled ?? axValueIsSettable(element)');
     expect(swift).toContain('["volumeup", "volumedown", "mute"]');
     expect(swift).toContain('(1...20).contains(value)');
   });
@@ -97,11 +219,11 @@ describe('macOS desktop safety hardening', () => {
 
   it('binds screen frames to the exact active-display topology', () => {
     expect(swift).toContain('private func sameDisplayTopology');
+    expect(swift).toContain('"displays": displayTopologyObject(finalDisplayRects)');
     expect(swift).toContain('let contentDisplayRects = content.displays.map(\\.frame)');
     expect(swift).toContain('sameDisplayTopology(displayRects, contentDisplayRects)');
     expect(swift).toContain('active display topology changed while screenshot capture was in progress');
     expect(swift).toContain('active display topology changed while screenshot was captured');
-    expect(swift).toContain('"displays": displayTopologyObject(displayRects)');
     expect(swift).toContain('active display topology changed after the screenshot');
     expect(computer).toContain('displayTopology: Rect[] | null');
     expect(computer).toContain('displays: frame.displayTopology');
@@ -114,7 +236,7 @@ describe('macOS desktop safety hardening', () => {
     expect(computer).toMatch(/screenshotFromReply\(reply, file, opts\.crop \? null : opts\.window \?\? null\)/);
     expect(computer).not.toContain('lastFrame?.windowId ?? null : cropFrame?.windowId');
     expect(computer).toContain("const frameWindow = captureMode === 'window' ? requestedWindow : null");
-    expect(computer).toContain('windowId: frame.windowId');
+    expect(computer).toContain('windowId: frameWindow');
     expect(computer).toContain("frame.captureMode !== 'screen_fallback'");
   });
 
@@ -131,11 +253,15 @@ describe('macOS desktop safety hardening', () => {
   });
 
   it('carries proven semantic and explicit focus targets into later keyboard input', () => {
-    expect(swift).toContain('var inputWindow = frameWindow');
-    expect(swift).toMatch(/case "click_ui", "set_value_ui":[\s\S]*inputWindow = actionWindow/);
-    expect(swift).toMatch(/case "type":[\s\S]*assertInputTarget\(inputWindow\)[\s\S]*targetWindow: inputWindow/);
-    expect(swift).toMatch(/case "keypress":[\s\S]*assertInputTarget\(inputWindow\)[\s\S]*targetWindow: inputWindow/);
-    expect(swift).toMatch(/case "focus":[\s\S]*inputWindow = requested/);
+    expect(swift).toContain('var leasedWindow = frameWindow ?? requestedTargetWindow');
+    expect(swift).toMatch(/case "click_ui", "set_value_ui":[\s\S]*leasedWindow = actionWindow/);
+    expect(swift).toMatch(
+      /case "type":[\s\S]*guard let target = leasedWindow[\s\S]*assertInputTarget\(target\)[\s\S]*targetWindow: target/
+    );
+    expect(swift).toMatch(
+      /case "keypress":[\s\S]*if let target = leasedWindow \{[\s\S]*assertInputTarget\(target\)[\s\S]*targetWindow: target/
+    );
+    expect(swift).toMatch(/case "focus":[\s\S]*leasedWindow = requested/);
   });
 
   it('publishes only the newest overlapping macOS permission refresh', () => {
@@ -148,5 +274,367 @@ describe('macOS desktop safety hardening', () => {
     expect(swift).toContain('Electron owns prompting through systemPreferences');
     expect(swift).not.toContain('AXIsProcessTrustedWithOptions');
     expect(swift).not.toContain('older unsigned/ad-hoc build');
+  });
+
+  it('keeps the fork targetWindow lease while preserving exact partial route evidence', () => {
+    expect(swift).toContain('var leasedWindow = frameWindow ?? requestedTargetWindow');
+    expect(swift).toContain('INPUT_TARGET_REQUIRED');
+    expect(computer).toContain('targetWindow: number | null');
+    expect(computer).toContain('readonly completedRoutes: ActionRoute[] | null');
+    expect(computer).toContain('function completedHelperRoutes');
+    expect(computer).toContain('const routeEvidence = exactRoutes');
+  });
+
+  it('bounds AX window copies and shares one native find_ui deadline', () => {
+    expect(swift).toContain('private func axElementValues');
+    expect(swift).toContain('axElementValues(app, attribute: kAXWindowsAttribute as CFString, limit: 64)');
+    expect(swift).not.toContain('windows.prefix(64)');
+    expect(swift).toContain('matchingAXWindow(_ row: WindowRow, deadline suppliedDeadline: TimeInterval? = nil)');
+    expect(swift).toContain('let root = try matchingAXWindow(row, deadline: deadline)');
+  });
+
+  it('keeps visible fallback pixels screen-bound and clamps edge coordinates', () => {
+    expect(computer).toContain("const frameWindow = captureMode === 'window' ? requestedWindow : null");
+    expect(computer).toContain("frame.captureMode !== 'screen_fallback'");
+    expect(computer).toContain('const clampMappedCoordinate =');
+    expect(computer).toContain('INPUT_TARGET_UNPROVEN: visible screen_fallback pixels cannot authorize window-bound coordinate input');
+  });
+
+  it('bounds WindowServer strings and revalidates screen topology throughout long drags', () => {
+    expect(swift).toContain('let process = boundedAXString(string(item[kCGWindowOwnerName as String]');
+    expect(swift).toContain('let displayTitle = boundedAXString(title.isEmpty ?');
+    expect(swift).toContain('expectedDisplays: [CGRect]? = nil');
+    expect(swift).toContain('active display topology changed during the drag');
+    expect(swift).toContain('targetWindow: target,');
+    expect(swift).toContain('expectedDisplays: frameWindow == nil ? displayTopology(frame?["displays"]) : nil');
+    expect(swift).toMatch(/func assertDragTarget[\s\S]*assertInputTarget\(targetWindow\)[\s\S]*sameDisplayTopology\(expectedDisplays, currentDisplays\)/);
+  });
+
+  it('keeps valid screenshots when only AX semantic traversal is unavailable', () => {
+    // This test used to pin the list of codes that were let through, and pinning a list is what
+    // let the defect in: splitting `UIA_AMBIGUOUS_WINDOW` out of `UIA_FAILED` took the new code
+    // off the list, so a snapshot of a window that could not be told apart from another returned
+    // neither the tree nor the picture — while asking for the picture alone still worked. A test
+    // that enumerates cannot fail on a case nobody thought to enumerate. So it pins the property
+    // instead: the exception asks what the failure *is*.
+    expect(swift).toContain('} catch let error as HelperFailure where onlyTheTreeFailed(error.code) {');
+    // Only a target-identity failure invalidates the capture. Permission, a malformed tree, a
+    // timeout, an id belonging to another window, an ambiguous window — all leave an image that
+    // is still valid and still wanted, so none of them may appear in the refusing case.
+    expect(swift).toContain('    case "WINDOW_NOT_FOUND", "WINDOW_MOVING", "BAD_REQUEST":');
+    const decision = swift.slice(swift.indexOf('private func onlyTheTreeFailed'));
+    for (const treeOnly of [
+      'ACCESSIBILITY_PERMISSION_REQUIRED',
+      'UIA_FAILED',
+      'UIA_TIMEOUT',
+      'UIA_NO_OWN_WINDOW',
+      'UIA_AMBIGUOUS_WINDOW'
+    ]) {
+      expect(decision.slice(0, 400)).not.toContain(treeOnly);
+    }
+    // A window that is gone is named rather than described as an empty desktop: a caller that
+    // asked for one window in particular should not have to guess which of the two happened.
+    expect(swift).toContain('is no longer on screen');
+    expect(swift).not.toContain('no matching visible window is available');
+  });
+
+  /**
+   * The scroll-settle ceiling is read from the clock, not counted in requested microseconds.
+   *
+   * `settledScrollState`'s loop used to add the *requested* 10_000 µs to `elapsed` on every turn,
+   * never the time `usleep` had actually spent. A QA round measured `usleep(10_000)` costing a
+   * median 12.06 ms on real hardware — before a single AX read even ran — so the loop's own
+   * 120 ms ceiling was reached at 145–348 ms by the wall clock. `systemUptime` is the deadline
+   * idiom every other wait in this file already uses; this one now matches them.
+   */
+  it('settles a scroll against the clock, not a count of requested microseconds', () => {
+    expect(swift).toMatch(
+      /let deadline = ProcessInfo\.processInfo\.systemUptime \+ 0\.120\s*\n\s*while ProcessInfo\.processInfo\.systemUptime < deadline \{/
+    );
+    // The old accounting is gone outright, not left dead beside the fix.
+    expect(swift).not.toMatch(/elapsed:\s*useconds_t/);
+    expect(swift).not.toContain('elapsed += 10_000');
+  });
+
+  /**
+   * An unrecognized field is refused everywhere it is cheap to check, not just on `act`.
+   *
+   * `window` was fixed as its own case first, then `act` got a general stray-key check — and a
+   * QA round measured that the rule had still not reached anywhere else: `warm`, `cursor` and
+   * `windows` took any key at all and silently did nothing with it, answering `ok: true` for a
+   * field that was never read. This pins that the same shape of check now guards those three.
+   */
+  it('rejects an unrecognized field on warm, cursor and windows instead of silently ignoring it', () => {
+    expect(swift).toMatch(/operation == "warm" \|\| operation == "cursor"/);
+    expect(swift).toMatch(/request\.keys\.first\(where: \{ \$0 != "op" \}\)/);
+    expect(swift).toContain('It takes no fields beyond `op`. Nothing was done.');
+
+    expect(swift).toMatch(/if operation == "windows" \{[\s\S]{0,300}knownWindowsKeys/);
+    expect(swift).toContain('let knownWindowsKeys: Set<String> = ["op", "focusable"]');
+    expect(swift).toContain('windows does not recognize `\\(strayKey)`. It reads `focusable` only, besides `op`. Nothing was done.');
+
+    // Both new checks run before the switch that actually does the work, the same place the
+    // existing `act` check runs — a request refused here must not fall through and act anyway.
+    const beforeSwitch = swift.slice(swift.indexOf('private func handle('), swift.indexOf('var result: JSONObject = ["ok": true]'));
+    expect(beforeSwitch).toContain('operation == "warm" || operation == "cursor"');
+    expect(beforeSwitch).toContain('if operation == "windows" {');
+  });
+
+  it('retains the documented process-global AX timeout contract', () => {
+    expect(swift).toContain('let system = AXUIElementCreateSystemWide()');
+    expect(swift).toContain('AXUIElementSetMessagingTimeout(system, 1.0)');
+  });
+
+  /**
+   * The 2.0.2 release blocker: `pressKeys` read the active input source from the Node worker
+   * thread the addon is entered on. Text Services is main-queue-affine, so macOS did not
+   * return an error — `dispatch_assert_queue` failed and EXC_BREAKPOINT took the whole host
+   * process down, below anything Swift or JS could catch.
+   *
+   * This file cannot execute the addon, so it holds the shape of the fix: the Text Services
+   * calls appear only inside the main-queue read, the wait is bounded rather than
+   * `DispatchQueue.main.sync`, and the search that does not need main affinity stays off it.
+   */
+  it('reads the keyboard input source on the main queue, without sync or an unbounded wait', () => {
+    expect(swift).toContain('private func currentKeyboardLayout() -> KeyboardLayoutSnapshot?');
+    // Both Text Services calls live in that one function and nowhere else.
+    expect(swift.match(/TISCopyCurrentKeyboardLayoutInputSource/g)).toHaveLength(1);
+    expect(swift.match(/TISGetInputSourceProperty/g)).toHaveLength(1);
+    expect(swift).toMatch(
+      /private func currentKeyboardLayout\(\)[\s\S]*onMainQueue \{[\s\S]*TISCopyCurrentKeyboardLayoutInputSource[\s\S]*TISGetInputSourceProperty/
+    );
+
+    // The layout bytes are copied out: they belong to an input source released on return.
+    expect(swift).toContain('Data(bytes: bytes, count: CFDataGetLength(data))');
+    // UCKeyTranslate is pure over those bytes, so the 128-keycode search — the expensive
+    // half — stays out of the main-queue section and off the UI thread entirely.
+    expect(swift).toMatch(
+      /private func currentLayoutKey\(for logicalName: String, in snapshot: KeyboardLayoutSnapshot\)[\s\S]*UCKeyTranslate/
+    );
+    const hop = swift.slice(
+      swift.indexOf('private func onMainQueue'),
+      swift.indexOf('private let keyCodes')
+    );
+    expect(hop).not.toContain('UCKeyTranslate');
+  });
+
+  /**
+   * One marshal, used by everything that needs AppKit or Text Services from the addon's
+   * worker thread. A bounded, deadlock-free hop is exactly the primitive that must not exist
+   * in two slightly different copies.
+   */
+  it('marshals to the main queue once, inline when already there and never unbounded', () => {
+    expect(swift.match(/private func onMainQueue<Value>/g)).toHaveLength(1);
+    expect(swift).toContain('if Thread.isMainThread { return work() }');
+    // The call, not the prose: the function's own comment names it as the thing to avoid.
+    expect(swift).not.toMatch(/DispatchQueue\.main\.sync\s*[({]/);
+    expect(swift).toContain('private let mainQueueTimeout: TimeInterval = 2.0');
+    expect(swift).toContain('done.wait(timeout: .now() + mainQueueTimeout) == .success');
+    expect(swift).toContain('"the active keyboard layout could not be read in time"');
+    // Every AppKit/Text Services reader goes through it rather than dispatching its own.
+    expect(swift.match(/DispatchQueue\.main\.async/g)).toHaveLength(1);
+  });
+
+  /**
+   * The pointer has to be drawn into a window capture, because `showsCursor` cannot reach it.
+   *
+   * A desktop-independent window filter captures the window detached from the desktop, and the
+   * pointer is a display compositing layer rather than part of any window's content — so the
+   * flag is set and does nothing on exactly the path an ordinary `observe` on a window uses.
+   * Display capture keeps the system's own pointer, which is why only windows are composited.
+   */
+  it('composites the pointer into a window capture, at its hotspot', () => {
+    expect(swift).toContain('private func drawingPointer(on image: CGImage, region: CGRect) -> (CGImage, String)');
+    expect(swift).toMatch(
+      /private func captureWindow[\s\S]*SCContentFilter\(desktopIndependentWindow: window\)[\s\S]*drawingPointer\(on: resized, region: region\)/
+    );
+    // Read through the shared hop, because NSCursor is AppKit.
+    expect(swift).toMatch(/private func currentPointerImage\(\)[\s\S]*onMainQueue \{[\s\S]*NSCursor\.currentSystem/);
+    // At the hotspot — the pixel the pointer addresses — not the image origin.
+    expect(swift).toContain('let x = (location.x - pointer.hotSpot.x - region.minX) * scale');
+    expect(swift).toContain('let top = (location.y - pointer.hotSpot.y - region.minY) * scale');
+    // A pointer that is not over this window is not drawn onto it.
+    expect(swift).toContain('region.contains(location)');
+    // Display capture still gets the system pointer, and must not be composited twice.
+    expect(swift.match(/configuration\.showsCursor = true/g)).toHaveLength(2);
+    expect(swift).not.toMatch(/private func captureDisplay[\s\S]{0,600}drawingPointer/);
+  });
+
+  /**
+   * A pointer missing from a window screenshot looks the same whichever reason caused it, and
+   * that ambiguity already cost one round of guessing at which. So each way of drawing nothing
+   * names itself, and the reason reaches the response — the only place a person reading a QA
+   * report can see it.
+   */
+  /**
+   * A drag has to look like a drag to the system that decides what a drag means.
+   *
+   * QA dragged a file in Finder three times, was told "Done" three times, and the file never
+   * moved. The events were posted; nothing read them as a drag. AppKit distinguishes a press
+   * that begins a drag session from one that is merely a click by whether the press settles and
+   * whether the pointer then travels continuously past a threshold — and the old code pressed,
+   * jumped straight to the destination, and released. Two waypoints are a teleport.
+   *
+   * Reported success without effect is worse than a clean failure, because a caller builds its
+   * next decision on a world state that never happened.
+   */
+  /**
+   * The focused window is read once per decision, not twice.
+   *
+   * frontWindowID reads AX focus to resolve an application's transient child windows, and both
+   * of its callers then read the same fact again to check the two agree. Between those reads
+   * focus can move — a bubble opens, a popup closes — and a second answer disagreeing with the
+   * first was treated as an app transition in flight. QA saw both halves of that: `No foreground
+   * window` while Chrome plainly occupied the screen, and FOCUS_FAILED against a window that was
+   * visibly active, because focusWindow polls the input fence and could never satisfy a
+   * condition that was partly a race.
+   *
+   * Every clause still has to hold. They just judge one observation instead of two.
+   */
+  /**
+   * The active application is read fresh, not from a cache nobody refills.
+   *
+   * NSWorkspace serves frontmostApplication from a running-applications cache that AppKit keeps
+   * current by delivering notifications on a run loop. The standalone helper has none — it reads
+   * commands with readLine() on the main thread and never returns to one — so the cache was
+   * fixed at first access and every application launched afterwards stayed invisible to it, for
+   * the life of the process. The app runs one long-lived helper, which made that permanent.
+   *
+   * QA reproduced it with two helpers on one desktop: the one that had queried before TextEdit
+   * launched reported no foreground window and kept doing so, while a freshly started one was
+   * correct throughout. Window enumeration was unaffected either way, because that goes through
+   * CGWindowListCopyWindowInfo — hence a window listed, capturable and plainly in front that
+   * nothing would call foreground.
+   *
+   * This is a second, independent cause of the same symptom as the transient child-window case.
+   * Fixing that one did not touch this one.
+   */
+  /**
+   * "Nothing is in front" and "I am in front" are different answers.
+   *
+   * The helper excludes its own process from window enumeration on purpose — the model must not
+   * be able to drive the app that is driving it — and in a packaged build the helper runs inside
+   * that app, so every Chat On Steroids window disappears. Correct, but it made foreground
+   * resolution answer nothing whenever the app itself was frontmost, which reads as the defect
+   * QA reported rather than as the refusal it is.
+   */
+  it('says when the frontmost application is the one it may not drive', () => {
+    expect(swift).toContain('result["foregroundIsSelf"] = frontmostPID() == getpid()');
+    // Both the cheap query and the one that carries a window report it.
+    expect(swift).toMatch(/case "cursor":[\s\S]{0,900}foregroundIsSelf/);
+    expect(swift).toMatch(/case "active":[\s\S]{0,200}foregroundIsSelf/);
+    // The exclusion itself is unchanged; this only describes it.
+    expect(swift).toContain('pid != ownPid');
+  });
+
+  it('reads the frontmost application fresh rather than from a frozen cache', () => {
+    expect(swift).toMatch(
+      /private func frontmostPID\(\) -> pid_t\? \{[\s\S]{0,400}CFRunLoopRunInMode\(\.defaultMode, 0, true\)/
+    );
+    // Bounded and non-blocking: a zero timeout returns at once when nothing is pending, and the
+    // pass count is capped so a busy run loop cannot hold a command hostage.
+    expect(swift).toContain('while drained < 32, CFRunLoopRunInMode(.defaultMode, 0, true) == .handledSource');
+    // Behind the main-queue hop, like every other AppKit read in this file, and reached only
+    // after the drain — an unguarded call elsewhere would reintroduce the stale answer.
+    expect(swift).toMatch(/private func frontmostPID[\s\S]{0,900}onMainQueue \{/);
+    expect(swift).toMatch(
+      /CFRunLoopRunInMode[\s\S]{0,200}NSWorkspace\.shared\.frontmostApplication\?\.processIdentifier/
+    );
+  });
+
+  it('judges one reading of the focused window, not two', () => {
+    expect(swift).toMatch(
+      /private func foregroundWindowID[\s\S]*let focused = AXIsProcessTrusted\(\) \? focusedAXWindowID\(for: pid, rows: rows\) : nil/
+    );
+    expect(swift).toMatch(
+      /private func foregroundWindowID[\s\S]*frontWindowID\(rows: rows, focusedWindow: focused\)/
+    );
+    expect(swift).toMatch(/private func foregroundWindowID[\s\S]*if let focused, focused != front\.id \{ return nil \}/);
+    // The input fence reads once as well, and still requires all of its clauses.
+    expect(swift).toMatch(
+      /private func inputTargetMatches[\s\S]*let focused = focusedAXWindowID\(for: row\.pid, rows: rows\)/
+    );
+    expect(swift).toMatch(
+      /private func inputTargetMatches[\s\S]*frontWindowID\(rows: rows, focusedWindow: focused\) == row\.id/
+    );
+    expect(swift).toMatch(
+      /private func inputTargetMatches[\s\S]*focusedAXElementWindowID\(for: row\.pid, rows: rows\) == row\.id/
+    );
+  });
+
+  it('paces a drag so the system reads it as one, rather than as a click', () => {
+    expect(swift).toContain('private let dragPressHoldMicroseconds');
+    expect(swift).toContain('private let dragDropDwellMicroseconds');
+    expect(swift).toContain('private func dragSteps(from start: CGPoint, to end: CGPoint, steps: Int)');
+    // Hold after the press, travel, then dwell before releasing — in that order.
+    expect(swift).toMatch(
+      /postMouse\(down[\s\S]*usleep\(dragPressHoldMicroseconds\)[\s\S]*dragSteps\(from: current[\s\S]*usleep\(dragDropDwellMicroseconds\)[\s\S]*postMouse\(up/
+    );
+    // Every interpolated event still re-proves the target; pacing must not cost the fence.
+    expect(swift).toMatch(/for step in dragSteps[\s\S]{0,200}try assertDragTarget\(\)/);
+    // Bounded for the whole path, not per hop. Per hop, a 64-waypoint drag could spend two
+    // minutes inside a 15-second parent deadline — and a helper killed there never reaches the
+    // release, leaving the button logically held down.
+    expect(swift).toContain('private let dragMaxTotalSteps = 180');
+    expect(swift).toContain('private func dragStepBudget(_ points: [CGPoint]) -> [Int]');
+    expect(swift).toMatch(/guard wantedTotal > dragMaxTotalSteps, total > 0 else \{ return wanted \}/);
+    expect(swift).not.toMatch(/min\(count, 240\)/);
+  });
+
+  it('says why no pointer was drawn, instead of drawing nothing silently', () => {
+    for (const reason of ['unavailable', 'outside_region', 'buffer_unavailable', 'drawn']) {
+      expect(swift).toContain(`"${reason}"`);
+    }
+    // The system draws the pointer for a display filter, so those paths say so rather than
+    // claiming this code drew it.
+    expect(swift).toMatch(/pointerNote = "system"/);
+    // And it is actually reported, not just computed.
+    expect(swift).toContain('"pointer": pointerNote');
+    expect(swift).toMatch(/captureWindow[\s\S]{0,200}throws -> \(CGImage, CGRect, String\)/);
+  });
+
+  /**
+   * QA found a blank TextEdit document refused with UI_ACTION_DISABLED while physical typing
+   * into the same control worked. TextEdit's document AXTextArea publishes no AXEnabled
+   * attribute at all, and the gate read that silence as false.
+   *
+   * A value write has a stronger authority available — accessibility says directly whether
+   * AXValue can be written — so silence defers to that. Silence still refuses a click, and an
+   * explicit AXEnabled=false still refuses everything: a control that says it is disabled is
+   * disabled whatever it reports about settability.
+   */
+  it('lets a settable value speak for a control that publishes no AXEnabled, for click as well as write', () => {
+    expect(swift).toContain('private func axOptionalBool');
+    expect(swift).toContain('private func axValueIsSettable');
+    // The same evidence now answers for a click. QA found the other half of the defect: the
+    // very TextArea this fix made writable was still refused for click_ref, while a coordinate
+    // click focused it and typing worked. Silence alone still refuses — no AXEnabled and no
+    // settable value gets nothing — but silence next to a settable value is not a refusal.
+    expect(swift).toContain('let permitted = enabled ?? axValueIsSettable(element)');
+    expect(swift).not.toContain('(enabled ?? false)');
+    // Read once, before the branch, so the refusal cannot disagree with the write below it.
+    expect(swift).toMatch(
+      /let enabled = axOptionalBool\(element, kAXEnabledAttribute as CFString\)[\s\S]*guard permitted else \{[\s\S]*UI_ACTION_DISABLED/
+    );
+    expect(swift).toMatch(/if action == "set_value" \{\s*\n\s*guard axValueIsSettable\(element\),/);
+    // The generic helper keeps its old meaning for every other caller.
+    expect(swift).toContain('axOptionalBool(element, attribute) ?? fallback');
+  });
+
+  /**
+   * And the ordering the crash fix must not cost us: the layout is taken before any window
+   * authority is resolved, so the existing revalidations still sit immediately before the
+   * events they guard. Fixing a P1 crash must not open a wrong-window race.
+   */
+  it('takes the layout snapshot once, ahead of every target-window revalidation', () => {
+    expect(swift).toMatch(
+      /let layout = normalized\.contains \{ \$0\.count == 1 \} \? currentKeyboardLayout\(\) : nil\s*\n\s*let resolved = try normalized\.map \{ try resolveKey\(\$0, in: layout\) \}/
+    );
+    expect(swift).toMatch(
+      /let resolved = try normalized\.map \{ try resolveKey\(\$0, in: layout\) \}[\s\S]*if let targetWindow \{ targetPID = try assertInputTarget\(targetWindow\)\.pid \}/
+    );
+    expect(swift).toMatch(
+      /A window transition while modifiers are down must abort before the ordinary key\.\s*\n\s*if let targetWindow \{ targetPID = try assertInputTarget\(targetWindow\)\.pid \}/
+    );
   });
 });

--- a/test/macos-desktop-v16-followup.test.ts
+++ b/test/macos-desktop-v16-followup.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const source = (rel: string) => readFileSync(path.join(root, ...rel.split('/')), 'utf8');
+const swift = source('native/macos-desktop-helper/main.swift');
+const computer = source('src/main/computer/index.ts');
+
+describe('PR #28 v16 follow-up review fixes', () => {
+  it('does not retarget an explicit find_ui request to the foreground window', () => {
+    const start = swift.indexOf('private func findUI');
+    const body = swift.slice(start, start + 6000);
+    expect(body).toContain('else if let rawRequested = request["id"], !(rawRequested is NSNull)');
+    expect(body).toContain('WINDOW_NOT_FOUND');
+    expect(body.indexOf('let rawRequested = request["id"]')).toBeLessThan(body.indexOf('foregroundWindowID()'));
+  });
+
+  it('treats asynchronous capture as one exact display-topology epoch', () => {
+    expect(swift).toContain('let contentDisplayRects = content.displays.map(\\.frame)');
+    expect(swift).toContain('active display topology changed before screenshot capture began');
+    expect(swift).toContain('let finalDisplayRects = try activeDisplayRects()');
+    expect(swift).toContain('display topology changed while screenshot was captured');
+    expect(swift).toContain('displayTopologyObject(finalDisplayRects)');
+  });
+
+  it('does not label a visible-screen crop as a window frame, on any platform', () => {
+    // Keeping the source window id on a crop would let pixels from an occluding app authorize
+    // input against the covered window — true everywhere, not only on the one platform this
+    // used to carve out an exception for. The crop is always screen-bound now.
+    expect(computer).toMatch(/screenshotFromReply\(reply, file, opts\.crop \? null : opts\.window \?\? null\)/);
+    expect(computer).not.toContain('lastFrame?.windowId ?? null : cropFrame?.windowId');
+  });
+
+  it('prevalidates cross-window batches before their first side effect', () => {
+    expect(computer).toContain('if (targetCandidates.size > 1)');
+    expect(computer).toContain('TARGET_WINDOW_CONFLICT: this batch spans windows');
+  });
+});

--- a/test/macos-input-routing-v12.test.ts
+++ b/test/macos-input-routing-v12.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const source = (rel: string) => readFileSync(path.join(root, ...rel.split('/')), 'utf8');
+const swift = source('native/macos-desktop-helper/main.swift');
+const computer = source('src/main/computer/index.ts');
+const tools = source('src/main/mcp/tools-desktop.ts');
+const instructions = source('src/main/mcp/instructions.ts');
+const ci = source('.github/workflows/ci.yml');
+
+describe('macOS Computer Use v16 input routing', () => {
+  it('keeps the in-process Electron -> Worker -> N-API -> Swift production boundary', () => {
+    expect(computer).toContain('new Worker');
+    expect(computer).toContain('MacOSAddonRuntime');
+    expect(swift).toContain('#if COS_DESKTOP_ADDON');
+    expect(swift).toContain('@_cdecl("cos_desktop_handle_json")');
+  });
+
+  it('fails closed for physical mutations without an exact WindowLease', () => {
+    expect(computer).toContain('targetWindow?: number');
+    expect(computer).toContain('const inferredTargetWindow');
+    expect(computer).toContain('const requiresWindowLease');
+    expect(computer).toContain('INPUT_TARGET_REQUIRED: physical pointer and application text mutations require targetWindow');
+    expect(swift).toContain('var leasedWindow = frameWindow ?? requestedTargetWindow');
+    expect(swift).toContain('click input requires targetWindow');
+    expect(swift).toContain('scroll input requires targetWindow');
+    expect(swift).toContain('drag input requires targetWindow');
+    expect(swift).toContain('text input requires targetWindow');
+    expect(swift).toContain('keyboard input requires targetWindow');
+  });
+
+  it('carries a semantic ref target forward into following keyboard input', () => {
+    expect(swift).toMatch(/case "click_ui", "set_value_ui":[\s\S]*leasedWindow = actionWindow[\s\S]*case "type":[\s\S]*targetWindow: target/);
+    expect(computer).toContain('{ targetWindow: inferredTargetWindow }');
+  });
+
+  it('does not activate a window merely to validate its coordinate frame', () => {
+    const validate = swift.slice(swift.indexOf('private func validateFrame'), swift.indexOf('@discardableResult', swift.indexOf('private func validateFrame')));
+    expect(validate).not.toContain('focusWindow(windowID)');
+    expect(validate).not.toContain('assertFrameTarget(frame)');
+  });
+
+  it('exposes closed-loop targetWindow and automatic result capture', () => {
+    expect(tools).toContain('targetWindow: windowIdArg.optional()');
+    expect(tools).toContain('decisionActions.length > 1');
+    expect(tools).toContain('const autoCapture = caps.screen && captureAfter !== false && mutatesDesktop');
+    expect(tools).toContain('captureMaxWidth ?? (autoCapture ? 1600 : undefined)');
+    expect(computer).toContain('captureFallback');
+    expect(computer).toContain('capture.window = result.targetWindow');
+    expect(computer).toContain('targetWindow: inferredTargetWindow ?? null');
+    expect(instructions).toContain('pass the observed window id as targetWindow');
+  });
+
+  it('compiles both real macOS helper architectures in CI', () => {
+    expect(ci).toContain('node scripts/prepare-macos-desktop-helper.mjs --platform darwin --arch x64');
+    expect(ci).toContain('node scripts/prepare-macos-desktop-helper.mjs --platform darwin --arch arm64');
+  });
+});

--- a/test/macos-review-v16.test.ts
+++ b/test/macos-review-v16.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const source = (rel: string) => readFileSync(path.join(root, ...rel.split('/')), 'utf8');
+const swift = source('native/macos-desktop-helper/main.swift');
+const content = source('extension/content.js');
+const dom = source('extension/chatgpt-dom.js');
+const packageJson = source('package.json');
+
+describe('macOS review v16 and bootstrap send safety', () => {
+  it('keeps the current native safety boundaries and removes the undeclared Electron wrapper', () => {
+    expect(swift).toContain('AXUIElementSetMessagingTimeout');
+    expect(swift).toContain('sameDisplayTopology');
+    expect(swift).toContain('maxEncodedScreenshotBytes');
+    expect(swift).toContain('private func isSystemShortcut');
+    expect(swift).toContain('["volumeup", "volumedown", "mute"]');
+    expect(packageJson).not.toContain('"verify:ci": "install-electron --no');
+  });
+
+  it('replaces a stale bootstrap draft and verifies the exact text before Send', () => {
+    expect(content).toContain('const RECORDER_VERSION = 11');
+    // Unattended startup owns the composer on a redeemed command page: 2.0.6 settled this as
+    // an unconditional replace, so what protects the user is the send-time check below, not a
+    // refusal to write. See issue #30 for the setting that was proposed and not taken.
+    expect(content).toContain('CLF_DOM.insertPrompt(boot.text, true)');
+    expect(content).toContain('waitForRevivalSubmitReady(openedConversation, attempt)');
+    expect(content).toContain('the composer changed before bootstrap send; the draft was preserved');
+    expect(dom).toContain('function insertPrompt(value, mode = false)');
+    expect(dom).toContain('box.replaceChildren()');
+  });
+});

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -831,7 +831,11 @@ describe('surface boundaries', () => {
       const bytes = Buffer.byteLength(JSON.stringify(tool), 'utf8');
       const budget =
         tool.name === 'computer'
-          ? 6_000
+          // 6.0k to 6.3k with the macOS pointer work: drag now spells out its own step budget
+          // and scroll its fraction, rather than leaving either to a free-form number the model
+          // has to guess at. Raised deliberately and asserted separately from the surface total,
+          // so the next growth still has to argue for itself.
+          ? 6_300
           : tool.name === 'apply_patch'
             ? 5_000
             : tool.name === 'agents'
@@ -1605,7 +1609,7 @@ describe('desktop capabilities', () => {
       arguments: { actions: [{ type: 'write_clipboard', text: 'nope' }] }
     });
     expect(written.body.result?.isError).toBe(true);
-    expect(textOf(written)).toContain('Replace clipboard text permission');
+    expect(textOf(written)).toContain('"Replace clipboard text"');
   });
 
   it('marks observing read-only and control destructive', async () => {

--- a/test/tools-desktop-runtime.test.ts
+++ b/test/tools-desktop-runtime.test.ts
@@ -126,6 +126,105 @@ describe('Desktop computer browser chords', () => {
     expect(result.isError).toBeFalsy();
     expect(desktop.activeWindow).not.toHaveBeenCalled();
   });
+
+  /**
+   * The fence is right and the way out was unsaid.
+   *
+   * Desktop input cannot reach a web page with no focused control, because the click that would
+   * create the focus is the click being refused — the macOS helper carries a long note saying so
+   * and asking the next reader not to file it as a bug. But a QA run met these refusals five
+   * times in a row against a browser, re-observing and retrying between each, and its closing
+   * judgement was that the app's failures are loud, correct, and read as a pattern of not
+   * working. `browser` drives the page over CDP and needs none of this; the refusal now says so.
+   */
+  it('points a caller fenced out of a browser window at the browser tool', async () => {
+    desktop.actAndCapture.mockClear();
+    desktop.activeWindow.mockReset();
+    desktop.activeWindow.mockResolvedValue({ window: chrome, screen });
+    desktop.actAndCapture.mockRejectedValueOnce(
+      new desktop.ComputerError('PARTIAL_BATCH: completed_count=0 failed_index=0. INPUT_TARGET_LOST: window 41 is no longer the exact active input target')
+    );
+    const computer = desktopSurface({ control: true }).get('computer')!;
+
+    const result = await computer.handler({ actions: [{ type: 'click', x: 10, y: 10, frameId: 1 }] });
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text as string;
+    // The real refusal survives intact; the hint is added to it, never instead of it.
+    expect(text).toContain('INPUT_TARGET_LOST');
+    expect(text).toContain('completed_count=0');
+    expect(text).toContain('Build GTA Web Game - Google Chrome');
+    expect(text).toContain('browser tool');
+  });
+
+  /**
+   * The refusal that fires *before* the action, for the same reason.
+   *
+   * INPUT_TARGET_REQUIRED names its own remedy well — supply targetWindow, a frame, a ref, or
+   * focus in the batch — but every one of those is a way to aim desktop input at a page, and a QA
+   * round hit it twice in four minutes while driving a browser. Against a browser the better
+   * answer is not to aim desktop input at all.
+   */
+  it('points at the browser tool for the target-required refusal too', async () => {
+    desktop.actAndCapture.mockClear();
+    desktop.activeWindow.mockReset();
+    desktop.activeWindow.mockResolvedValue({ window: chrome, screen });
+    desktop.actAndCapture.mockRejectedValueOnce(
+      new desktop.ComputerError('PARTIAL_BATCH: completed_count=0 failed_index=0. INPUT_TARGET_REQUIRED: application keyboard input requires targetWindow')
+    );
+    const computer = desktopSurface({ control: true }).get('computer')!;
+
+    const result = await computer.handler({ actions: [{ type: 'type', text: 'hello' }] });
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text as string;
+    expect(text).toContain('INPUT_TARGET_REQUIRED');
+    expect(text).toContain('browser tool');
+  });
+
+  /** A capture whose geometry moved is an answer about the screenshot, not about aiming input. */
+  it('leaves a stale-frame refusal alone', async () => {
+    desktop.actAndCapture.mockClear();
+    desktop.activeWindow.mockReset();
+    desktop.activeWindow.mockResolvedValue({ window: chrome, screen });
+    desktop.actAndCapture.mockRejectedValueOnce(
+      new desktop.ComputerError('STALE_FRAME: window 11678 changed geometry before capture')
+    );
+    const computer = desktopSurface({ control: true }).get('computer')!;
+
+    const result = await computer.handler({ actions: [{ type: 'click', x: 10, y: 10, frameId: 1 }] });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('STALE_FRAME');
+    expect(result.content[0].text).not.toContain('browser tool');
+  });
+
+  it('adds no browser advice when the window is not a browser', async () => {
+    desktop.actAndCapture.mockClear();
+    desktop.activeWindow.mockReset();
+    desktop.activeWindow.mockResolvedValue({ window: notepad, screen });
+    desktop.actAndCapture.mockRejectedValueOnce(
+      new desktop.ComputerError('INPUT_TARGET_LOST: window 42 is no longer the exact active input target')
+    );
+    const computer = desktopSurface({ control: true }).get('computer')!;
+
+    const result = await computer.handler({ actions: [{ type: 'click', x: 10, y: 10, frameId: 1 }] });
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text as string;
+    expect(text).toContain('INPUT_TARGET_LOST');
+    expect(text).not.toContain('browser tool');
+  });
+
+  /** An unrelated failure is not an invitation to talk about browsers. */
+  it('leaves a refusal that is not an input fence untouched', async () => {
+    desktop.actAndCapture.mockClear();
+    desktop.activeWindow.mockReset();
+    desktop.activeWindow.mockResolvedValue({ window: chrome, screen });
+    desktop.actAndCapture.mockRejectedValueOnce(new desktop.ComputerError('CLIPBOARD_FAILED: nothing to read'));
+    const computer = desktopSurface({ control: true }).get('computer')!;
+
+    const result = await computer.handler({ actions: [{ type: 'click', x: 10, y: 10, frameId: 1 }] });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('CLIPBOARD_FAILED');
+    expect(result.content[0].text).not.toContain('browser tool');
+  });
 });
 
 describe('Desktop observe runtime contract', () => {


### PR DESCRIPTION
The native half split out of #78, as asked. 19 files, +3,596 / −230, no `docs/`, nothing about browser control.

@hhh2210 — this builds directly on the macOS backend from #28, so your read on the boundary would be worth more than mine.

### What changes

The helper drove input by asking AppKit to synthesise it. Enough to move a pointer and enough to look right in a screenshot, not enough for an application to believe: a drag arrived as a jump, a scroll as a single notch, and a click could land at a point the window had since moved away from.

- **Drag and scroll are spelled out.** An explicit step budget and pointer path instead of one synthesized move; scroll carries its own fraction. The pointer image is read back, so a reply can say what was actually under it.
- **Every physical mutation revalidates its window-bound frame.** A window that moved between observation and action refuses rather than hitting whatever is now at those coordinates.
- **Targeting is fail-closed.** Workspace, WindowServer and AX must agree before physical input is delivered. Explicit-UI and captured-pixel target identities stay apart instead of being merged. System shortcuts route globally; a disabled semantic control is refused. Screen frames bind to the exact active-display topology rather than assuming the primary display.

### Costs, stated

`computer`'s schema grows **6.0k → 6.3k bytes**, and the per-tool ceiling in `test/mcp.test.ts` is raised deliberately rather than the schema trimmed to fit. Spelling a step budget out is precisely what stops the model guessing at one, so the bytes buy something — but the number stays asserted separately from the surface total so the next growth has to argue for itself.

### Also here, because the tests bind it

The disabled-tool refusal now names the **permission** to turn on rather than the internal capability — the difference between a dead end and an instruction. It has its own test.

CI compiles the helper for **both** real macOS architectures, so an arm64-only build can no longer pass while x64 is broken.

### Verified, and its limit

Full suite **3,474 passed**. The macOS assertions here are source-inspection tests, which is how this repo already checks the Swift helper, so they run and pass on any platform — but I should be plain that **I have not run this on a Mac**. The behavioural claims come from the branch it was extracted from; what I verified is that the extraction is faithful and self-consistent.

The four remaining failures are `renderer-usage` (locale-dependent number formatting) and one `mcp` shell test, which fail identically on unmodified `main` on this Windows machine and pass in CI.

### Scope note

This is one capability area rather than one change, and it is large. If you would rather see it as separate pieces — the pointer/drag work, the fail-closed targeting, the display topology — say which cut you want and I will resubmit along it.