### PR TITLE
Never close a tab the user pinned

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1252,7 +1252,7 @@ async function retireFailedCommandTab(entry) {
       failedCommand: { id: entry.id, client: entry.client } }, { documentId: source.documentId });
     const latest = await chrome.tabs.get(source.tab);
     if (proof?.safe === true && proof.conversationId === null && proof.navigationEpoch === source.navigationEpoch &&
-        latest && !latest.pendingUrl && latest.url === url && ownsDocument(source)) await chrome.tabs.remove(source.tab);
+        latest && !latest.pendingUrl && latest.url === url && ownsDocument(source)) await closeUnpinnedTab(source.tab);
   } catch { /* A busy, edited, replaced or unreadable page stays open. */ }
 }
 
@@ -1775,7 +1775,7 @@ async function deliverDesktopInputs(inputs, background, reusableConversations = 
         const current = await chrome.tabs.get(tab.id);
         const successor = replacement ? await chrome.tabs.get(replacement.id) : null;
         if (proof?.safe === true && ownsDocument(source) && String(current.url || '').includes(marker) &&
-            (input.retire === true || (successor && replacements.some(next => matchesInput(next, successor))))) await chrome.tabs.remove(tab.id);
+            (input.retire === true || (successor && replacements.some(next => matchesInput(next, successor))))) await closeUnpinnedTab(tab.id);
       } catch { /* only the exact still-owned temporary document may close */ }
       continue;
     }
@@ -1896,7 +1896,7 @@ function inspectRequestedPluginRefresh(publications, background, browserOnly = f
       let timer;
       const proof = await Promise.race([chrome.tabs.sendMessage(tab.id, { type: 'clf-plugin-refresh-state', id }).catch(() => null), new Promise(resolve => { timer = setTimeout(() => resolve(null), 3000); })]).finally(() => clearTimeout(timer));
       if (proof?.safe !== true) return;
-      if (pluginRefreshMarker(await chrome.tabs.get(tab.id).catch(() => null)) === id) await chrome.tabs.remove(tab.id);
+      if (pluginRefreshMarker(await chrome.tabs.get(tab.id).catch(() => null)) === id) await closeUnpinnedTab(tab.id);
     }
     if (!requests.length) return;
     const held = tabs.find(tab => requests.some(request => request.id === pluginRefreshMarker(tab)));
@@ -1981,7 +1981,7 @@ function inspectRequestedModels(request) {
           const latest = await chrome.tabs.get(candidate.id);
           if (proof?.safe !== true || proof.conversationId !== null || proof.navigationEpoch !== source.navigationEpoch || !ownsDocument(source) ||
             latest.pendingUrl || latest.url !== candidate.url) continue;
-          await chrome.tabs.remove(candidate.id);
+          await closeUnpinnedTab(candidate.id);
         } catch { /* Busy, drafting or changed documents keep their tab for ordinary maintenance. */ }
       }
     };
@@ -2105,7 +2105,7 @@ async function pruneManagedTabs(tabs, policy, protectedChats, closable) {
       const latest = await chrome.tabs.get(tab.id);
       if (latest.pendingUrl || conversationFromUrl(latest.url) !== conversationId || !ownsDocument(source) || journalCountForConversation(conversationId) > 0) continue;
 
-      await chrome.tabs.remove(tab.id);
+      if (!(await closeUnpinnedTab(tab.id))) continue;
       remaining = remaining.filter(other => other.id !== tab.id);
     } catch { /* Missing document, navigation or unreadable draft state is not close permission. */ }
   }
@@ -2402,6 +2402,32 @@ function projectFromUrl(value) {
   }
 }
 
+/**
+ * Close a tab this app is cleaning up, unless the user has pinned it.
+ *
+ * Pinning is the one gesture Chrome offers for "this tab stays", and every close below is
+ * automatic — a retired conversation, a spent helper document, a duplicate. None of them is
+ * the user asking for anything, so none may take away a tab they explicitly kept. A pinned
+ * tab reported on 2026-09-10 vanished without appearing in Chrome's recently-closed list,
+ * because the final boundary looked at conversation identity, navigation and unsent work and
+ * never at `pinned`.
+ *
+ * Read fresh rather than from the caller's tab object, for the same reason every caller
+ * re-reads identity here: pinning can happen while the checks above are awaiting. The app
+ * may still retire, sleep or supersede the conversation — this governs the physical close
+ * and nothing else.
+ */
+async function closeUnpinnedTab(tabId) {
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    if (tab?.pinned === true) return false;
+  } catch {
+    return false;
+  }
+  await chrome.tabs.remove(tabId);
+  return true;
+}
+
 function isChatGptUrl(value) {
   try {
     const url = new URL(String(value || ''));
@@ -2530,7 +2556,7 @@ const HANDLERS = {
       // that navigated while the app durably committed the decision.
       try {
         const current = await chrome.tabs.get(source.tab);
-        if (ownsDocument(source) && conversationFromUrl(current.url) === conversationId) await chrome.tabs.remove(source.tab);
+        if (ownsDocument(source) && conversationFromUrl(current.url) === conversationId) await closeUnpinnedTab(source.tab);
       } catch { /* already closed; the accepted app-side answer remains authoritative */ }
     }
     return result;

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -3355,13 +3355,52 @@ describe('the goal opening, which waits on a model', () => {
 });
 
 
+/**
+ * The pruner plus the one function it closes through, so a test exercises the real boundary
+ * rather than a stub of it.
+ */
+function pruneSource(): string {
+  const at = (needle: string, from = 0) => backgroundSource.indexOf(needle, from);
+  const closer = backgroundSource.slice(at('async function closeUnpinnedTab('), at('function isChatGptUrl('));
+  const start = at('async function pruneManagedTabs(');
+  const pruner = backgroundSource.slice(start, at('function maintain(', start));
+  return closer + '\n' + pruner;
+}
+
+/**
+ * Pinning is Chrome's one gesture for "this tab stays", and every close in the worker is
+ * automatic — a retired conversation, a spent helper, a duplicate. The final boundary checked
+ * conversation identity, navigation and unsent work, and never `pinned`, so a tab the user had
+ * explicitly kept was closed and did not even appear in Chrome's recently-closed list.
+ */
+it.each([true, false])('never closes a tab the user pinned (pinned: %s)', async pinned => {
+  const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+  const tab = { id: 71, url: `https://chatgpt.com/c/${conversationId}`, active: false, pinned };
+  const tabsRemove = vi.fn();
+  const prune = vm.runInNewContext(`${pruneSource()}
+pruneManagedTabs`, {
+    cleanConversationId: (id: string) => id, conversationForTab: () => conversationId,
+    conversationFromUrl: (url: string) => url.split('/c/')[1], tabDocuments: { '71': 'doc' },
+    tabEpochs: { '71': 0 }, ownsDocument: () => true, journalCountForConversation: () => 0,
+    chrome: { tabs: { get: async () => tab,
+      sendMessage: async () => ({ safe: true, conversationId, navigationEpoch: 0 }), remove: tabsRemove } }
+  });
+
+  const remaining = await prune([tab], { managedConversations: [conversationId], retiredConversations: [conversationId] }, new Set(), new Set());
+
+  expect(tabsRemove).toHaveBeenCalledTimes(pinned ? 0 : 1);
+  // And a tab that stayed open is still reported as present, so nothing downstream treats it
+  // as closed and reopens the same conversation beside it.
+  expect(remaining.map((entry: { id: number }) => entry.id)).toEqual(pinned ? [71] : []);
+});
+
 it.each(['matching', 'wrong-document', 'unsafe-draft', 'newer-navigation'])('retires a cancelled helper only under its exact safe claim: %s', async scenario => {
   const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
   const tab = { id: 71, url: `https://chatgpt.com/c/${conversationId}`, active: false };
   const claims = [{ id: 'old-input', owner: '71:doc:0', conversationId }, { id: 'new-input', owner: '71:doc:0', conversationId }];
   const tabsRemove = vi.fn();
   const sendMessage = vi.fn(async (..._args: unknown[]) => ({ safe: scenario !== 'unsafe-draft', conversationId, navigationEpoch: 0 }));
-  const code = backgroundSource.slice(backgroundSource.indexOf('async function pruneManagedTabs('), backgroundSource.indexOf('\nfunction maintain(', backgroundSource.indexOf('async function pruneManagedTabs(')));
+  const code = pruneSource();
   const prune = vm.runInNewContext(`${code}\npruneManagedTabs`, {
     cleanConversationId: (id: string) => id, conversationForTab: () => conversationId,
     conversationFromUrl: (url: string) => url.split('/c/')[1], tabDocuments: { '71': scenario === 'wrong-document' ? 'replacement' : 'doc' },

--- a/test/plugin-refresh-workflow.test.ts
+++ b/test/plugin-refresh-workflow.test.ts
@@ -115,7 +115,10 @@ it.each([{ deny: true }, { navigateDuringClaim: true }])('never clicks after den
 });
 it('reuses one owned management tab and preserves unreachable helpers and user chats', async () => {
   const background = readFileSync(new URL('../extension/background.js', import.meta.url), 'utf8');
-  const code = background.slice(background.indexOf('let pluginRefreshFlight = null;'), background.indexOf('async function catalogProbe('));
+  // Includes the one function the worker closes tabs through, so this exercises the real
+  // close boundary - including its refusal to touch a tab the user pinned.
+  const closer = background.slice(background.indexOf('async function closeUnpinnedTab('), background.indexOf('function isChatGptUrl('));
+  const code = closer + background.slice(background.indexOf('let pluginRefreshFlight = null;'), background.indexOf('async function catalogProbe('));
   let requests: object[] = [{ id }];
   const tabs = [{ id: 7, url: `https://chatgpt.com/?cos-plugin-refresh=${id}#settings/Plugins` }, { id: 8, url: 'https://chatgpt.com/c/user-conversation' }];
   const create = vi.fn(async () => ({ id: 9 }));


### PR DESCRIPTION
Closes #150.

### Confirmed

`pinned` did not appear in `extension/background.js` at all:

```
$ grep -c "pinned" extension/background.js
0
```

The reporter's reading is exact: `pruneManagedTabs()` checks conversation identity, navigation state, unsent work and the page-side close proof, then calls `chrome.tabs.remove(tab.id)` — and never asks whether the user pinned the tab.

### Scope

The issue names `pruneManagedTabs` as the narrow confirmed defect and adds:

> I expected a user-pinned tab to be protected from **every** automatic cleanup path.

There were six `tabs.remove` call sites, and every one of them is automatic cleanup — a retired conversation, a spent temporary planner, a plugin-refresh helper, a model-catalog helper, a duplicate, an accepted decision document. None is the user asking for anything. So the rule is stated once, in `closeUnpinnedTab`, and all six go through it:

```
$ grep -c "chrome.tabs.remove" extension/background.js
1
```

It re-reads the tab rather than trusting the caller's object, for the same reason every one of those callers re-reads identity at that point: pinning can happen while the checks above are awaiting.

Deliberately unchanged: the conversation may still be retired, slept, superseded or marked duplicate. This governs the physical close and nothing else. `pruneManagedTabs` now keeps a refused tab in its `remaining` set, so nothing downstream treats it as gone and opens the same conversation beside it.

### Verified

Fails before the change:

```
× never closes a tab the user pinned (pinned: true)
  AssertionError: expected "vi.fn()" to be called +0 times, but got 1 times
```

Passes after, with the unpinned case asserted in the same test so the pruner is not simply disabled.

**One thing worth flagging for review.** Two harnesses (`test/extension.test.ts`, `test/plugin-refresh-workflow.test.ts`) slice these functions out of the worker source and run them in a `vm` context. Both now include `closeUnpinnedTab` in the slice, so they exercise the real close boundary — without that, `plugin-refresh-workflow` failed with a missing reference and the pinned test would have been passing against a stub that could not refuse.

`npm run typecheck` clean. Full suite 3442 passed; the four failures are `renderer-usage` (locale-dependent number formatting) and one `mcp` shell test, which fail identically on unmodified `main` on this Windows machine and pass in CI.

### Not addressed

Why the reported conversation was classified as closable in the first place. The report is explicit that this may be a separate lifecycle problem, and this PR does not touch that — it only stops the physical close from ignoring a user's claim on the tab.
