### PR TITLE
Recover replies that finish on the server but freeze in the page

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -2159,6 +2159,8 @@ async function maintainOnce() {
     .map((entry) => ({
       conversationId: cleanConversationId(entry && entry.conversationId),
       token: entry && typeof entry.token === 'string' ? entry.token : '',
+      reason: entry && entry.reason === 'stale-render' ? 'stale-render' : '',
+      turnId: entry && typeof entry.turnId === 'string' ? entry.turnId.slice(0, 100) : '',
       focus: Boolean(entry && entry.focus === true)
     }))
     .filter((entry) => entry.conversationId && entry.token);
@@ -2216,7 +2218,7 @@ async function maintainOnce() {
     if (changed) await persistLive().catch(() => undefined);
   }
   if (repairs.length === 0) return clearRetryIfIdle();
-  for (const { conversationId, token, focus } of repairs) {
+  for (const { conversationId, token, reason, focus, turnId } of repairs) {
     // Re-scanned per repair rather than reused from above. Earlier entries in this same batch
     // may have created a tab, and the scan has to be the state immediately before the action or
     // the duplicate rule below is deciding on a tab list that no longer exists.
@@ -2234,6 +2236,53 @@ async function maintainOnce() {
     const owned = candidates.filter((tab) => tabConversations[tab.id] === conversationId);
     const [target] = (owned.length > 0 ? owned : candidates).sort((a, b) => a.id - b.id);
     const repairAction = target ? 'reloaded' : 'reopened';
+    if (reason === 'stale-render') {
+      // This repair belongs to the document that witnessed one exact still-open turn. Losing the
+      // tab cannot authorize reopening it, and the user may have typed, sent, or started a tool
+      // since the observation crossed the bridge. Ask that exact document to check and initiate
+      // reload in one JavaScript task, so no later background action can race a fresh draft.
+      if (!target || target.pendingUrl || typeof target.url !== 'string' || !target.url ||
+          typeof turnId !== 'string' || !turnId) {
+        await call(`/status?repairSkipped=${encodeURIComponent(token)}`);
+        continue;
+      }
+      const key = String(target.id);
+      const source = {
+        tab: target.id,
+        documentId: tabDocuments[key],
+        navigationEpoch: tabEpochs[key]
+      };
+      const scannedUrl = target.url;
+      let proof;
+      try {
+        const current = await chrome.tabs.get(target.id);
+        if (!ownsDocument(source) || current.pendingUrl || current.url !== scannedUrl ||
+            conversationForTab(current) !== conversationId) {
+          await call(`/status?repairSkipped=${encodeURIComponent(token)}`);
+          continue;
+        }
+        proof = await chrome.tabs.sendMessage(target.id, {
+          type: 'clf-stale-render-reload',
+          conversationId,
+          turnId
+        });
+      } catch {
+        await call(`/status?repairFailed=${encodeURIComponent(token)}&repairAction=reloaded`);
+        continue;
+      }
+      if (proof?.safe !== true || proof.conversationId !== conversationId ||
+          proof.turnId !== turnId || proof.navigationEpoch !== source.navigationEpoch) {
+        await call(`/status?repairSkipped=${encodeURIComponent(token)}`);
+        continue;
+      }
+      if (proof.reloading !== true) {
+        await call(`/status?repairFailed=${encodeURIComponent(token)}&repairAction=reloaded`);
+        continue;
+      }
+      // The exact page already initiated its own reload synchronously with the final check.
+      await call(`/status?repaired=${encodeURIComponent(token)}&repairAction=reloaded`);
+      continue;
+    }
     try {
       // Select the working tab within Chrome without stealing OS focus from the
       // desktop app. Tab selection and window activation are separate operations.

--- a/extension/content.js
+++ b/extension/content.js
@@ -108,6 +108,12 @@
   const STATUS_MS = 15_000;
   /** Longer than any honest tool call: past this a silent turn is called stalled. */
   const STALL_MS = 10 * 60 * 1000;
+  /**
+   * A rendered answer can stop updating even though ChatGPT continues and commits it on the
+   * server. When the page has returned to its Send control, keep the exact local turn open but
+   * ask the app for its one bounded same-chat reload after this much stable silence.
+   */
+  const STALE_RENDER_RECOVERY_MS = 30_000;
   /** How long the button says "Starting…" before believing something went wrong. */
   const PRESS_GRACE_MS = 12_000;
   /** Persistent popup preference. On by default as of 1.7.4; the popup can turn it off. */
@@ -555,6 +561,8 @@
     if (stagePanel?.root.dataset.clfStageKind === 'wait') removeStagePanel();
   }
   let stallReported = false;
+  /** The exact local generation has already asked the app for stale-render recovery. */
+  let staleRenderReported = false;
   let userStopped = false;
   /**
    * Final public ChatGPT message that already terminalised the local turn while the page's
@@ -1370,6 +1378,7 @@
     quietOutcome = null;
     userStopped = false;
     stallReported = false;
+    staleRenderReported = false;
     fiberTerminalMessageId = null;
     bindResumeGoalTurn(open);
     return true;
@@ -1570,6 +1579,7 @@
     baselineMarks = [];
     userStopped = false;
     stallReported = false;
+    staleRenderReported = false;
     fiberTerminalMessageId = null;
     // The settle window names a turn in the conversation being left behind. Carrying it
     // across would re-read chat B's tree and attribute what it finds to chat A's turn.
@@ -2294,6 +2304,7 @@
       quietOutcome = null;
       userStopped = false;
       stallReported = false;
+      staleRenderReported = false;
       genCount++;
       turnId = `g-${RUN_ID}-${epoch}-${genCount}`;
       unwitnessedGeneration = false;
@@ -2450,6 +2461,39 @@
       // never a terminal boundary on its own. User stop is already explicit; a new user
       // message is handled above, and Fiber end_turn closes independently in refreshFiber().
       const markerOnlyInterrupted = result.outcome === 'interrupted' && !userStopped;
+      const quietPageTurn = quietTurn || turn;
+      const quietFiberTurn = fiberTurnFor(quietPageTurn);
+      const fiberHasPendingCall = Boolean(
+        quietFiberTurn?.calls?.some((call) => call && call.answered !== true)
+      );
+      // Live 2026-09-09: the public answer froze at 156 characters and the native composer
+      // returned to Send, while the server continued to a 19,329-character final that appeared
+      // immediately after a manual refresh. This is neither completion evidence nor authority
+      // to submit anything again. It is exact-document evidence for the app's existing one-shot
+      // same-chat reload path. Require a generation witnessed running in this document, its
+      // current Fiber turn still nonterminal, stable visible prose, no outstanding browser/tool
+      // work, and the native Send control continuously back beyond the bounded window.
+      if (
+        !staleRenderReported &&
+        !unwitnessedGeneration &&
+        result.outcome === 'unknown' &&
+        quietFor >= STALE_RENDER_RECOVERY_MS &&
+        Date.now() - lastChangeAt >= STALE_RENDER_RECOVERY_MS &&
+        Boolean(CLF_DOM.sendButton?.()) &&
+        Boolean(quietFiberTurn) &&
+        !quietFiberTurn.endMessageId &&
+        !fiberHasPendingCall &&
+        pendingTools === 0 &&
+        answerText(quietPageTurn).length > 0 &&
+        turnId
+      ) {
+        staleRenderReported = true;
+        emit({
+          kind: 'stale_render',
+          text: 'ChatGPT stopped updating this answer after its Send control returned. Reloading the same chat may recover the server result.',
+          turnId
+        });
+      }
       if (
         userStopped ||
         (result.outcome !== 'unknown' && !markerOnlyInterrupted && quietFor >= TURN_SETTLE_MS)
@@ -10135,6 +10179,70 @@
       (home ? !rows.length && !marker.has('cos-input') && !marker.has('temporary-chat') :
         !!CLF_DOM.conversationId() && rows.at(-1)?.role === 'assistant');
   }
+
+  /**
+   * Final authority for reloading a page whose rendered assistant answer stopped moving.
+   *
+   * Detection and the browser maintenance pass are separated by two IPC hops. Everything that
+   * made the first observation safe can change between them: the user can start a new turn, type
+   * a draft, or a late tool call can appear. Re-read those facts in the exact document and exact
+   * local turn immediately before background.js reloads it. This never submits or completes a
+   * turn; it only authorizes one refresh of the same currently open server turn.
+   */
+  function staleRenderReloadSafe(expectedConversation, expectedTurnId) {
+    const pageTurn = quietTurn || generationTurn();
+    const fiberTurn = fiberTurnFor(pageTurn);
+    const pendingFiberCall = Boolean(
+      fiberTurn?.calls?.some((call) => !call || call.answered !== true)
+    );
+    return Boolean(
+      alive &&
+      staleRenderReported &&
+      generating &&
+      !unwitnessedGeneration &&
+      quietSince > 0 &&
+      Date.now() - quietSince >= STALE_RENDER_RECOVERY_MS &&
+      Date.now() - lastChangeAt >= STALE_RENDER_RECOVERY_MS &&
+      expectedConversation &&
+      expectedConversation === conversationId &&
+      CLF_DOM.conversationId() === expectedConversation &&
+      expectedTurnId &&
+      turnId === expectedTurnId &&
+      !CLF_DOM.generating() &&
+      CLF_DOM.sendButton?.() &&
+      pageTurn &&
+      endOutcome(pageTurn).outcome === 'unknown' &&
+      answerText(pageTurn).length > 0 &&
+      fiberTurn &&
+      !fiberTurn.endMessageId &&
+      !pendingFiberCall &&
+      pendingTools === 0 &&
+      !nativeBusy &&
+      !goalBusy &&
+      !(job && job.busy) &&
+      !objectiveBusy &&
+      !desktopInputBusy &&
+      !modelCatalogBusy &&
+      !pluginRefreshBusy &&
+      !desktopDecision &&
+      !commandAttempt &&
+      !commandJournalGate &&
+      queue.length === 0 &&
+      !flushWork &&
+      CLF_DOM.composer() &&
+      !(CLF_DOM.composer().textContent || '').trim() &&
+      !CLF_DOM.hasComposerAttachments()
+    );
+  }
+
+  /** Starts navigation in the same JavaScript task that made the final safety decision. */
+  function reloadStaleRenderDocument() {
+    if (TEST_MODE && typeof globalThis.CLF_TEST_RELOAD === 'function') {
+      globalThis.CLF_TEST_RELOAD();
+      return;
+    }
+    location.reload();
+  }
   async function prepareDesktopInputPage(message) {
     if (!/^[a-f0-9-]{36}$/i.test(message.id) || !inputReuseSafe()) return { ready: false };
     const startEpoch = epoch, startConversation = CLF_DOM.conversationId();
@@ -10249,6 +10357,24 @@
       }
       if (message.type === 'clf-input-reuse-state') {
         sendResponse({ safe: inputReuseSafe(), navigationEpoch: epoch });
+        return false;
+      }
+      if (message.type === 'clf-stale-render-reload') {
+        const safe = staleRenderReloadSafe(message.conversationId, message.turnId);
+        if (!safe) {
+          sendResponse({ safe: false, conversationId, turnId, navigationEpoch: epoch });
+          return false;
+        }
+        try {
+          // No await or callback belongs between the check above and this call. A user event,
+          // Fiber update, or tool start cannot interleave and invalidate the checked snapshot.
+          reloadStaleRenderDocument();
+          sendResponse({ safe: true, reloading: true, conversationId, turnId, navigationEpoch: epoch });
+        } catch {
+          // The checked state remains valid; only the browser action failed, so the app may keep
+          // this exact handout retryable rather than confusing failure with revoked authority.
+          sendResponse({ safe: true, reloading: false, conversationId, turnId, navigationEpoch: epoch });
+        }
         return false;
       }
       if (message.type === 'clf-prepare-desktop-input') {
@@ -10533,6 +10659,7 @@
       visibleStream,
       /** So a test settles a turn by the real window rather than a copy of the number. */
       TURN_SETTLE_MS,
+      STALE_RENDER_RECOVERY_MS,
       STALL_MS,
       GOAL_RETRY_MS,
       PRESENTATION_SCROLL_IDLE_MS,

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -759,6 +759,7 @@ const OBSERVATION_KINDS = new Set([
   'turn_start',
   'turn_end',
   'chat_error',
+  'stale_render',
   // Not stored as transcript content. These request records populate the exact
   // requestId -> conversationId correlation registry.
   'tool_evidence'
@@ -1414,12 +1415,15 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
     // mean the last repair did not happen. Empty, which is almost always, costs one request.
     const repaired = url.searchParams.get('repaired');
     const repairFailed = url.searchParams.get('repairFailed');
+    const repairSkipped = url.searchParams.get('repairSkipped');
     const repairAction = url.searchParams.get('repairAction');
     const action = repairAction === 'reloaded' || repairAction === 'reopened' ? repairAction : null;
     if (repaired) {
       await confirmRepair(repaired.slice(0, 64), action);
     } else if (repairFailed) {
       await failRepairAttempt(repairFailed.slice(0, 64), action);
+    } else if (repairSkipped) {
+      await skipRepairAttempt(repairSkipped.slice(0, 64));
     }
     const revival = pendingBrowserRevival();
     const inputRows = await listInputs();
@@ -1449,7 +1453,7 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
         placement: pendingBrowserPlacement(null),
         // A failure report closes this request. Reissuing the repair in the same response would
         // replace the visible failure with "Trying" before a renderer could ever observe it.
-        repairs: repairFailed ? [] : await takePendingRepairs(),
+        repairs: repairFailed || repairSkipped ? [] : await takePendingRepairs(),
         ...tabPolicy,
         recoveryMonitoring: browserRecoveryMonitoring()
       },
@@ -5275,7 +5279,9 @@ interface Repair {
   state: 'queued' | 'handed' | 'done';
   /** Stable identity of the failure/inactivity episode. A new activity stamp mints a new one. */
   episode: string;
-  reason: 'unattributed' | 'assistant-error' | 'no-tab' | 'silence' | 'goal' | 'compaction';
+  reason: 'unattributed' | 'assistant-error' | 'stale-render' | 'no-tab' | 'silence' | 'goal' | 'compaction';
+  /** Exact open local turn whose still-current state authorizes a stale-render reload. */
+  sourceTurnId?: string;
   /** Cooldown boundary. The browser is never asked before this instant. */
   notBefore: number;
   /**
@@ -5374,7 +5380,8 @@ function queueBrowserRecovery(
   episode: string,
   reason: Repair['reason'],
   endedTurns = 0,
-  now = Date.now()
+  now = Date.now(),
+  sourceTurnId: string | null = null
 ): boolean {
   // A blocked chat is one the user took this app's hands off, and every repair here is a hand
   // going back on: a reload restarts the rogue page's turn machinery, and a reopen gives a
@@ -5387,7 +5394,7 @@ function queueBrowserRecovery(
   // The turn's one error reload, already spent. Checked before the episode and state guards
   // below because it outlives both: those forget a repair the moment its episode changes, and
   // the whole point here is that a *new* error on the same broken turn buys nothing.
-  if (reason === 'assistant-error') {
+  if (reason === 'assistant-error' || reason === 'stale-render') {
     // Read against the turn the chat is on *now*: the release in retireSpentRepairs runs on
     // the browser's pass, and an error on the next turn can arrive before that pass does.
     const spent = turnRepairSpent.get(conversationId);
@@ -5431,6 +5438,7 @@ function queueBrowserRecovery(
     state: 'queued',
     episode,
     reason,
+    ...(sourceTurnId ? { sourceTurnId } : {}),
     notBefore,
     token: '',
     progressId: `browser-repair:${randomBytes(9).toString('base64url')}`
@@ -5563,6 +5571,29 @@ async function noteRecoveryObservations(
   // watchdog may grant recovery authority. The error may precede a page turn, so turn identity,
   // agent binding and recent tool calls are still not prerequisites for a recognized failure.
   const now = Date.now();
+  for (const item of observations) {
+    if (item.kind !== 'stale_render' || !item.turnId || !sessionId) continue;
+    const live = liveConversations().find(
+      (entry) => entry.conversationId === conversationId && entry.sessionId === sessionId
+    );
+    // A page may deliver an old journal after the user has continued. Only the exact open local
+    // turn that emitted this observation can grant a reload, and the browser must prove it again.
+    if (live?.activeTurnId !== item.turnId) continue;
+    if (
+      queueBrowserRecovery(
+        conversationId,
+        sessionId,
+        `stale-render:${item.turnId}`,
+        'stale-render',
+        live.endedTurns,
+        now,
+        item.turnId
+      )
+    ) {
+      logInfo(`bridge: stale rendered response — asking the browser to recheck ${conversationId}`);
+    }
+    break;
+  }
   for (const item of observations) {
     if (item.kind !== 'chat_error') continue;
     // A provider access limit is the page saying it will not carry this chat for a few
@@ -6254,8 +6285,13 @@ function retireSpentRepairs(): void {
   for (const [conversationId, repair] of repairsInFlight) {
     // Both turn-scoped reasons, and only those. `silence` and `no-tab` are about a chat rather
     // than a turn, and keep the activity-driven lifecycle above.
-    if (!TURN_SCOPED_REPAIRS.has(repair.reason)) continue;
     const entry = live.get(conversationId);
+    if (repair.reason === 'stale-render') {
+      if (!entry || !repair.sourceTurnId || entry.sessionId !== repair.sessionId ||
+          entry.activeTurnId !== repair.sourceTurnId) repairsInFlight.delete(conversationId);
+      continue;
+    }
+    if (!TURN_SCOPED_REPAIRS.has(repair.reason)) continue;
     if (entry && entry.endedTurns > repair.endedTurns) repairsInFlight.delete(conversationId);
   }
   // The budget is released by the chat being on a different turn than the one it was charged
@@ -6523,7 +6559,7 @@ function tickUnattributedIncident(): void {
  */
 async function takePendingRepairs(
   now = Date.now()
-): Promise<Array<{ conversationId: string; token: string; reason: Repair['reason']; focus: boolean }>> {
+): Promise<Array<{ conversationId: string; token: string; reason: Repair['reason']; focus: boolean; turnId?: string }>> {
   retireSpentRepairs();
   // The queue can outlive the decision that filled it: a repair queued a minute before the user
   // pressed Block would otherwise still be handed to the browser, and the block's whole promise
@@ -6533,8 +6569,10 @@ async function takePendingRepairs(
   for (const [conversationId, repair] of [...repairsInFlight]) {
     const session = await getSession(repair.sessionId);
     const superseded = await conversationWasSuperseded(conversationId);
+    const staleRenderCurrent = repair.reason !== 'stale-render' ||
+      (!!repair.sourceTurnId && session?.activeTurnId === repair.sourceTurnId);
     if (!isChatBlocked(conversationId) && !superseded && session?.conversationId === conversationId &&
-        !stopRequestedFor(conversationId, session.activeTurnId)) continue;
+        staleRenderCurrent && !stopRequestedFor(conversationId, session.activeTurnId)) continue;
     repairsInFlight.delete(conversationId);
     turnRepairSpent.delete(conversationId);
     const grant = activeUntil.get(conversationId);
@@ -6561,6 +6599,8 @@ async function takePendingRepairs(
     reason: Repair['reason'];
     /** Raise the tab (or open the chat in front) before acting: a background tab is throttled. */
     focus: boolean;
+    /** Present only for stale-render repair and rechecked by the exact browser document. */
+    turnId?: string;
   }> = [];
   for (const [conversationId, repair] of repairsInFlight) {
     if (repair.state !== 'queued') continue;
@@ -6575,7 +6615,8 @@ async function takePendingRepairs(
       `Trying to reload chat to recover ${repairReason(repair)}…`
     );
     if (repairsInFlight.get(conversationId) === repair && !stopRequestedFor(conversationId))
-      ready.push({ conversationId, token: repair.token, reason: repair.reason, focus: repair.reason === 'compaction' });
+      ready.push({ conversationId, token: repair.token, reason: repair.reason,
+        focus: repair.reason === 'compaction', ...(repair.sourceTurnId ? { turnId: repair.sourceTurnId } : {}) });
   }
   return ready;
 }
@@ -6618,7 +6659,7 @@ async function confirmRepair(token: string, action: 'reloaded' | 'reopened' | nu
           goalActiveFor(conversationId) ? GOAL_SILENCE_LISTEN_MS : CHAT_SILENCE_MS
         );
       }
-      if (repair.reason === 'assistant-error') {
+      if (repair.reason === 'assistant-error' || repair.reason === 'stale-render') {
         // Charged to the turn the chat is on when the reload lands, running or not, and
         // released when it is on another one — see turnRepairSpent.
         const live = liveConversations().find((entry) => entry.conversationId === conversationId);
@@ -6631,6 +6672,20 @@ async function confirmRepair(token: string, action: 'reloaded' | 'reopened' | nu
       );
       return;
     }
+  }
+}
+
+/** A final page preflight disproved this exact handout; retire it without claiming a reload. */
+async function skipRepairAttempt(token: string): Promise<void> {
+  for (const [conversationId, repair] of repairsInFlight) {
+    if (repair.state !== 'handed' || repair.token !== token || repair.reason !== 'stale-render') continue;
+    repairsInFlight.delete(conversationId);
+    await updateRepairProgress(
+      conversationId,
+      repair,
+      `Skipped chat reload because ${repairReason(repair)} was no longer current.`
+    );
+    return;
   }
 }
 
@@ -6654,6 +6709,7 @@ function repairReason(repair: Repair): string {
   return {
     unattributed: 'missing connector attribution',
     'assistant-error': 'an interrupted response',
+    'stale-render': 'a frozen rendered response',
     'no-tab': 'a missing browser tab',
     silence: 'an unresponsive open turn',
     goal: 'a goal reply nothing collected',

--- a/src/main/session/recorder.ts
+++ b/src/main/session/recorder.ts
@@ -1554,6 +1554,7 @@ export interface ChatObservation {
     | 'turn_start'
     | 'turn_end'
     | 'chat_error'
+    | 'stale_render'
     | 'tool_evidence';
   time: number;
   /** Current native selection evidence, not a historical message or requested worker model. */
@@ -1982,6 +1983,15 @@ async function recordChatObservationsNow(
           message: await storeText(sessionId, item.text ?? '', 2000)
         });
         activity.meaningful = true; activity.at = Math.max(activity.at ?? 0, item.time);
+        break;
+      case 'stale_render':
+        // This is a lack of page progress, not activity. Keep its diagnosis in the durable
+        // timeline without moving the silence clock or pretending the assistant advanced.
+        await appendEvent(sessionId, {
+          ...base,
+          kind: 'chat_error',
+          message: await storeText(sessionId, item.text ?? '', 2000)
+        });
         break;
       case 'turn_start':
         // Lifecycle without a durable local id is not a lifecycle boundary a later reader

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -4823,7 +4823,7 @@ describe('unattributed activity recovery', () => {
   async function maintenanceBatch(
     repaired?: string,
     repairAction?: 'reloaded' | 'reopened'
-  ): Promise<Array<{ conversationId: string; token: string; reason: string }>> {
+  ): Promise<Array<{ conversationId: string; token: string; reason: string; turnId?: string }>> {
     const path = repaired
       ? `/status?repaired=${encodeURIComponent(repaired)}${repairAction ? `&repairAction=${repairAction}` : ''}`
       : '/status';
@@ -4842,7 +4842,7 @@ describe('unattributed activity recovery', () => {
   async function maintenance(
     repaired?: string,
     repairAction?: 'reloaded' | 'reopened'
-  ): Promise<{ conversationId: string; token: string; reason: string } | null> {
+  ): Promise<{ conversationId: string; token: string; reason: string; turnId?: string } | null> {
     const batch = await maintenanceBatch(repaired, repairAction);
     expect(batch.length).toBeLessThanOrEqual(1);
     return batch[0] ?? null;
@@ -5486,6 +5486,71 @@ describe('unattributed activity recovery', () => {
         recoverable: true
       }]);
       expect(chatOf(await maintenance())).toBe(PRIME);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('hands out stale-render recovery only while its exact local turn remains current', async () => {
+    await pair();
+    await events(PRIME, [openTurn('turn-frozen-render')]);
+    await events(PRIME, [{
+      kind: 'stale_render',
+      time: Date.now(),
+      turnId: 'turn-frozen-render',
+      text: 'ChatGPT stopped updating this answer after its Send control returned.'
+    }]);
+    const repair = await maintenance();
+    expect(repair).toMatchObject({
+      conversationId: PRIME,
+      reason: 'stale-render',
+      turnId: 'turn-frozen-render'
+    });
+
+    // The browser has not acted yet. A next user turn makes the old handout stale, so its late
+    // receipt cannot reload or close anything belonging to the new turn.
+    await events(PRIME, [endTurn('turn-frozen-render', 'failed'), openTurn('turn-after-freeze')]);
+    expect(await maintenance()).toBeNull();
+    expect(await maintenance(repair!.token, 'reloaded')).toBeNull();
+  });
+
+  it('retires a stale-render handout when the final browser preflight refuses it', async () => {
+    await pair();
+    await events(PRIME, [openTurn('turn-draft-race')]);
+    await events(PRIME, [{
+      kind: 'stale_render',
+      time: Date.now(),
+      turnId: 'turn-draft-race',
+      text: 'ChatGPT stopped updating this answer after its Send control returned.'
+    }]);
+    const repair = await maintenance();
+    expect(repair?.reason).toBe('stale-render');
+
+    const skipped = await request('GET', `/status?repairSkipped=${encodeURIComponent(repair!.token)}`);
+    expect(skipped.status).toBe(200);
+    expect(skipped.body.repairs).toEqual([]);
+    expect(await maintenance()).toBeNull();
+  });
+
+  it('spends at most one confirmed stale-render reload per active turn', async () => {
+    vi.useFakeTimers();
+    try {
+      await pair();
+      await events(OTHER, [openTurn('turn-stale-budget')]);
+      const signal = (turnId: string) => ({ kind: 'stale_render', time: Date.now(), turnId,
+        text: 'ChatGPT stopped updating this answer after its Send control returned.' });
+      await events(OTHER, [signal('turn-stale-budget')]);
+      const first = await maintenance();
+      expect(first?.reason).toBe('stale-render');
+      expect(await maintenance(first!.token, 'reloaded')).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(BROWSER_RECOVERY_COOLDOWN_MS);
+      await events(OTHER, [signal('turn-stale-budget')]);
+      expect(await maintenance()).toBeNull();
+
+      await events(OTHER, [endTurn('turn-stale-budget', 'failed'), openTurn('turn-stale-budget-2')]);
+      await events(OTHER, [signal('turn-stale-budget-2')]);
+      expect((await maintenance())?.reason).toBe('stale-render');
     } finally {
       vi.useRealTimers();
     }

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -148,6 +148,8 @@ interface Hook {
   visibleStream(entries: Array<Record<string, any>>, groupId?: string | null): Array<Record<string, any>>;
   /** How long the stop button must stay gone before content.js calls a turn finished. */
   TURN_SETTLE_MS: number;
+  /** Stable Send-state silence before requesting same-chat stale-render recovery. */
+  STALE_RENDER_RECOVERY_MS: number;
   /** Test seam for the no-visible-progress fallback. */
   STALL_MS: number;
   /** How long a failed Goal draft waits before it asks again. */
@@ -171,6 +173,8 @@ interface Harness {
   reply: Map<string, (message: Record<string, any>) => unknown>;
   /** Sends one popup/background message to the content script's runtime listener. */
   runtimeMessage(message: Record<string, any>): Promise<unknown>;
+  /** Same-task page reload seam used only by the stale-render recovery tests. */
+  pageReload: ReturnType<typeof vi.fn>;
   /** Browser-extension listeners still owned by live recorder instances in this document. */
   listenerCounts(): { runtime: number; storage: number };
   /** Moves the clock the script reads. Nothing else advances it between ticks. */
@@ -211,6 +215,8 @@ async function harness(
   });
 
   const sent: Array<Record<string, any>> = [];
+  const pageReload = vi.fn();
+  window.CLF_TEST_RELOAD = pageReload;
   const reply = new Map<string, (message: Record<string, any>) => unknown>();
   type RuntimeListener = (
     message: Record<string, any>,
@@ -349,6 +355,7 @@ async function harness(
         });
         if (async !== true && !answered) resolve(undefined);
       }),
+    pageReload,
     listenerCounts: () => ({ runtime: runtimeListeners.size, storage: storageListeners.size }),
     advance,
     close: () => dom.window.close()
@@ -703,7 +710,7 @@ describe('desktop input delivery and helper ownership', () => {
     const sending = live.runtimeMessage({ type: 'clf-desktop-input', id: inputId, conversationId: chatA });
     await settle();
     expect(live.sent.some(message => message.type === 'desktop_input')).toBe(false);
-    expect(emitted(live.sent, 'chat_error')).toHaveLength(0);
+    expect(emitted(live.sent, 'stale_render')).toHaveLength(0);
     stopGenerating(live.document);
     live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
       userTurn(live!.document, 'next-stage-user', text);
@@ -712,7 +719,7 @@ describe('desktop input delivery and helper ownership', () => {
     });
     expect(await sending).toEqual({ ok: true });
     expect(live.sent.filter(message => message.type === 'desktop_input' && message.ack)).toHaveLength(1);
-    expect(emitted(live.sent, 'chat_error')).toHaveLength(0);
+    expect(emitted(live.sent, 'stale_render')).toHaveLength(0);
   });
 
   it.each([false, true])('handles autosaved text hydrated during model selection only for an owned fresh input (%s)', async (fresh) => {
@@ -5668,6 +5675,138 @@ describe('a stop button that goes missing while the turn is still running', () =
     live.hook.observe();
     await settle();
     expect(emitted(live.sent, 'turn_start').map((entry) => entry.event.turnId)).toEqual([opened]);
+    expect(emitted(live.sent, 'turn_end')).toHaveLength(0);
+  });
+
+  it('requests one same-chat recovery when Send returns over a frozen nonterminal Fiber reply', async () => {
+    live = await harness();
+    startGenerating(live.document);
+    const section = assistantTurn(live.document, 'turn-stale-render', []);
+    prose(live.document, section, 'stale-render-partial', 'The reply started, but this rendered prefix stopped moving.');
+    live.hook.observe();
+    await settle();
+    const opened = emitted(live.sent, 'turn_start')[0]!.event.turnId;
+
+    await bindFiberTurns([{ section, turn: {
+      turnId: 'turn-stale-render',
+      conversationId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      endMessageId: null,
+      calls: [],
+      messages: [{
+        messageId: 'stale-render-partial',
+        rawMessageId: 'stale-render-partial',
+        stable: true,
+        rawText: 'The reply started, but this rendered prefix stopped moving.',
+        renderedHtml: '<p>The reply started, but this rendered prefix stopped moving.</p>'
+      }],
+      activities: []
+    } }]);
+    await settle();
+
+    stopGenerating(live.document);
+    live.hook.observe();
+    await settle();
+    // Fiber asks use bounded page-message timers that also move the harness clock. Stay well
+    // below the production threshold here instead of testing a fake-clock off-by-one.
+    live.advance(live.hook.STALE_RENDER_RECOVERY_MS / 2);
+    live.hook.observe();
+    await settle();
+    expect(emitted(live.sent, 'stale_render')).toHaveLength(0);
+
+    live.advance(live.hook.STALE_RENDER_RECOVERY_MS);
+    live.hook.observe();
+    await settle();
+    const errors = emitted(live.sent, 'stale_render').map((entry) => entry.event);
+    expect(errors).toEqual([expect.objectContaining({
+      text: expect.stringContaining('stopped updating this answer'),
+      turnId: opened
+    })]);
+    expect(emitted(live.sent, 'turn_end')).toHaveLength(0);
+    expect(live.sent.some((message) => message.type === 'reload_owned_chat')).toBe(false);
+
+    await live.hook.flush();
+    await settle();
+    const reload = live.runtimeMessage({
+      type: 'clf-stale-render-reload',
+      conversationId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      turnId: opened
+    });
+    // The checked operation starts navigation before its caller can regain control and mutate
+    // draft/tool state. There is no successful preflight result that background.js acts on later.
+    expect(live.pageReload).toHaveBeenCalledTimes(1);
+    expect(await reload).toMatchObject({ safe: true, reloading: true, turnId: opened });
+
+    // A draft typed after detection revokes reload authority without erasing it.
+    const composer = live.document.querySelector('#prompt-textarea')!;
+    composer.textContent = 'new user draft';
+    expect(await live.runtimeMessage({
+      type: 'clf-stale-render-reload',
+      conversationId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      turnId: opened
+    })).toMatchObject({ safe: false, turnId: opened });
+    expect(live.pageReload).toHaveBeenCalledTimes(1);
+    composer.textContent = '';
+
+    // A late connector request is newer work by the same turn and also revokes the reload.
+    await bindFiberTurns([{ section, turn: {
+      turnId: 'turn-stale-render',
+      conversationId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      endMessageId: null,
+      calls: [{ messageId: 'stale-render-late-call', tool: 'read_file', order: 0, answered: false }],
+      messages: [{
+        messageId: 'stale-render-partial',
+        rawMessageId: 'stale-render-partial',
+        stable: true,
+        rawText: 'The reply started, but this rendered prefix stopped moving.',
+        renderedHtml: '<p>The reply started, but this rendered prefix stopped moving.</p>'
+      }],
+      activities: []
+    } }]);
+    await settle();
+    expect(await live.runtimeMessage({
+      type: 'clf-stale-render-reload',
+      conversationId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      turnId: opened
+    })).toMatchObject({ safe: false, turnId: opened });
+    expect(live.pageReload).toHaveBeenCalledTimes(1);
+
+    live.advance(live.hook.STALE_RENDER_RECOVERY_MS * 2);
+    live.hook.observe();
+    await settle();
+    expect(emitted(live.sent, 'stale_render')).toHaveLength(1);
+  });
+
+  it('does not request stale-render recovery while the exact Fiber turn has pending work', async () => {
+    live = await harness();
+    startGenerating(live.document);
+    const section = assistantTurn(live.document, 'turn-stale-render-tool', []);
+    prose(live.document, section, 'stale-render-tool-partial', 'Waiting for the tool result.');
+    live.hook.observe();
+    await settle();
+    await bindFiberTurns([{ section, turn: {
+      turnId: 'turn-stale-render-tool',
+      conversationId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      endMessageId: null,
+      calls: [{ messageId: 'stale-render-call', tool: 'read_file', order: 0, answered: false, requestId: 'wfr-stale-render' }],
+      messages: [{
+        messageId: 'stale-render-tool-partial',
+        rawMessageId: 'stale-render-tool-partial',
+        stable: true,
+        rawText: 'Waiting for the tool result.',
+        renderedHtml: '<p>Waiting for the tool result.</p>'
+      }],
+      activities: []
+    } }]);
+    await settle();
+
+    stopGenerating(live.document);
+    live.hook.observe();
+    await settle();
+    live.advance(live.hook.STALE_RENDER_RECOVERY_MS * 2);
+    live.hook.observe();
+    await settle();
+
+    expect(emitted(live.sent, 'stale_render')).toHaveLength(0);
     expect(emitted(live.sent, 'turn_end')).toHaveLength(0);
   });
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -809,6 +809,102 @@ describe('exact chat recovery from a fresh Chrome tab scan', () => {
     return { fetch, asked, actions, failedActions, arm: (id: string) => { outstanding = id; } };
   }
 
+  function staleRenderApp() {
+    const asked: string[] = [];
+    let outstanding = false;
+    const token = 'stale-render-token';
+    const fetch = vi.fn(async (input: string) => {
+      const url = new URL(input);
+      if (url.pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
+      if (url.pathname === '/closed') return response(200, { ok: true });
+      if (url.pathname === '/status') {
+        const skipped = url.searchParams.get('repairSkipped');
+        const repaired = url.searchParams.get('repaired');
+        const failed = url.searchParams.get('repairFailed');
+        if (skipped) { asked.push(`skipped:${skipped}`); outstanding = false; }
+        else if (repaired) { asked.push(`repaired:${repaired}`); outstanding = false; }
+        else if (failed) asked.push(`failed:${failed}`);
+        else asked.push('status');
+        return response(200, {
+          ok: true,
+          repairs: outstanding
+            ? [{ conversationId: CHAT, token, reason: 'stale-render', turnId: 'turn-stale-render', focus: false }]
+            : []
+        });
+      }
+      return response(404, {});
+    });
+    return { fetch, asked, token, arm: () => { outstanding = true; } };
+  }
+
+  it('reloads a frozen rendered answer only after the exact document approves a final preflight', async () => {
+    const app = staleRenderApp();
+    const tab = { id: 71, url: `https://chatgpt.com/c/${CHAT}` };
+    const reloadRequest = vi.fn(async () => ({ safe: true, reloading: true, conversationId: CHAT,
+      turnId: 'turn-stale-render', navigationEpoch: 0 }));
+    const worker = loadWorker({ local: new FakeStorageArea(paired), session: new FakeStorageArea(),
+      fetch: app.fetch, tabsGet: async () => tab, tabsSendMessage: reloadRequest });
+    await worker.registerTab(71);
+    await worker.send({ type: 'bind', conversationId: CHAT }, 71);
+    app.arm();
+
+    await worker.fireAlarm();
+    expect(reloadRequest).toHaveBeenCalledWith(71, {
+      type: 'clf-stale-render-reload',
+      conversationId: CHAT,
+      turnId: 'turn-stale-render'
+    });
+    expect(worker.tabsReload).not.toHaveBeenCalled();
+    expect(app.asked).toContain(`repaired:${app.token}`);
+  });
+
+  it('does not reload after a draft or late tool makes the stale-render preflight unsafe', async () => {
+    const app = staleRenderApp();
+    const tab = { id: 72, url: `https://chatgpt.com/c/${CHAT}` };
+    const worker = loadWorker({ local: new FakeStorageArea(paired), session: new FakeStorageArea(),
+      fetch: app.fetch, tabsGet: async () => tab,
+      tabsSendMessage: async () => ({ safe: false, conversationId: CHAT,
+        turnId: 'turn-stale-render', navigationEpoch: 0 }) });
+    await worker.registerTab(72);
+    await worker.send({ type: 'bind', conversationId: CHAT }, 72);
+    app.arm();
+
+    await worker.fireAlarm();
+    expect(worker.tabsReload).not.toHaveBeenCalled();
+    expect(worker.tabsCreate).not.toHaveBeenCalled();
+    expect(app.asked).toContain(`skipped:${app.token}`);
+  });
+
+  it('never reopens a missing stale-render tab', async () => {
+    const app = staleRenderApp();
+    const worker = loadWorker({ local: new FakeStorageArea(paired), session: new FakeStorageArea(), fetch: app.fetch });
+    app.arm();
+
+    await worker.fireAlarm();
+    expect(worker.tabsReload).not.toHaveBeenCalled();
+    expect(worker.tabsCreate).not.toHaveBeenCalled();
+    expect(app.asked).toContain(`skipped:${app.token}`);
+  });
+
+  it('refuses stale-render reload when the tab starts navigating before the page operation', async () => {
+    const app = staleRenderApp();
+    const tab = { id: 73, url: `https://chatgpt.com/c/${CHAT}` };
+    const reloadRequest = vi.fn(async () => ({ safe: true, reloading: true, conversationId: CHAT,
+      turnId: 'turn-stale-render', navigationEpoch: 0 }));
+    const worker = loadWorker({ local: new FakeStorageArea(paired), session: new FakeStorageArea(),
+      fetch: app.fetch,
+      tabsGet: async () => ({ ...tab, pendingUrl: 'https://chatgpt.com/' }),
+      tabsSendMessage: reloadRequest });
+    await worker.registerTab(73);
+    await worker.send({ type: 'bind', conversationId: CHAT }, 73);
+    app.arm();
+
+    await worker.fireAlarm();
+    expect(worker.tabsReload).not.toHaveBeenCalled();
+    expect(reloadRequest).not.toHaveBeenCalled();
+    expect(app.asked).toContain(`skipped:${app.token}`);
+  });
+
   it('browser-only recovery waits for the missing chat and then reloads its exact existing tab', async () => {
     const { fetch, asked } = appWith(OTHER, true);
     const worker = loadWorker({ local: new FakeStorageArea(paired), session: new FakeStorageArea(), fetch });


### PR DESCRIPTION
Fixes #147.

A ChatGPT reply can visibly stop after a short prefix even though the composer has returned to Send and the server continues to completion. In the captured session, the same assistant message stayed at 156 rendered characters and appeared as a 19,329-character final only after a manual refresh; Chat On Steroids remained in the running state.

This change detects that exact locally witnessed condition after 30 seconds of stable visible text, then carries the conversation and local turn identity through the recorder and bridge. The exact content document performs a final synchronous safety check for the same conversation and turn, an empty composer, no attachments, no pending Fiber calls, and no app-owned work before initiating one page reload. It never replays the prompt and never treats the visible prefix as a completed answer. A changed turn, draft, pending tool, missing tab, or navigation retires the repair without reopening the chat.

Validation:
- `npx vitest run test/content-script.test.ts test/extension.test.ts test/bridge.test.ts` (895 passed)
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `node --check extension/content.js`
- `node --check extension/background.js`
