### PR TITLE
fix(extension): never close a tab the user pinned

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1252,7 +1252,7 @@ async function retireFailedCommandTab(entry) {
       failedCommand: { id: entry.id, client: entry.client } }, { documentId: source.documentId });
     const latest = await chrome.tabs.get(source.tab);
     if (proof?.safe === true && proof.conversationId === null && proof.navigationEpoch === source.navigationEpoch &&
-        latest && !latest.pendingUrl && latest.url === url && ownsDocument(source)) await chrome.tabs.remove(source.tab);
+        latest && latest.pinned !== true && !latest.pendingUrl && latest.url === url && ownsDocument(source)) await chrome.tabs.remove(source.tab);
   } catch { /* A busy, edited, replaced or unreadable page stays open. */ }
 }
 
@@ -1774,7 +1774,7 @@ async function deliverDesktopInputs(inputs, background, reusableConversations = 
         const proof = await chrome.tabs.sendMessage(tab.id, { type: 'clf-close-temporary-planner', id: input.id, owner: input.owner }, { documentId });
         const current = await chrome.tabs.get(tab.id);
         const successor = replacement ? await chrome.tabs.get(replacement.id) : null;
-        if (proof?.safe === true && ownsDocument(source) && String(current.url || '').includes(marker) &&
+        if (proof?.safe === true && current.pinned !== true && ownsDocument(source) && String(current.url || '').includes(marker) &&
             (input.retire === true || (successor && replacements.some(next => matchesInput(next, successor))))) await chrome.tabs.remove(tab.id);
       } catch { /* only the exact still-owned temporary document may close */ }
       continue;
@@ -1896,7 +1896,8 @@ function inspectRequestedPluginRefresh(publications, background, browserOnly = f
       let timer;
       const proof = await Promise.race([chrome.tabs.sendMessage(tab.id, { type: 'clf-plugin-refresh-state', id }).catch(() => null), new Promise(resolve => { timer = setTimeout(() => resolve(null), 3000); })]).finally(() => clearTimeout(timer));
       if (proof?.safe !== true) return;
-      if (pluginRefreshMarker(await chrome.tabs.get(tab.id).catch(() => null)) === id) await chrome.tabs.remove(tab.id);
+      const latest = await chrome.tabs.get(tab.id).catch(() => null);
+      if (latest?.pinned !== true && pluginRefreshMarker(latest) === id) await chrome.tabs.remove(tab.id);
     }
     if (!requests.length) return;
     const held = tabs.find(tab => requests.some(request => request.id === pluginRefreshMarker(tab)));
@@ -1980,7 +1981,7 @@ function inspectRequestedModels(request) {
           ]).finally(() => clearTimeout(timer));
           const latest = await chrome.tabs.get(candidate.id);
           if (proof?.safe !== true || proof.conversationId !== null || proof.navigationEpoch !== source.navigationEpoch || !ownsDocument(source) ||
-            latest.pendingUrl || latest.url !== candidate.url) continue;
+            latest.pinned === true || latest.pendingUrl || latest.url !== candidate.url) continue;
           await chrome.tabs.remove(candidate.id);
         } catch { /* Busy, drafting or changed documents keep their tab for ordinary maintenance. */ }
       }
@@ -2083,6 +2084,9 @@ async function pruneManagedTabs(tabs, policy, protectedChats, closable) {
   for (const tab of candidates) {
     const conversationId = conversationForTab(tab);
     if (!Number.isInteger(tab.id)) continue;
+    // A tab the user pinned is theirs to close. Retirement, closable and duplicate
+    // state stay recorded; the tab closes once the user unpins it.
+    if (tab.pinned === true) continue;
     const duplicate = keeper.get(conversationId) !== tab.id && remaining.some(other => other.id !== tab.id && conversationForTab(other) === conversationId);
     if (protectedChats.has(conversationId)) continue;
     // Idleness and broker slot pressure are not retirement. Reusable chats stay
@@ -2097,13 +2101,14 @@ async function pruneManagedTabs(tabs, policy, protectedChats, closable) {
     if (cancelledClaims.length && !cancelledDecisions.length) continue;
     try {
       const current = await chrome.tabs.get(tab.id);
-      if (conversationFromUrl(current.url) !== conversationId || current.pendingUrl) continue;
+      if (current.pinned === true || conversationFromUrl(current.url) !== conversationId || current.pendingUrl) continue;
 
       const proof = await chrome.tabs.sendMessage(tab.id, { type: 'clf-tab-close-check', conversationId,
         allowGenerating: blocked.has(conversationId), ...(cancelledDecisions.length ? { cancelledDecisions } : {}) }, { documentId: source.documentId });
       if (proof?.safe !== true || proof.conversationId !== conversationId || proof.navigationEpoch !== source.navigationEpoch || !ownsDocument(source)) continue;
       const latest = await chrome.tabs.get(tab.id);
-      if (latest.pendingUrl || conversationFromUrl(latest.url) !== conversationId || !ownsDocument(source) || journalCountForConversation(conversationId) > 0) continue;
+      // Pinning during the close proof counts too: the last read before the close decides.
+      if (latest.pinned === true || latest.pendingUrl || conversationFromUrl(latest.url) !== conversationId || !ownsDocument(source) || journalCountForConversation(conversationId) > 0) continue;
 
       await chrome.tabs.remove(tab.id);
       remaining = remaining.filter(other => other.id !== tab.id);
@@ -2530,7 +2535,7 @@ const HANDLERS = {
       // that navigated while the app durably committed the decision.
       try {
         const current = await chrome.tabs.get(source.tab);
-        if (ownsDocument(source) && conversationFromUrl(current.url) === conversationId) await chrome.tabs.remove(source.tab);
+        if (current.pinned !== true && ownsDocument(source) && conversationFromUrl(current.url) === conversationId) await chrome.tabs.remove(source.tab);
       } catch { /* already closed; the accepted app-side answer remains authoritative */ }
     }
     return result;

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -3373,3 +3373,23 @@ it.each(['matching', 'wrong-document', 'unsafe-draft', 'newer-navigation'])('ret
   expect(tabsRemove).toHaveBeenCalledTimes(scenario === 'matching' ? 1 : 0);
   if (scenario === 'matching') expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({ cancelledDecisions: claims });
 });
+
+it.each(['already-pinned', 'pinned-during-close-proof'])('never closes a tab the user pinned: %s', async scenario => {
+  const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+  const tab = { id: 72, url: `https://chatgpt.com/c/${conversationId}`, active: false, pinned: scenario === 'already-pinned' };
+  const tabsRemove = vi.fn();
+  const sendMessage = vi.fn(async (..._args: unknown[]) => ({ safe: true, conversationId, navigationEpoch: 0 }));
+  let reads = 0;
+  const code = backgroundSource.slice(backgroundSource.indexOf('async function pruneManagedTabs('), backgroundSource.indexOf('\nfunction maintain(', backgroundSource.indexOf('async function pruneManagedTabs(')));
+  const prune = vm.runInNewContext(`${code}\npruneManagedTabs`, {
+    cleanConversationId: (id: string) => id, conversationForTab: () => conversationId,
+    conversationFromUrl: (url: string) => url.split('/c/')[1], tabDocuments: { '72': 'doc' }, tabEpochs: { '72': 0 },
+    ownsDocument: () => true, journalCountForConversation: () => 0,
+    // The second fresh read is the one right before the close: pinning by then must still count.
+    chrome: { tabs: { get: async () => ({ ...tab, pinned: tab.pinned || ++reads === 2 }), sendMessage, remove: tabsRemove } }
+  });
+  const remaining = await prune([tab], { managedConversations: [conversationId], retiredConversations: [conversationId] }, new Set(), new Set());
+  expect(tabsRemove).not.toHaveBeenCalled();
+  expect(remaining).toEqual([tab]);
+  if (scenario === 'already-pinned') expect(sendMessage).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Root cause

Fixes #150.

`pruneManagedTabs()` in `extension/background.js` checks conversation identity, navigation state, unsent work and the page-side close proof before `chrome.tabs.remove(tab.id)`, but neither the initial tab object nor the two fresh `chrome.tabs.get` reads are checked for `pinned === true`. A pinned conversation tab was therefore closed exactly like an unpinned one as soon as its conversation showed up in `retiredConversations` / `closableConversations` or counted as a duplicate.

## Smallest behavior change

- `pruneManagedTabs`: a pinned tab is never a close candidate (`continue` before any policy evaluation), and the flag is re-checked on both fresh reads (`current` before the close proof, `latest` right before the close), so pinning during the asynchronous close-proof sequence counts as well. Retirement/closable/duplicate state is untouched; the tab closes once the user unpins it.
- The other automatic closes read a fresh tab object before `chrome.tabs.remove` already; each now also requires `pinned !== true` on that object: the accepted Goal-helper answer close, `retireFailedCommandTab`, the temporary planner retirement, the plugin-refresh tabs and the model-catalog tabs. No permission, identity or recovery logic changes; a pinned tab simply stays open.

## Validation

`test/extension.test.ts`: two new cases run the sliced `pruneManagedTabs` the same way the existing cancelled-helper test does. A retired conversation tab that is already pinned is never messaged or removed and stays in the returned list; a tab that becomes pinned between the close proof and the final read is not removed either. Both fail on `main` (the tab is removed).

```
npx vitest run test/extension.test.ts -t "pinned|cancelled helper"   → 6 passed
npx tsc --noEmit -p tsconfig.json                                    → clean
```

Not exercised against a live Chrome; the change only adds `pinned` checks next to the existing fresh-read guards.
