### PR TITLE
Stop reloading a chat that answers every reload the same way

### DIFF
--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -77,6 +77,7 @@ import {
   noteChatOrigin,
   recordAgentMessage,
   recordChatObservations,
+  recordNote,
   recordProgress,
   restoreRecordedConversation,
   setCallAttributionListener,
@@ -5331,6 +5332,25 @@ const lastBrowserRecoveryAt = new Map<string, number>();
  */
 const turnRepairSpent = new Map<string, { sessionId: string; turnKey: string }>();
 
+/**
+ * Silence reloads on one chat that each came back reporting the same failure.
+ *
+ * `turnRepairSpent` says a remedy is spent for one *turn*; this says a remedy has been proven
+ * not to work for this *chat*. The two are different questions and the second had no answer:
+ * a chat wedged on ChatGPT's own "Connection interrupted" was reloaded every three minutes for
+ * an hour — sixteen reloads, twelve identical errors back — and carried on reloading after the
+ * app had itself recorded `turn_end outcome=stalled`. The state being recovered from is
+ * ChatGPT's, not the page's, so the remedy could not work however often it ran.
+ *
+ * Not a cap on the watchdog. Silence still asks its chat-level question on every sweep and
+ * still supersedes a stuck turn-scoped repair; what stops is repeating one specific reload
+ * that this chat has already answered the same way three times. Any *different* answer clears
+ * it — a reload that comes back quiet, a new turn, a different failure — because then the
+ * remedy is no longer the proven-useless one.
+ */
+const SILENCE_RELOAD_ATTEMPTS = 3;
+const silenceProvenUseless = new Map<string, { turnKey: string; error: string; attempts: number; told: boolean }>();
+
 /** The identity of the turn a chat is on right now, for the error reload's budget. */
 function turnKeyFor(live: { activeTurnId: string | null; endedTurns: number } | undefined): string {
   return live?.activeTurnId ?? `ended:${live?.endedTurns ?? 0}`;
@@ -5394,6 +5414,28 @@ function queueBrowserRecovery(
     const live = liveConversations().find((entry) => entry.conversationId === conversationId);
     if (spent && turnKeyFor(live) === spent.turnKey) return false;
     if (spent) turnRepairSpent.delete(conversationId);
+  }
+  // The reload this chat has already answered the same way. Bounded per chat rather than per
+  // turn, because a wedged turn never ends and so never releases a turn-scoped budget.
+  if (reason === 'silence') {
+    const proven = silenceProvenUseless.get(conversationId);
+    const live = liveConversations().find((entry) => entry.conversationId === conversationId);
+    if (proven && proven.turnKey === turnKeyFor(live) && proven.attempts >= SILENCE_RELOAD_ATTEMPTS) {
+      if (!proven.told) {
+        proven.told = true;
+        // Sixteen silent retries with no user-visible verdict was its own half of this defect:
+        // the app knew the turn was dead and said so only to its log.
+        void recordNote(
+          sessionId,
+          `Stopped reloading this chat: ${SILENCE_RELOAD_ATTEMPTS} reloads each came back with the same failure — ` +
+            `"${proven.error.slice(0, 200)}". The turn is broken on ChatGPT's side, which a reload cannot repair. ` +
+            'Continue in a new chat, or send a message here to start a fresh turn.'
+        ).catch(() => undefined);
+        logWarn(`bridge: ${conversationId} answered ${SILENCE_RELOAD_ATTEMPTS} silence reloads with the same failure — not reloading it again`);
+        changed();
+      }
+      return false;
+    }
   }
   const held = repairsInFlight.get(conversationId);
   if (held?.episode === episode) return false;
@@ -5579,6 +5621,18 @@ async function noteRecoveryObservations(
       continue;
     }
     if (item.recoverable !== true) continue;
+    // The answer to the last reload. A page that comes back on the same turn reporting the same
+    // failure is the evidence that the reload did not repair anything; a different turn or a
+    // different failure means the chat moved, so the count starts over rather than accumulating
+    // across unrelated trouble.
+    {
+      const live = liveConversations().find((entry) => entry.conversationId === conversationId);
+      const turnKey = turnKeyFor(live);
+      const error = (item.text ?? '').slice(0, 240);
+      const proven = silenceProvenUseless.get(conversationId);
+      if (proven && proven.turnKey === turnKey && proven.error === error) proven.attempts += 1;
+      else silenceProvenUseless.set(conversationId, { turnKey, error, attempts: 1, told: false });
+    }
     // Auto-compaction owns this chat's recovery clock until its ticket commits or is cancelled.
     // A native error inside a handoff is not permission for the ordinary two-minute response
     // watchdog to cut across the compaction's own pickup schedule. The failure is still the page

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -5445,6 +5445,91 @@ describe('unattributed activity recovery', () => {
     expect((await maintenance())?.reason).toBe('assistant-error');
   });
 
+  /**
+   * The field cadence, measured: a turn broken on ChatGPT's side, reloaded every three minutes
+   * for an hour with no escalation and no stopping condition.
+   *
+   * The assistant-error path spends exactly one reload per turn. Silence has no such budget on
+   * purpose — it asks the chat-level question and is the answer to a stuck turn-scoped repair.
+   * But a reload whose page comes back reporting the same error is a remedy that has been
+   * proven not to work, and the loop has no next step after it fails.
+   */
+  it('stops reloading a chat whose every reload comes back with the same error', async () => {
+    vi.useFakeTimers();
+    try {
+      await pair();
+      await events(PRIME, [openTurn('turn-wedged')]);
+
+      const reloads: string[] = [];
+      for (let round = 0; round < 6; round++) {
+        await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS + 15_000);
+        const repair = await maintenance();
+        if (repair) {
+          reloads.push(repair.reason);
+          await maintenance(repair.token);
+        }
+        // The reloaded page comes back on the same broken turn, with the same error.
+        await events(PRIME, [{
+          kind: 'chat_error',
+          time: Date.now(),
+          text: 'Connection interrupted. Waiting for the complete answer',
+          turnId: 'turn-wedged',
+          recoverable: true
+        }]);
+      }
+
+      // Three silence reloads, then the assistant-error path's own single per-turn reload, and
+      // then nothing: the remedy this chat has answered the same way three times is not tried a
+      // fourth. Unbounded before this — six rounds produced six silence reloads and would have
+      // gone on for as long as the chat stayed open.
+      expect(reloads).toEqual(['silence', 'silence', 'silence', 'assistant-error']);
+
+      // And the user is told, once, in the chat's own timeline rather than only in the log.
+      const session = await findSessionByConversation(PRIME);
+      const notes = await readEvents(session!.id, { kinds: ['note'] });
+      const stopped = notes.filter(event => event.kind === 'note' && event.message.text.includes('Stopped reloading this chat'));
+      expect(stopped).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  /**
+   * The other half of the same rule: only a remedy proven useless is withheld.
+   *
+   * A chat that goes quiet three times for three unrelated reasons has not answered anything
+   * the same way, and muting its liveness check is how a wedged chat went unnoticed before this
+   * watchdog existed. The count is keyed on the failure and the turn, so anything else resets it.
+   */
+  it('keeps reloading a chat whose trouble is different each time', async () => {
+    vi.useFakeTimers();
+    try {
+      await pair();
+      await events(PRIME, [openTurn('turn-varied')]);
+
+      const reloads: string[] = [];
+      const failures = [
+        'Connection interrupted. Waiting for the complete answer',
+        'Message delivery timed out. Please try again.',
+        'Network error.',
+        'Something went wrong.'
+      ];
+      for (const text of failures) {
+        await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS + 15_000);
+        const repair = await maintenance();
+        if (repair) {
+          reloads.push(repair.reason);
+          await maintenance(repair.token);
+        }
+        await events(PRIME, [{ kind: 'chat_error', time: Date.now(), text, turnId: 'turn-varied', recoverable: true }]);
+      }
+
+      expect(reloads.filter(reason => reason === 'silence')).toHaveLength(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('reloads for recognized transport errors, once per user turn', async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
A chat whose turn breaks on ChatGPT's side is reloaded every three minutes, indefinitely, with no escalation and no stopping condition — including after the app has itself declared the turn dead.

### Measured

One conversation, one hour of app log, wedged on ChatGPT's own `Connection interrupted. Waiting for the complete answer`:

```
13:49:16  silence-reload        two-minute watchdog fires
13:49:48  transport-failure     the reloaded page reports the same error, 32 s later
13:51:48  silence-reload
13:52:18  transport-failure
…
14:45:35  silence-reload        still going
```

**16 silence reloads, 12 assistant-error reports, one hour.** The decisive detail is at 14:43, where the app recorded

```
turn_end  outcome=stalled  "no visible output and no progress for ten minutes"
```

and reloaded again at 14:45:35. Its own verdict that the turn is dead did not stop the loop. The user's view of the chat shows the pair repeating: `↻ Reloaded chat to recover an unresponsive open turn` followed seconds later by `! Connection interrupted`.

### Why it does not stop

Two triggers reach `queueBrowserRecovery` and only one is bounded. The assistant-error path spends exactly one reload per turn. The silence watchdog has no such budget, deliberately — and the comment above it is right about why:

> Silence asks the chat-level question instead — is this conversation alive at all — and it is the answer to a stuck turn-scoped repair, not something one may mute.

Only `BROWSER_RECOVERY_COOLDOWN_MS` paces it, which is exactly the observed three-minute cadence. The intent is sound and the outcome is a livelock: the remedy is provably ineffective after the first attempt, because the state being recovered from is ChatGPT's rather than the page's.

### The change

**Not a cap.** Silence still runs on every sweep and still supersedes a stuck turn-scoped repair. What stops is repeating one *specific* reload that this chat has already answered the same way three times.

`turnRepairSpent` already models "this remedy is spent for this turn". That is the wrong unit here: a wedged turn never ends, so its budget is never released. The new record is per chat and keyed on the failure **and** the turn, so any different answer clears it — a reload that comes back quiet, a new turn, a different failure. Only the proven-useless remedy is withheld.

It is also said out loud, once, in the chat's own timeline:

> Stopped reloading this chat: 3 reloads each came back with the same failure — "…". The turn is broken on ChatGPT's side, which a reload cannot repair. Continue in a new chat, or send a message here to start a fresh turn.

Sixteen silent retries with no user-visible verdict was the other half of this defect.

### Verified, both directions

| | before | after |
|---|---|---|
| six rounds of the **same** failure | 6 silence reloads, unbounded | 3, plus the assistant-error path's own single per-turn reload |
| four rounds of **different** failures | 4 reloads | 4 reloads, unchanged |

The second row is the one that matters for the objection: the liveness check is not muted. Fail-before output on unmodified `main`:

```
- "assistant-error"
+ "silence"
+ "silence"
```

`npm run typecheck` clean. Full suite 3442 passed; the four failures are `renderer-usage` (locale-dependent number formatting) and one `mcp` shell test, which fail identically on unmodified `main` on this Windows machine and pass in CI.

### Not included

Escalating to Compact & Resume was the other option considered. It needs ChatGPT to write the brief, and in this state ChatGPT is what is broken — so it cannot be the only path, and it is a larger design decision than this. Recovering an already-wedged chat still means blocking it (which refuses every trigger, since they all converge on `queueBrowserRecovery`) and moving the work by hand.
