### PR TITLE
Default composer to ChatGPT Native mode to prevent blocking sends on unobserved models

### DIFF
--- a/src/renderer/chat-models.ts
+++ b/src/renderer/chat-models.ts
@@ -12,6 +12,22 @@ let discovery: Promise<void> | null = null;
 let catalogSubscribed = false;
 type ObservedSelection = { model: string; reasoningEffort?: ReasoningEffort; observedAt: number };
 let composerContext: { scope: string | null; observation: ObservedSelection | null; edited: boolean } | null = null;
+export type ComposerMode = 'native' | 'explicit';
+let composerMode: ComposerMode = 'native';
+
+export function getComposerMode(): ComposerMode {
+  return composerMode;
+}
+
+export function setComposerMode(mode: ComposerMode): void {
+  composerMode = mode;
+  paintStatus();
+}
+
+export function isNativeComposerMode(): boolean {
+  return composerMode === 'native';
+}
+
 const pairs = [['composerModel', 'composerReasoning'], ['workerModel', 'workerReasoning'], ['helperModel', 'helperReasoning']] as const;
 const effortNames: Record<string, string> = { none: 'Instant', minimal: 'Minimal', low: 'Low', medium: 'Medium', high: 'High', xhigh: 'Extra high', max: 'Max', ultra: 'Ultra', pro: 'Pro' } satisfies Record<ReasoningEffort, string>;
 const composerEfforts = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra', 'pro'] as const;
@@ -34,9 +50,15 @@ function paintComposerContext(): void {
 export function applyComposerSessionModel(scope: string | null, observation: ObservedSelection | null): void {
   if (!composerContext || composerContext.scope !== scope) {
     composerContext = { scope, observation, edited: false };
-    if (scope === null) paintPair('composerModel', 'composerReasoning', '', '');
+    if (scope === null) {
+      composerMode = 'native';
+      paintPair('composerModel', 'composerReasoning', '', '');
+    } else if (observation?.model) {
+      composerMode = 'explicit';
+    }
   } else if (observation && (!composerContext.observation || observation.observedAt >= composerContext.observation.observedAt)) {
     composerContext.observation = observation;
+    if (observation.model) composerMode = 'explicit';
   }
   paintComposerContext(); paintStatus();
 }
@@ -100,7 +122,7 @@ function paintComposerChoices(): void {
   const selected = $<HTMLSelectElement>('composerModel');
   const effort = $<HTMLSelectElement>('composerReasoning');
   const choices = composerModels();
-  const signature = JSON.stringify([catalog.state, choices, selected.value, effort.value]);
+  const signature = JSON.stringify([catalog.state, choices, selected.value, effort.value, composerMode]);
   if (models.dataset.signature === signature) return;
   models.dataset.signature = signature;
   models.replaceChildren();
@@ -111,9 +133,16 @@ function paintComposerChoices(): void {
   })));
   const title = document.getElementById('composerPowerTitle');
   const subtitle = document.getElementById('composerPowerModel');
+  const defaultBtn = document.getElementById('composerDefaultBtn') as HTMLButtonElement | null;
+  if (defaultBtn) {
+    defaultBtn.hidden = composerMode === 'native' || !steps.length;
+    defaultBtn.onclick = () => {
+      setComposerMode('native');
+    };
+  }
   if (!steps.length) {
-    if (title) title.textContent = catalog.state === 'pending' ? 'Loading models…' : 'Models unavailable';
-    if (subtitle) subtitle.textContent = catalog.state === 'pending' ? 'Reading your ChatGPT account' : 'Reload models';
+    if (title) title.textContent = catalog.state === 'pending' ? 'Loading models…' : composerMode === 'native' ? 'ChatGPT Default' : 'Models unavailable';
+    if (subtitle) subtitle.textContent = catalog.state === 'pending' ? 'Reading your ChatGPT account' : composerMode === 'native' ? 'Native account model & reasoning' : 'Reload models';
     return;
   }
   const current = steps.findIndex(step => step.model === selected.value && step.effort === effort.value);
@@ -125,27 +154,33 @@ function paintComposerChoices(): void {
   slider.setAttribute('aria-label', 'Model and thinking effort');
   const show = () => {
     const step = steps[Number(slider.value)]!;
-    if (title) title.textContent = effortNames[step.effort] ?? step.effort;
-    if (subtitle) subtitle.textContent = step.modelLabel;
+    if (title) title.textContent = composerMode === 'native' ? 'ChatGPT Default' : (effortNames[step.effort] ?? step.effort);
+    if (subtitle) subtitle.textContent = composerMode === 'native' ? 'Native account model & reasoning' : step.modelLabel;
     slider.setAttribute('aria-valuetext', step.label);
     track.style.setProperty('--power-position', `${steps.length > 1 ? Number(slider.value) / (steps.length - 1) * 100 : 100}%`);
     return step;
   };
   if (current >= 0) show();
-  else {
+  else if (composerMode === 'native') {
+    if (title) title.textContent = 'ChatGPT Default';
+    if (subtitle) subtitle.textContent = 'Native account model & reasoning';
+    slider.setAttribute('aria-valuetext', 'Choose an available model and effort');
+  } else {
     if (title) title.textContent = 'Choose a level';
     if (subtitle) subtitle.textContent = 'Previous selection unavailable';
     slider.setAttribute('aria-valuetext', 'Choose an available model and effort');
   }
   const choose = () => {
+    composerMode = 'explicit';
     if (composerContext) composerContext.edited = true;
     const step = show();
     paintPair('composerModel', 'composerReasoning', step.model, step.effort);
     paintComposerLabel();
-    models.dataset.signature = JSON.stringify([catalog.state, choices, selected.value, effort.value]);
+    if (defaultBtn) defaultBtn.hidden = false;
+    models.dataset.signature = JSON.stringify([catalog.state, choices, selected.value, effort.value, composerMode]);
   };
   slider.oninput = choose;
-  slider.onclick = () => { if (current < 0) choose(); };
+  slider.onclick = () => { if (current < 0 || composerMode === 'native') choose(); };
   // Keep the range node alive through pointer/keyboard adjustment; hidden selects remain
   // the existing send authority, and no separate model selection state is introduced.
   track.append(dots, slider); powers.append(track);
@@ -163,9 +198,11 @@ export function confirmedComposerModel(): { model: string; reasoningEffort: Reas
 function paintComposerLabel(): void {
   // Display the same admission decision as Send, including discovery and removed efforts.
   const confirmed = confirmedComposerModel();
-  const label = confirmed
-    ? chatModelDisplayLabel(catalog.models.find(model => model.id === confirmed.model)!.label, confirmed.reasoningEffort, effortNames[confirmed.reasoningEffort]!)
-    : catalog.state === 'pending' ? 'Loading models…' : 'Select model';
+  const label = composerMode === 'native'
+    ? 'ChatGPT Default'
+    : confirmed
+      ? chatModelDisplayLabel(catalog.models.find(model => model.id === confirmed.model)!.label, confirmed.reasoningEffort, effortNames[confirmed.reasoningEffort]!)
+      : catalog.state === 'pending' ? 'Loading models…' : 'Select model';
   const node = $('composerModelLabel');
   node.textContent = label;
   node.title = label;
@@ -218,6 +255,7 @@ function discoverModels(): Promise<void> {
 }
 
 export async function ensureComposerModel(): Promise<ReturnType<typeof confirmedComposerModel>> {
+  composerMode = 'explicit';
   if (catalog.models.length) return confirmedComposerModel();
   const ready = new Promise<void>(resolve => {
     const finish = () => { clearTimeout(timer); catalogWaiters.delete(check); resolve(); };
@@ -251,6 +289,7 @@ export function applyChatModels(config: Config, previous?: Config): void {
 
 export function initChatModels(onPaint?: () => void): void {
   onComposerPaint = onPaint;
+  composerMode = 'native';
   if (window.api.onChatModelsChanged) {
     catalogSubscribed = true;
     window.api.onChatModelsChanged(value => {
@@ -263,16 +302,25 @@ export function initChatModels(onPaint?: () => void): void {
   document.getElementById('modelMenu')?.addEventListener('toggle', () => {
     if (($('modelMenu') as HTMLDetailsElement).open && !catalog.models.length) $('refreshComposerModels').click();
   });
+  document.getElementById('composerDefaultBtn')?.addEventListener('click', () => {
+    setComposerMode('native');
+  });
   for (const [modelId, effortId] of pairs) {
     document.getElementById(modelId)?.addEventListener('change', () => {
-      if (modelId === 'composerModel' && composerContext) composerContext.edited = true;
+      if (modelId === 'composerModel') {
+        composerMode = 'explicit';
+        if (composerContext) composerContext.edited = true;
+      }
       const model = $<HTMLSelectElement>(modelId);
       const supported = catalog.models.find(item => item.id === model.value)?.efforts ?? [];
       paintPair(modelId, effortId, model.value, supported.includes('high') ? 'high' : supported[0] ?? '');
       paintStatus();
     });
     document.getElementById(effortId)?.addEventListener('change', () => {
-      if (effortId === 'composerReasoning' && composerContext) composerContext.edited = true;
+      if (effortId === 'composerReasoning') {
+        composerMode = 'explicit';
+        if (composerContext) composerContext.edited = true;
+      }
       paintStatus();
     });
   }

--- a/src/renderer/chat.ts
+++ b/src/renderer/chat.ts
@@ -1,4 +1,4 @@
-import { applyChatModels, applyComposerSessionModel, initChatModels, confirmedComposerModel, ensureComposerModel } from './chat-models.js';
+import { applyChatModels, applyComposerSessionModel, initChatModels, confirmedComposerModel, ensureComposerModel, isNativeComposerMode } from './chat-models.js';
 import { marked, Marked } from 'marked';
 import { safeExternalLink } from '../shared/external-link.js';
 import { createAgentPanel } from './agent-panel.js';
@@ -8,6 +8,7 @@ import { communicationTitle, foldAgentCommunication } from './agent-communicatio
 import { initContextMeter, paintContextMeter } from './context-meter.js';
 import { isAstraModel } from '../shared/chat-models.js';
 import type { InputImage, InputAttachment, InputAutomation } from '../shared/input.js';
+import type { ReasoningEffort } from '../shared/session.js';
 import type { InputEntry } from '../main/session/input.js';
 import type { LocalProject } from '../shared/projects.js';
 import type { TaskProgress } from '../shared/task-progress.js';
@@ -3052,15 +3053,21 @@ async function sendComposer(delivery?: 'finish', plan?: string[]): Promise<boole
     }
     return;
   }
-  const discoveryGeneration = ++composerDiscoveryGeneration;
-  const discoverySelection = selectionGeneration, discoverySession = selectedId, discoveryDraft = input.value;
-  const modelSettings = confirmedComposerModel() ?? await ensureComposerModel();
-  // Discovery can outlive navigation or draft edits. Only the latest unchanged
-  // authored send may continue; a second click must never send the same text twice.
-  if (discoveryGeneration !== composerDiscoveryGeneration || discoverySelection !== selectionGeneration || discoverySession !== selectedId ||
-      input.value !== discoveryDraft || (imageDrafts.get(key) ?? []).some((image, index) => image !== images[index]) ||
-      (imageDrafts.get(key)?.length ?? 0) !== images.length) return false;
-  if (!modelSettings) { toast('Model discovery could not confirm your selection. Choose an available model and thinking effort, then send again.'); return false; }
+  let modelSettings: { model: string | null; reasoningEffort: ReasoningEffort | null } | null;
+  if (isNativeComposerMode()) {
+    modelSettings = { model: null, reasoningEffort: null };
+  } else {
+    const discoveryGeneration = ++composerDiscoveryGeneration;
+    const discoverySelection = selectionGeneration, discoverySession = selectedId, discoveryDraft = input.value;
+    const confirmed = confirmedComposerModel() ?? await ensureComposerModel();
+    // Discovery can outlive navigation or draft edits. Only the latest unchanged
+    // authored send may continue; a second click must never send the same text twice.
+    if (discoveryGeneration !== composerDiscoveryGeneration || discoverySelection !== selectionGeneration || discoverySession !== selectedId ||
+        input.value !== discoveryDraft || (imageDrafts.get(key) ?? []).some((image, index) => image !== images[index]) ||
+        (imageDrafts.get(key)?.length ?? 0) !== images.length) return false;
+    if (!confirmed) { toast('Model discovery could not confirm your selection. Choose an available model and thinking effort, then send again.'); return false; }
+    modelSettings = confirmed;
+  }
   const sessionId = selectedId;
   const generation = selectionGeneration;
   const chosenMode = delivery ?? $<HTMLSelectElement>('sendMode').value;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -871,12 +871,13 @@
                 </div>
                 </div>
                 <details class="composer-menu model-menu" id="modelMenu">
-                  <summary><span id="composerModelLabel">Model</span><svg class="ico picker-chevron" viewBox="0 0 20 20" aria-hidden="true"><path d="m6 8 4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></summary>
+                  <summary><span id="composerModelLabel">ChatGPT Default</span><svg class="ico picker-chevron" viewBox="0 0 20 20" aria-hidden="true"><path d="m6 8 4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></summary>
                   <div class="composer-popover">
                     <div class="power-header"><div class="power-caption"><strong id="composerPowerTitle">Choose a level</strong><span id="composerPowerModel">Observed models</span></div><button class="btn model-reload" id="refreshComposerModels" data-keep-menu="true" type="button" title="Reload ChatGPT models" aria-label="Reload ChatGPT models"><svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 7v5h-5M20 12a8 8 0 1 0-2 5M20 7l-3 3" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" /></svg></button>
                     </div><p id="composerModelStatus" class="muted" role="status" hidden></p>
                     <div id="composerModelChoices" role="group" aria-label="Model"></div><div id="composerPowerChoices" role="group" aria-label="Thinking effort"></div><label hidden>Model<select id="composerModel" aria-label="ChatGPT model"><option value="" disabled>No observed choices</option></select></label>
                     <label hidden>Reasoning<select id="composerReasoning" aria-label="Reasoning effort"><option value="" disabled>No observed choices</option></select></label>
+                    <button class="btn composer-default-btn" id="composerDefaultBtn" data-keep-menu="true" type="button" hidden>Use ChatGPT Default</button>
                   </div>
                 </details>
                 <button class="btn" id="generateFinishGoal" type="button" hidden>Generate Goal</button>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2733,6 +2733,7 @@ select option { background: var(--card); color: var(--ink); }
 
 .model-menu .composer-popover { width: 272px; padding: 8px 12px 15px; }
 .model-menu .model-reload { display: flex; width: 28px; height: 28px; min-height: 28px; padding: 5px; justify-content: center; }
+.composer-default-btn { width: 100%; margin-top: 12px; font-size: 12px; padding: 6px 10px; text-align: center; border-radius: 6px; }
 #composerModelStatus { font-size: 12px; padding: 4px 10px; line-height: 1.5; }
 .power-header { display: grid; grid-template-columns: 28px minmax(0, 1fr) 28px; align-items: center; gap: 8px; margin-bottom: 17px; }
 .power-caption { grid-column: 2; display: flex; flex-direction: column; align-items: center; min-width: 0; gap: 3px; }

--- a/test/composer-native-mode.test.ts
+++ b/test/composer-native-mode.test.ts
@@ -1,0 +1,317 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import type { Config } from '../src/shared/types.js';
+
+let dom: JSDOM;
+let sendInputCalls: any[] = [];
+
+function setupDom(html: string, initialCatalog: any) {
+  dom = new JSDOM(html, { url: 'https://local.test/', pretendToBeVisual: true });
+  const w = dom.window as any;
+
+  sendInputCalls = [];
+
+  const ok = (data: any) => Promise.resolve({ ok: true as const, data });
+  let chatModelsListener: ((cat: any) => void) | null = null;
+
+  const api: any = new Proxy(
+    {
+      getChatModels: async () => ok(initialCatalog),
+      requestChatModels: async () => ok(initialCatalog),
+      onChatModelsChanged: (listener: (cat: any) => void) => {
+        chatModelsListener = listener;
+        if (initialCatalog) listener(initialCatalog);
+        return () => { chatModelsListener = null; };
+      },
+      listSessions: async () => ok({ sessions: [], activeId: null, pressure: [], total: 0, nextCursor: null }),
+      getSession: async () => ok({ summary: null, events: [], total: 0, nextFrom: 1 }),
+      getSwarm: async () => ok({ running: false, runId: null, agents: [], maxWorkers: 2, pendingReports: 0 }),
+      onSessionChanged: () => () => {},
+      onTaskProgress: () => () => {},
+      onSwarmChanged: () => () => {},
+      sendInput: async (payload: any) => {
+        sendInputCalls.push(payload);
+        return ok({ id: payload.id, sessionId: payload.sessionId, state: 'queued', dueAt: Date.now() });
+      }
+    },
+    {
+      get(target, prop) {
+        if (prop in target) return (target as any)[prop];
+        return (..._args: any[]) => ok(null);
+      }
+    }
+  );
+
+  w.api = api;
+  if (!w.matchMedia) {
+    w.matchMedia = () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} });
+  }
+  if (!w.HTMLElement.prototype.scrollIntoView) {
+    w.HTMLElement.prototype.scrollIntoView = () => {};
+  }
+  if (!w.HTMLElement.prototype.animate) {
+    w.HTMLElement.prototype.animate = () => ({ finish: () => {} });
+  }
+
+  Object.assign(globalThis, {
+    window: w,
+    document: w.document,
+    HTMLElement: w.HTMLElement,
+    Element: w.Element,
+    Node: w.Node,
+    DocumentFragment: w.DocumentFragment,
+    HTMLInputElement: w.HTMLInputElement,
+    HTMLSelectElement: w.HTMLSelectElement,
+    HTMLTextAreaElement: w.HTMLTextAreaElement,
+    HTMLButtonElement: w.HTMLButtonElement,
+    Event: w.Event,
+    CustomEvent: w.CustomEvent
+  });
+
+  return { w, pushCatalog: (c: any) => chatModelsListener?.(c) };
+}
+
+afterEach(() => {
+  dom?.window.close();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe('Composer Native Mode', () => {
+  it('Test 1: Native mode + no model catalogue (models: []) => send allowed (model: null, reasoningEffort: null)', async () => {
+    const html = await readFile('src/renderer/index.html', 'utf8');
+    const catalog = { state: 'ready', requestedAt: 1, observedAt: 2, models: [] };
+    setupDom(html, catalog);
+
+    const { initChat } = await import('../src/renderer/chat.js');
+    const { getComposerMode, isNativeComposerMode } = await import('../src/renderer/chat-models.js');
+
+    const config = {
+      sessions: { record: true, limitTokens: 533000 },
+      compaction: { auto: true, autoTokens: 400000 },
+      ui: { developerMode: true, planBackend: 'chatgpt' },
+      multiAgent: {},
+      goal: {}
+    } as Config;
+
+    initChat({ save: async () => {}, state: () => ({ config }) as any });
+    await Promise.resolve();
+
+    expect(getComposerMode()).toBe('native');
+    expect(isNativeComposerMode()).toBe(true);
+
+    const input = dom.window.document.getElementById('chatInput') as HTMLTextAreaElement;
+    input.value = 'Hello in native mode without models';
+
+    const form = dom.window.document.getElementById('composer') as HTMLFormElement;
+    form.dispatchEvent(new dom.window.Event('submit', { cancelable: true }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(sendInputCalls).toHaveLength(1);
+    expect(sendInputCalls[0].text).toBe('Hello in native mode without models');
+    expect(sendInputCalls[0].model).toBeNull();
+    expect(sendInputCalls[0].reasoningEffort).toBeNull();
+  });
+
+  it('Test 2: Native mode + picker_unavailable => send allowed', async () => {
+    const html = await readFile('src/renderer/index.html', 'utf8');
+    const catalog = { state: 'unavailable', requestedAt: 1, observedAt: null, models: [], error: 'picker_unavailable' };
+    setupDom(html, catalog);
+
+    const { initChat } = await import('../src/renderer/chat.js');
+    const { getComposerMode } = await import('../src/renderer/chat-models.js');
+
+    const config = {
+      sessions: { record: true, limitTokens: 533000 },
+      compaction: { auto: true, autoTokens: 400000 },
+      ui: { developerMode: true, planBackend: 'chatgpt' },
+      multiAgent: {},
+      goal: {}
+    } as Config;
+
+    initChat({ save: async () => {}, state: () => ({ config }) as any });
+    await Promise.resolve();
+
+    expect(getComposerMode()).toBe('native');
+
+    const input = dom.window.document.getElementById('chatInput') as HTMLTextAreaElement;
+    input.value = 'Native send when picker is unavailable';
+
+    const form = dom.window.document.getElementById('composer') as HTMLFormElement;
+    form.dispatchEvent(new dom.window.Event('submit', { cancelable: true }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(sendInputCalls).toHaveLength(1);
+    expect(sendInputCalls[0].text).toBe('Native send when picker is unavailable');
+    expect(sendInputCalls[0].model).toBeNull();
+    expect(sendInputCalls[0].reasoningEffort).toBeNull();
+  });
+
+  it('Test 3: Explicit mode + picker_unavailable => send blocked with error toast', async () => {
+    const html = await readFile('src/renderer/index.html', 'utf8');
+    const catalog = { state: 'unavailable', requestedAt: 1, observedAt: null, models: [], error: 'picker_unavailable' };
+    setupDom(html, catalog);
+
+    const { initChat } = await import('../src/renderer/chat.js');
+    const { setComposerMode, getComposerMode } = await import('../src/renderer/chat-models.js');
+
+    const config = {
+      sessions: { record: true, limitTokens: 533000 },
+      compaction: { auto: true, autoTokens: 400000 },
+      ui: { developerMode: true, planBackend: 'chatgpt' },
+      multiAgent: {},
+      goal: {}
+    } as Config;
+
+    initChat({ save: async () => {}, state: () => ({ config }) as any });
+    await Promise.resolve();
+
+    setComposerMode('explicit');
+    expect(getComposerMode()).toBe('explicit');
+
+    const input = dom.window.document.getElementById('chatInput') as HTMLTextAreaElement;
+    input.value = 'Should be blocked';
+
+    const form = dom.window.document.getElementById('composer') as HTMLFormElement;
+    form.dispatchEvent(new dom.window.Event('submit', { cancelable: true }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(sendInputCalls).toHaveLength(0);
+    expect(input.value).toBe('Should be blocked');
+  });
+
+  it('Test 4: Explicit mode + observed model => send allowed with { model, reasoningEffort }', async () => {
+    const html = await readFile('src/renderer/index.html', 'utf8');
+    const catalog = {
+      state: 'ready',
+      requestedAt: 1,
+      observedAt: 2,
+      models: [{ id: 'sol', label: 'GPT-5.6 Sol', efforts: ['high', 'pro'] }]
+    };
+    setupDom(html, catalog);
+
+    const { initChat } = await import('../src/renderer/chat.js');
+    const { applyChatModels, setComposerMode, confirmedComposerModel } = await import('../src/renderer/chat-models.js');
+
+    const config = {
+      sessions: { record: true, limitTokens: 533000 },
+      compaction: { auto: true, autoTokens: 400000 },
+      ui: { developerMode: true, planBackend: 'chatgpt' },
+      multiAgent: {},
+      goal: {}
+    } as Config;
+
+    initChat({ save: async () => {}, state: () => ({ config }) as any });
+    setComposerMode('explicit');
+    applyChatModels(config);
+    await Promise.resolve();
+
+    const slider = dom.window.document.querySelector<HTMLInputElement>('#composerPowerChoices input');
+    if (slider) {
+      slider.value = '0';
+      slider.dispatchEvent(new dom.window.Event('input'));
+    }
+
+    expect(confirmedComposerModel()).toEqual({ model: 'sol', reasoningEffort: 'high' });
+
+    const input = dom.window.document.getElementById('chatInput') as HTMLTextAreaElement;
+    input.value = 'Explicit send with confirmed model';
+
+    const form = dom.window.document.getElementById('composer') as HTMLFormElement;
+    form.dispatchEvent(new dom.window.Event('submit', { cancelable: true }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise(r => setTimeout(r, 20));
+
+    expect(sendInputCalls).toHaveLength(1);
+    expect(sendInputCalls[0].text).toBe('Explicit send with confirmed model');
+    expect(sendInputCalls[0].model).toBe('sol');
+    expect(sendInputCalls[0].reasoningEffort).toBe('high');
+  });
+
+  it('Test 5: Switch native <-> explicit preserves correct state and labels', async () => {
+    const html = await readFile('src/renderer/index.html', 'utf8');
+    const catalog = {
+      state: 'ready',
+      requestedAt: 1,
+      observedAt: 2,
+      models: [{ id: 'sol', label: 'GPT-5.6 Sol', efforts: ['high'] }]
+    };
+    setupDom(html, catalog);
+
+    const { initChatModels, applyChatModels, getComposerMode } = await import('../src/renderer/chat-models.js');
+    const config = { multiAgent: {}, goal: {} } as Config;
+
+    initChatModels();
+    applyChatModels(config);
+    await Promise.resolve();
+
+    const label = dom.window.document.getElementById('composerModelLabel')!;
+    const defaultBtn = dom.window.document.getElementById('composerDefaultBtn') as HTMLButtonElement;
+
+    // Initially in native mode
+    expect(getComposerMode()).toBe('native');
+    expect(label.textContent).toBe('ChatGPT Default');
+    expect(defaultBtn.hidden).toBe(true);
+
+    // Switch to explicit via slider selection
+    const slider = dom.window.document.querySelector<HTMLInputElement>('#composerPowerChoices input')!;
+    slider.dispatchEvent(new dom.window.Event('input'));
+
+    expect(getComposerMode()).toBe('explicit');
+    expect(label.textContent).toBe('GPT-5.6 Sol · High');
+    expect(defaultBtn.hidden).toBe(false);
+
+    // Switch back to native using the "Use ChatGPT Default" button
+    defaultBtn.click();
+
+    expect(getComposerMode()).toBe('native');
+    expect(label.textContent).toBe('ChatGPT Default');
+    expect(defaultBtn.hidden).toBe(true);
+  });
+
+  it('Test 6: Changing/reloading model catalogue does not erase Native mode', async () => {
+    const html = await readFile('src/renderer/index.html', 'utf8');
+    let catalog: any = { state: 'pending', requestedAt: 1, observedAt: null, models: [] };
+    const { pushCatalog } = setupDom(html, catalog);
+
+    const { initChatModels, applyChatModels, getComposerMode, isNativeComposerMode } = await import('../src/renderer/chat-models.js');
+    const config = { multiAgent: {}, goal: {} } as Config;
+
+    initChatModels();
+    applyChatModels(config);
+    await Promise.resolve();
+
+    expect(getComposerMode()).toBe('native');
+    expect(isNativeComposerMode()).toBe(true);
+    const label = dom.window.document.getElementById('composerModelLabel')!;
+    expect(label.textContent).toBe('ChatGPT Default');
+
+    // Catalog update arrives with observed models
+    catalog = {
+      state: 'ready',
+      requestedAt: 1,
+      observedAt: 2,
+      models: [{ id: 'sol', label: 'GPT-5.6 Sol', efforts: ['high', 'xhigh'] }]
+    };
+    pushCatalog(catalog);
+    applyChatModels(config);
+    await Promise.resolve();
+
+    // Native mode MUST remain intact
+    expect(getComposerMode()).toBe('native');
+    expect(isNativeComposerMode()).toBe(true);
+    expect(label.textContent).toBe('ChatGPT Default');
+  });
+});

--- a/test/renderer-chat-models.test.ts
+++ b/test/renderer-chat-models.test.ts
@@ -261,9 +261,9 @@ it('keeps the trigger consistent with send admission during reload and a removed
     getChatModels: async () => ({ ok: true, data: catalog }),
     requestChatModels: async () => ({ ok: true, data: { ...catalog, state: 'pending', requestedAt: 3 } })
   } });
-  const { initChatModels, applyChatModels, confirmedComposerModel } = await import('../src/renderer/chat-models.js');
+  const { initChatModels, applyChatModels, confirmedComposerModel, setComposerMode } = await import('../src/renderer/chat-models.js');
   const config = { multiAgent: {}, goal: {} } as Config;
-  initChatModels(); applyChatModels(config); await Promise.resolve();
+  initChatModels(); setComposerMode('explicit'); applyChatModels(config); await Promise.resolve();
   const label = dom.window.document.getElementById('composerModelLabel')!;
   expect(label.textContent).toBe('GPT-5.6 Sol · High');
   expect(confirmedComposerModel()).toEqual({ model: 'sol', reasoningEffort: 'high' });


### PR DESCRIPTION
## What changed

### Context & Problem
While setting up and using Chat On Steroids on Windows with ChatGPT, I encountered a blocker when trying to send messages from the desktop composer. Every message attempt stalled waiting for model discovery and failed with the toast error:
> *"Model discovery could not confirm your selection. Choose an available model and thinking effort, then send again."*

Checking the extension logs and network traffic revealed that model discovery was returning `picker_unavailable` with 0 models (`models: []`). On accounts using newer ChatGPT subscription configurations or interface variants (such as Go tiers or regional rollout layouts where the DOM model picker is styled differently or absent), the companion extension cannot locate or scrape observed model options from the web page.

Because the desktop composer treated having a verified model catalogue as a mandatory prerequisite for admission, any failure in model discovery made the entire app unable to send messages — even though the local MCP servers, bridge connection, and ChatGPT tab were otherwise functioning properly.

### Root Cause
In `src/renderer/chat.ts`, `sendComposer()` unconditionally waited on model discovery:
```typescript
const modelSettings = confirmedComposerModel() ?? await ensureComposerModel();
if (!modelSettings) {
  toast('Model discovery could not confirm your selection. Choose an available model and thinking effort, then send again.');
  return false;
}
```
When `ensureComposerModel()` returned `null`, sending was rejected outright.

Looking at `extension/chatgpt-dom.js` (around line 1994), however, the companion extension already has native support for sending without an explicit model selection:
```javascript
if (!model && !effort) return true;
```
When `model: null` and `reasoningEffort: null` are passed, the extension bypasses DOM model picker manipulation entirely and injects the message directly into the active ChatGPT conversation. ChatGPT then handles the turn using whatever default model and reasoning settings are already active on the user's account. In addition, the IPC schema in `src/main/session/input.ts` already permits `null` for both `model` and `reasoningEffort`.

### Proposed Fix: ChatGPT Native Mode
Rather than blocking all composer sends on model discovery, this pull request introduces **Native Mode** as the default admission state:

1. **Default to Native Mode (`composerMode = 'native'`)**:
   - The composer defaults to `ChatGPT Default` (both in label and state).
   - In Native Mode, `sendComposer()` bypasses the blocking `ensureComposerModel()` call and submits `{ model: null, reasoningEffort: null }`.
   - Messages are delivered immediately to the active conversation without requiring DOM model picker interaction.

2. **Explicit Selection Mode (`composerMode = 'explicit'`)**:
   - If the user moves the reasoning power slider or chooses an observed model in the dropdown, the composer automatically transitions to Explicit Mode.
   - In Explicit Mode, all existing validation checks, model catalogue confirmations, and error toasts remain active.

3. **User Control**:
   - Added a "Use ChatGPT Default" button (`#composerDefaultBtn`) inside the `#modelMenu` popover so users can return to Native Mode from an explicit selection at any time.
   - Starting a new chat (`selectNewChat()`) cleanly resets to Native Mode, while existing session observations continue to bind properly.

---

## Validation

- [x] Added or updated a deterministic regression test where behavior changed.
  - Added `test/composer-native-mode.test.ts` covering 6 deterministic test scenarios:
    1. Native mode with empty catalog (`models: []`) -> sends permitted with `{ model: null, reasoningEffort: null }`.
    2. Native mode with `picker_unavailable` -> sends permitted with `{ model: null, reasoningEffort: null }`.
    3. Explicit mode with `picker_unavailable` -> sends blocked with toast error as expected.
    4. Explicit mode with observed model -> sends with selected `{ model, reasoningEffort }`.
    5. Native <-> Explicit mode switching preserves state, UI labels, and button visibility.
    6. Background catalogue pushes do not reset or overwrite an active Native mode.
  - Updated `test/renderer-chat-models.test.ts` to test explicit catalog reload behavior cleanly.
  - All 36 tests in `test/chat-models.test.ts`, `test/renderer-chat-models.test.ts`, and `test/composer-native-mode.test.ts` pass cleanly.
- [x] `npm run verify` passes (`npm run typecheck` passes with 0 errors).
- [x] Packaging/runtime smoke was run when the change can differ after bundling.
  - Built the Windows x64 NSIS package with `npm run dist:x64` (`Chat-On-Steroids-Setup-x64.exe`). Tested unpackaged binary in `release/win-unpacked` on Windows; message dispatch operates without stalling on accounts where picker discovery fails.
- [x] No unrelated formatting, generated output, local debugging notes, or private data is included.
- [x] Screenshots, logs and examples use placeholders instead of real usernames, paths, chat text, IDs or credentials.
- [x] Security-sensitive details are being handled privately instead of disclosed here.
