### PR TITLE
Resume reusable tabs after native New Chat navigation

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1721,6 +1721,16 @@ async function createChatTab(url, background = false, active = !background) {
   });
 }
 
+async function boundedDocumentMessage(tabId, message, documentId, timeoutMs) {
+  let timer;
+  try {
+    return await Promise.race([
+      chrome.tabs.sendMessage(tabId, message, { documentId }).catch(() => null),
+      new Promise(resolve => { timer = setTimeout(() => resolve(null), timeoutMs); })
+    ]);
+  } finally { clearTimeout(timer); }
+}
+
 async function deliverDesktopInputs(inputs, background, reusableConversations = [], activeIds) {
   if (!Array.isArray(inputs)) return;
   // Only the app's complete outbox projection retires spent opening authority.
@@ -1783,6 +1793,45 @@ async function deliverDesktopInputs(inputs, background, reusableConversations = 
     // A later user-close or duplicate document cannot transfer that election.
     if (tab && !elected) await elect(input.id, { tab: tab.id, stage: 'ready', conversationId: target });
     if (!tab) {
+      // Native New Chat can replace the document before sendMessage returns. The durable
+      // preparing election already spent this operation's one-tab authority, so resume only
+      // that exact tab after the replacement recorder proves it is still an eligible page.
+      // Never turn a lost reply into authority to open or take over a different tab.
+      if (!target && elected?.stage === 'preparing' && Number.isInteger(elected.tab)) {
+        const candidate = tabs.find(row => row.id === elected.tab);
+        const documentId = candidate && tabDocuments[String(candidate.id)];
+        const navigationEpoch = candidate && tabEpochs[String(candidate.id)];
+        const source = candidate && { tab: candidate.id, documentId, navigationEpoch };
+        if (candidate && !candidate.pendingUrl && ownsDocument(source)) {
+          const proof = await boundedDocumentMessage(candidate.id, { type: 'clf-input-reuse-state' }, documentId, 3000);
+          const current = proof?.safe === true ? await chrome.tabs.get(candidate.id).catch(() => null) : null;
+          const currentConversation = conversationForTab(current);
+          const sourceConversation = cleanConversationId(elected.sourceConversationId);
+          let transitionedHome = false;
+          try {
+            const currentUrl = new URL(current?.url || '');
+            transitionedHome = currentUrl.origin === 'https://chatgpt.com' && currentUrl.pathname === '/' &&
+              !currentUrl.searchParams.has('cos-input') && !currentUrl.searchParams.has('cos-model-catalog') &&
+              !currentUrl.searchParams.has('cos-plugin-refresh') && !currentUrl.searchParams.has('temporary-chat') &&
+              !currentUrl.hash.startsWith('#settings/') && !new URLSearchParams(currentUrl.hash.slice(1)).has('cos-input');
+          } catch { /* not an eligible ChatGPT transition */ }
+          const sameTransition = sourceConversation
+            ? currentConversation === sourceConversation || (!currentConversation && transitionedHome)
+            : current?.url === elected.sourceUrl;
+          if (proof?.navigationEpoch === navigationEpoch && ownsDocument(source) && current &&
+              !current.pendingUrl && current.url === candidate.url && sameTransition) {
+            const prepared = await boundedDocumentMessage(candidate.id, { type: 'clf-prepare-desktop-input', id: input.id }, documentId, 15000);
+            const latest = prepared?.ready === true ? await chrome.tabs.get(candidate.id).catch(() => null) : null;
+            if (latest && !latest.pendingUrl && tabDocuments[String(candidate.id)] === documentId && matchesInput(input, latest)) {
+              await elect(input.id, { tab: candidate.id, stage: 'ready', conversationId: target });
+              elected = elections[input.id];
+              tab = latest;
+            }
+          }
+        }
+      }
+    }
+    if (!tab) {
       // Handout is opening authority, not a missing delivery receipt. A closed or
       // unresponsive elected document never grants another opening attempt.
       if (elections[input.id]) continue;
@@ -1796,18 +1845,16 @@ async function deliverDesktopInputs(inputs, background, reusableConversations = 
         for (const candidate of choices) {
           const source = { tab: candidate.id, documentId: tabDocuments[String(candidate.id)], navigationEpoch: tabEpochs[String(candidate.id)] };
           if (!ownsDocument(source)) continue;
-          let proof;
-          try { proof = await chrome.tabs.sendMessage(candidate.id, { type: 'clf-input-reuse-state' }, { documentId: source.documentId }); }
-          catch { continue; }
+          const proof = await boundedDocumentMessage(candidate.id, { type: 'clf-input-reuse-state' }, source.documentId, 3000);
           const current = await chrome.tabs.get(candidate.id).catch(() => null);
           if (proof?.safe !== true || proof.navigationEpoch !== source.navigationEpoch || !ownsDocument(source) ||
               !current || current.pendingUrl || current.url !== candidate.url) continue;
-          await elect(input.id, { tab: candidate.id, stage: 'preparing' });
+          await elect(input.id, { tab: candidate.id, stage: 'preparing',
+            sourceConversationId: conversationForTab(current), sourceUrl: current.url });
           const owner = (await chrome.storage.session.get('modelCatalogOwner')).modelCatalogOwner;
           if (owner?.tab === candidate.id) await chrome.storage.session.set({ modelCatalogOwner: { ...owner, handedToInput: input.id } });
-          let prepared;
-          try { prepared = await chrome.tabs.sendMessage(candidate.id, { type: 'clf-prepare-desktop-input', id: input.id }, { documentId: source.documentId }); }
-          catch { break; } // Ambiguous preparation is not a fallback authorization.
+          const prepared = await boundedDocumentMessage(candidate.id, { type: 'clf-prepare-desktop-input', id: input.id }, source.documentId, 15000);
+          if (!prepared) break; // Ambiguous preparation is not a fallback authorization.
           const latest = await chrome.tabs.get(candidate.id).catch(() => null);
           if (!latest || latest.pendingUrl || tabDocuments[String(candidate.id)] !== source.documentId) break;
           if (prepared?.ready === true && matchesInput(input, latest)) {

--- a/test/desktop-input-maintenance.test.ts
+++ b/test/desktop-input-maintenance.test.ts
@@ -6,6 +6,7 @@ import { BRIDGE_PROTOCOL } from '../src/main/version.js';
 const source = readFileSync(new URL('../extension/background.js', import.meta.url), 'utf8');
 const firstId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
 const secondId = 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff';
+const thirdId = 'cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa';
 
 it('missing models retain the elected Work document without a New Chat or helper fallback', async () => {
   const h = await worker([]);
@@ -399,6 +400,81 @@ describe('one browser maintenance flight per desktop outbox publication', () => 
     expect(h.create).not.toHaveBeenCalled();
     expect(h.sendMessage).toHaveBeenCalledWith(7, { type: 'clf-desktop-input', id: firstId, conversationId: null });
     expect((h.localSaved.inputOpenings as any)[firstId].tab).toBe(7);
+  });
+  it('resumes the exact elected tab when native New Chat replaces the document before replying', async () => {
+    const h = await worker([{ id: firstId, conversationId: null }]);
+    const conversationUrl = `https://chatgpt.com/c/${secondId}`;
+    h.tabs.push({ id: 7, url: conversationUrl, active: true });
+    await h.authorizeDocument({ tab: { id: 7 }, documentId: 'conversation', frameId: 0, url: conversationUrl }, { navigationEpoch: 1 });
+    h.fetch.mockResolvedValue({ ok: true, status: 200, json: async () => ({ app: 'chat-on-steroids', bridge: BRIDGE_PROTOCOL,
+      compatible: true, paired: true, ok: true, inputs: [{ id: firstId, conversationId: null }], reusableConversations: [secondId] }) });
+    let preparations = 0;
+    h.sendMessage.mockImplementation(async (_id, message) => {
+      if (message.type === 'clf-input-reuse-state') {
+        return { safe: true, navigationEpoch: h.tabs[0]!.url === conversationUrl ? 1 : 2 } as never;
+      }
+      if (message.type === 'clf-prepare-desktop-input') {
+        preparations += 1;
+        if (preparations === 1) {
+          h.tabs[0]!.url = 'https://chatgpt.com/';
+          await h.authorizeDocument({ tab: { id: 7 }, documentId: 'home', frameId: 0, url: h.tabs[0]!.url }, { navigationEpoch: 2 });
+          throw new Error('old document closed before the reply');
+        }
+        h.tabs[0]!.url = `https://chatgpt.com/?cos-input=${firstId}#cos-input=${firstId}`;
+        return { ready: true } as never;
+      }
+      return { ok: true };
+    });
+
+    await h.maintain();
+    expect(h.localSaved.inputOpenings).toMatchObject({
+      [firstId]: { tab: 7, stage: 'preparing', sourceConversationId: secondId, sourceUrl: conversationUrl }
+    });
+    await h.maintain();
+
+    expect(preparations).toBe(2);
+    expect(h.create).not.toHaveBeenCalled();
+    expect(h.sendMessage).toHaveBeenCalledWith(7, { type: 'clf-desktop-input', id: firstId, conversationId: null });
+    expect(h.localSaved.inputOpenings).toMatchObject({ [firstId]: { tab: 7, stage: 'ready', conversationId: null } });
+  });
+  it.each(['unsafe', 'stale-epoch', 'other-conversation'])('does not resume a preparing election from an %s document', async reason => {
+    const sourceUrl = `https://chatgpt.com/c/${secondId}`;
+    const currentUrl = reason === 'other-conversation' ? `https://chatgpt.com/c/${thirdId}` : 'https://chatgpt.com/';
+    const h = await worker([{ id: firstId, conversationId: null }], undefined, { inputOpenings: {
+      [firstId]: { tab: 7, stage: 'preparing', sourceConversationId: secondId, sourceUrl }
+    } });
+    h.tabs.push({ id: 7, url: currentUrl });
+    await h.authorizeDocument({ tab: { id: 7 }, documentId: 'current', frameId: 0, url: currentUrl }, { navigationEpoch: 2 });
+    h.sendMessage.mockImplementation(async (_id, message) => message.type === 'clf-input-reuse-state'
+      ? { safe: reason !== 'unsafe', navigationEpoch: reason === 'stale-epoch' ? 1 : 2 } as never
+      : { ok: true, ready: true });
+
+    await h.maintain();
+
+    expect(h.sendMessage.mock.calls.some(([, message]) => message.type === 'clf-prepare-desktop-input')).toBe(false);
+    expect(h.sendMessage.mock.calls.some(([, message]) => message.type === 'clf-desktop-input')).toBe(false);
+    expect(h.create).not.toHaveBeenCalled();
+    expect(h.localSaved.inputOpenings).toMatchObject({ [firstId]: { tab: 7, stage: 'preparing' } });
+  });
+  it('bounds an unresponsive preparing-document proof without opening a fallback tab', async () => {
+    vi.useFakeTimers();
+    try {
+      const sourceUrl = `https://chatgpt.com/c/${secondId}`;
+      const h = await worker([{ id: firstId, conversationId: null }], undefined, { inputOpenings: {
+        [firstId]: { tab: 7, stage: 'preparing', sourceConversationId: secondId, sourceUrl }
+      } });
+      h.tabs.push({ id: 7, url: 'https://chatgpt.com/' });
+      await h.authorizeDocument({ tab: { id: 7 }, documentId: 'home', frameId: 0, url: h.tabs[0]!.url }, { navigationEpoch: 2 });
+      h.sendMessage.mockImplementation(async (_id, message) => message.type === 'clf-input-reuse-state'
+        ? new Promise(() => {}) : { ok: true, ready: true });
+
+      const maintenance = h.maintain();
+      await vi.advanceTimersByTimeAsync(3000);
+      await maintenance;
+
+      expect(h.create).not.toHaveBeenCalled();
+      expect(h.localSaved.inputOpenings).toMatchObject({ [firstId]: { tab: 7, stage: 'preparing' } });
+    } finally { vi.useRealTimers(); }
   });
   it.each(['explicit-failure', 'ambiguous', 'closed'])('allows a single pre-send fallback only for %s', async reason => {
     const h = await worker([{ id: firstId, conversationId: null }]);


### PR DESCRIPTION
A new-session input could remain stuck in `preparing` when native New Chat replaced the reusable conversation document before the prepare reply reached the background worker. The durable election then pointed at the same Chrome tab, but maintenance searched only marker candidates and never resumed that tab.

This change resumes only the exact elected tab after its replacement document proves a safe, stable ChatGPT page with the current document ID and navigation epoch. Reuse-state checks are bounded to 3 seconds and preparation to 15 seconds; timeouts, stale epochs, drafts, and unrelated conversations preserve the election without opening a fallback or replaying another request.

Fixes #156.

Validation:
- `npm test -- test/desktop-input-maintenance.test.ts` (69 passed)
- `npm test -- test/desktop-input-maintenance.test.ts test/extension.test.ts test/content-script.test.ts` (655 passed)
- `npm run typecheck`
- `npm run build`
- `npx vitest run test/mcp-shutdown.test.ts` (2 passed)
- `npm run verify` reached 3,446 passed and 29 skipped; one unrelated Windows pipeline test exceeded its existing 30-second timeout (`exec-hints.test.ts`, `Select-Object -First`).
