### PR TITLE
Find standard Windows uv installs without restarting CoS

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -31,6 +31,9 @@ refresh manually; the Plugins endpoint itself always serves the complete current
 - Pinned npm and Python recipes: Blender MCP, Knowledge Memory, Playwright Browser, Web Fetch and Unity Editor.
   Node.js/npm or Python/uv must be installed where the recipe requires them. CoS installs
   packages into private per-plugin directories and does not install missing system runtimes.
+  On Windows, the standard per-user uv directory (`%USERPROFILE%\.local\bin`) is also
+  searched, so installing uv there does not require restarting an already-running CoS.
+  For custom runtime locations, add the directory to PATH and restart CoS.
 - An executable with explicit arguments (no shell interpolation).
 - Remote Streamable HTTP MCP URLs, with HTTPS or loopback HTTP. Credentials use encrypted
   storage; do not embed them in URLs or arguments. HeyGen and Recraft use explicit browser OAuth

--- a/src/main/plugins/installer.ts
+++ b/src/main/plugins/installer.ts
@@ -12,7 +12,19 @@ import { envValue, pathEntries, setEnvValue } from '../env.js';
 /** One minimal environment for runtime discovery, installation and plugin startup. */
 export function pluginEnvironment(inherited = getDefaultEnvironment(), platform = process.platform): Record<string, string> {
   const env = { ...inherited };
-  if (platform === 'win32') return env;
+  if (platform === 'win32') {
+    // uv's standalone installer uses this per-user directory. An already-running
+    // desktop app has the old PATH, so use the same runtime environment for discovery,
+    // installation and startup instead of requiring a restart after installing uv.
+    const home = envValue(env, 'USERPROFILE');
+    if (home && path.win32.isAbsolute(home)) {
+      const directories = (envValue(env, 'PATH') ?? '').split(';').filter(Boolean);
+      const userBin = path.win32.join(home, '.local', 'bin');
+      if (!directories.some(directory => directory.toLowerCase() === userBin.toLowerCase())) directories.push(userBin);
+      setEnvValue(env, 'PATH', directories.join(';'));
+    }
+    return env;
+  }
   // Desktop launchers do not inherit interactive shell setup. Keep the inherited path
   // first, then the standard Node/Homebrew and uv user-install locations. Never execute
   // shell startup files or copy the application's wider secret-bearing environment.

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -204,7 +204,7 @@ async function modern(
     headers['Mcp-Name'] = params['name'];
   }
   const res = await rawPost(endpoint.urls.core, JSON.stringify(body), headers);
-  return { status: res.status, body: decode(res) };
+  return { status: res.status, headers: res.headers, body: decode(res) };
 }
 
 const toolNames = (reply: any): string[] =>
@@ -986,6 +986,12 @@ describe('2025-era clients', () => {
 });
 
 describe('2026-07-28 clients', () => {
+  it.each(['server/discover', 'tools/list'])('returns JSON for modern %s', async method => {
+    const reply = await modern(method);
+    expect(reply.status).toBe(200);
+    expect(reply.body.error).toBeUndefined();
+    expect(reply.headers['content-type']).toContain('application/json');
+  });
   it('lists tools when the request carries the _meta envelope', async () => {
     const reply = await modern('tools/list');
     expect(reply.status).toBe(200);

--- a/test/plugins-environment.test.ts
+++ b/test/plugins-environment.test.ts
@@ -1,0 +1,37 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { pluginEnvironment, runInstaller } from '../src/main/plugins/installer.js';
+
+describe('Windows plugin runtime discovery', () => {
+  it('finds a standard per-user uv install after the app started, preserving inherited precedence', () => {
+    const inherited = { PATH: 'C:\\tools;C:\\Windows', USERPROFILE: 'C:\\Users\\example' };
+    const env = pluginEnvironment(inherited, 'win32');
+    expect(env.PATH).toBe('C:\\tools;C:\\Windows;C:\\Users\\example\\.local\\bin');
+    expect(inherited.PATH).toBe('C:\\tools;C:\\Windows');
+    expect(pluginEnvironment(env, 'win32')).toEqual(env);
+  });
+
+  it('does not add a relative search directory when the user profile is unavailable', () => {
+    expect(pluginEnvironment({ PATH: 'C:\\tools' }, 'win32')).toEqual({ PATH: 'C:\\tools' });
+    expect(pluginEnvironment({ PATH: 'C:\\tools', USERPROFILE: 'relative' }, 'win32').PATH).toBe('C:\\tools');
+  });
+
+  it.skipIf(process.platform !== 'win32')('launches the newly installed executable through the real installer environment', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'cos-plugin-path-'));
+    try {
+      const bin = path.join(root, '.local', 'bin');
+      await fs.mkdir(bin, { recursive: true });
+      // Stand in for uv without installing packages or relying on the host's uv.
+      await fs.copyFile(process.execPath, path.join(bin, 'uv.exe'));
+      vi.stubEnv('USERPROFILE', root);
+      vi.stubEnv('PATH', path.join(process.env.SystemRoot ?? 'C:\\Windows', 'System32'));
+      await runInstaller('uv', ['-e', 'require("node:fs").writeFileSync("receipt.txt", "launched")'], root);
+      expect(await fs.readFile(path.join(root, 'receipt.txt'), 'utf8')).toBe('launched');
+    } finally {
+      vi.unstubAllEnvs();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Windows plugin installation now finds uv in its standard per-user directory even when uv was installed after CoS started. The shared plugin environment appends the absolute user-profile `.local\bin` directory after inherited PATH, preserving runtime precedence and the minimal environment. Custom and pip-installed runtime locations still require PATH configuration and an app restart. This addresses the standard standalone-install case in #138.

Also adds real HTTP assertions that modern `server/discover` and `tools/list` already return `application/json` with the current SDK defaults. These pass against unchanged production MCP code, so no global response-mode change or hosted-tunnel fix is claimed for #137.

Validation: the path regression fails before the fix; three environment tests pass afterward, including a real Windows subprocess launched through `runInstaller`. Full `npm run verify` passes 3,441 main-suite tests plus 2 isolated shutdown tests (29 skipped), including privacy, notices, pinned native sources and typecheck. `npm run build` and independent source review pass. No installer, live plugin package installation or release was performed.
