### PR TITLE
Correlate Core calls from live ChatGPT response streams

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -9830,23 +9830,39 @@
     if (encoded.length > 24000 || encoded === lastUsageProjection) return;
     void ask({ type: 'usage_observation', rows, observedAt }).then((reply) => { if (reply?.ok) lastUsageProjection = encoded; });
   });
+  function confirmStreamRequestOrigin(claimed, requestIds, observedAt) {
+    const pending = { timer: null, deadline: Date.now() + 30_000 };
+    const attempt = () => {
+      pending.timer = null;
+      if (!alive) return;
+      const route = CLF_DOM.conversationId();
+      if (route === claimed) {
+        void confirmLiveRequestOwners(
+          requestIds.map((requestId) => ({ requestId, messageId: null, createTime: observedAt / 1000 })),
+          route
+        );
+        return;
+      }
+      // A fresh chat receives its server conversation id in the response stream before the SPA
+      // publishes /c/<id> in the address bar. Keep that exact response pair briefly and require
+      // the route to converge before granting it authority. A different concrete route is a hard
+      // mismatch and is never retried, so a response finishing after navigation cannot cross chats.
+      if (route || Date.now() >= pending.deadline) return;
+      pending.timer = setTimeout(attempt, 100);
+    };
+    rememberCleanup(() => { if (pending.timer !== null) clearTimeout(pending.timer); });
+    attempt();
+  }
   window.addEventListener('message', (event) => {
     if (!alive || event.source !== window || event.origin !== location.origin || event.data?.type !== 'cos-request-origin') return;
-    const route = CLF_DOM.conversationId();
     const claimed = typeof event.data.conversationId === 'string' ? event.data.conversationId : '';
-    // The stream names its server conversation and the address bar independently names this
-    // document. Both must agree. A response that finishes after SPA navigation therefore has
-    // no authority in the destination chat.
-    if (!route || claimed !== route || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(claimed)) return;
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(claimed)) return;
     const raw = Array.isArray(event.data.requestIds) ? event.data.requestIds : [];
     if (raw.length === 0 || raw.length > 16) return;
     const requestIds = [...new Set(raw.filter((id) => typeof id === 'string' && /^wfr_[a-zA-Z0-9_-]{1,96}$/.test(id)))];
     if (requestIds.length === 0) return;
     const observedAt = Number.isFinite(event.data.observedAt) ? event.data.observedAt : Date.now();
-    void confirmLiveRequestOwners(
-      requestIds.map((requestId) => ({ requestId, messageId: null, createTime: observedAt / 1000 })),
-      route
-    );
+    confirmStreamRequestOrigin(claimed, requestIds, observedAt);
   });
   window.postMessage({ type: 'cos-usage-request' }, location.origin);
   let desktopDecision = null;

--- a/extension/content.js
+++ b/extension/content.js
@@ -9830,6 +9830,24 @@
     if (encoded.length > 24000 || encoded === lastUsageProjection) return;
     void ask({ type: 'usage_observation', rows, observedAt }).then((reply) => { if (reply?.ok) lastUsageProjection = encoded; });
   });
+  window.addEventListener('message', (event) => {
+    if (!alive || event.source !== window || event.origin !== location.origin || event.data?.type !== 'cos-request-origin') return;
+    const route = CLF_DOM.conversationId();
+    const claimed = typeof event.data.conversationId === 'string' ? event.data.conversationId : '';
+    // The stream names its server conversation and the address bar independently names this
+    // document. Both must agree. A response that finishes after SPA navigation therefore has
+    // no authority in the destination chat.
+    if (!route || claimed !== route || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(claimed)) return;
+    const raw = Array.isArray(event.data.requestIds) ? event.data.requestIds : [];
+    if (raw.length === 0 || raw.length > 16) return;
+    const requestIds = [...new Set(raw.filter((id) => typeof id === 'string' && /^wfr_[a-zA-Z0-9_-]{1,96}$/.test(id)))];
+    if (requestIds.length === 0) return;
+    const observedAt = Number.isFinite(event.data.observedAt) ? event.data.observedAt : Date.now();
+    void confirmLiveRequestOwners(
+      requestIds.map((requestId) => ({ requestId, messageId: null, createTime: observedAt / 1000 })),
+      route
+    );
+  });
   window.postMessage({ type: 'cos-usage-request' }, location.origin);
   let desktopDecision = null;
   let desktopDecisionSession = null;

--- a/extension/usage.js
+++ b/extension/usage.js
@@ -1,4 +1,12 @@
-/** Passive, bounded usage projection. Never reads request headers, cookies or credentials. */
+/**
+ * Passive, bounded page-response projection.
+ *
+ * Never reads request headers, cookies, credentials, prompt text or tool arguments. Besides
+ * quota metadata, it observes the two opaque identifiers ChatGPT itself puts in the live
+ * conversation event stream: `conversation_id` and `metadata.request_id`. The latter can
+ * reach the stream tens of seconds before React publishes it, which is the difference between
+ * an exact Core caller and CALLER_IDENTITY_REQUIRED. Only that pair crosses worlds.
+ */
 (() => {
   'use strict';
   if (window.__cosUsageObserver) return;
@@ -7,6 +15,10 @@
   const post = window.postMessage.bind(window);
   let latest = null;
   let requestOrder = 0, latestOrder = 0;
+  const CONVERSATION = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const REQUEST = /^wfr_[a-zA-Z0-9_-]{1,96}$/;
+  const CONVERSATION_FIELD = /(?:^|[,{\s])\"conversation_id\"\s*:\s*\"([0-9a-f-]{36})\"/gi;
+  const REQUEST_FIELD = /(?:^|[,{\s])\"request_id\"\s*:\s*\"(wfr_[a-zA-Z0-9_-]{1,96})\"/g;
   const project = (data, observedAt, order) => {
     if (!data || typeof data !== 'object') return;
     const rows = [];
@@ -60,11 +72,80 @@
     } catch { /* Unsupported metadata is unavailable, never guessed. */ }
     finally { clearTimeout(timer); void reader.cancel().catch(() => {}); }
   }
+  /**
+   * Reads only complete SSE frames from the cloned response. Regexes are anchored to JSON
+   * field syntax, so quoted user/model text (whose quotes are escaped) cannot manufacture an
+   * identifier. A concrete server conversation id and a wfr request id must both occur in the
+   * same response before anything is emitted. The original response is never delayed or
+   * replaced, and this clone is cancelled after the first 4 MiB or 90 seconds.
+   */
+  async function inspectRequestOrigins(response, observedAt) {
+    let url;
+    try { url = new URL(response.url); } catch { return; }
+    if (url.origin !== location.origin || url.pathname !== '/backend-api/conversation') return;
+    if (!response.ok || !response.headers.get('content-type')?.includes('text/event-stream')) return;
+    const copy = response.clone(), reader = copy.body?.getReader();
+    if (!reader) return;
+    const timer = setTimeout(() => void reader.cancel().catch(() => {}), 90_000);
+    const decoder = new TextDecoder();
+    const emitted = new Set();
+    let bytes = 0, buffer = '';
+    const scan = (frame) => {
+      if (!frame || frame.length > 512 * 1024) return;
+      const conversations = new Set();
+      CONVERSATION_FIELD.lastIndex = 0;
+      for (let match; (match = CONVERSATION_FIELD.exec(frame));) {
+        if (CONVERSATION.test(match[1])) conversations.add(match[1]);
+      }
+      // One complete server event must carry both sides of the join. Retaining an id from a
+      // prior frame would turn response order into authority; a contradictory frame abstains.
+      if (conversations.size !== 1) return;
+      const conversationId = conversations.values().next().value;
+      const requestIds = new Set();
+      REQUEST_FIELD.lastIndex = 0;
+      for (let match; (match = REQUEST_FIELD.exec(frame));) if (REQUEST.test(match[1])) requestIds.add(match[1]);
+      const fresh = [...requestIds].filter((id) => !emitted.has(id)).slice(0, 16);
+      if (fresh.length === 0) return;
+      for (const id of fresh) emitted.add(id);
+      post({ type: 'cos-request-origin', conversationId, requestIds: fresh, observedAt }, location.origin);
+    };
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        bytes += value.byteLength;
+        if (bytes > 4 * 1024 * 1024) return;
+        buffer += decoder.decode(value, { stream: true });
+        for (;;) {
+          const lf = buffer.indexOf('\n\n');
+          const crlf = buffer.indexOf('\r\n\r\n');
+          const split = lf < 0 ? crlf : crlf < 0 ? lf : Math.min(lf, crlf);
+          if (split < 0) break;
+          const width = buffer.startsWith('\r\n\r\n', split) ? 4 : 2;
+          scan(buffer.slice(0, split));
+          buffer = buffer.slice(split + width);
+        }
+        if (buffer.length > 512 * 1024) return;
+      }
+      buffer += decoder.decode();
+      scan(buffer);
+    } catch { /* A missing stream observation leaves the existing Fiber path in charge. */ }
+    finally { clearTimeout(timer); void reader.cancel().catch(() => {}); }
+  }
   window.fetch = function (...args) {
     // Request order fences late responses, not accounts. No account identity is inferred.
     const observedAt = Date.now(), order = ++requestOrder;
     const result = originalFetch.apply(this, args);
-    void result.then((response) => inspect(response, observedAt, order)).catch(() => {});
+    void result.then((response) => {
+      void inspect(response, observedAt, order);
+      let method = 'GET';
+      try {
+        const explicit = args[1] && typeof args[1].method === 'string' ? args[1].method : null;
+        const inherited = args[0] && typeof args[0] === 'object' && typeof args[0].method === 'string' ? args[0].method : null;
+        method = String(explicit || inherited || 'GET').toUpperCase();
+      } catch { return; }
+      if (method === 'POST') void inspectRequestOrigins(response, observedAt);
+    }).catch(() => {});
     return result;
   };
   window.addEventListener('message', (event) => {

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -7956,6 +7956,36 @@ describe('evidence from the page context', () => {
     ]);
   });
 
+  it('keeps a fresh-chat stream identity until the address bar publishes its exact route', async () => {
+    live = await harness('https://chatgpt.com/?cos-input=aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee');
+    const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const requestId = 'wfr_fresh_route_convergence';
+    live.reply.set('correlate', () => ({
+      ok: true,
+      status: 200,
+      data: { ok: true, conversationId, confirmed: [requestId], complete: true }
+    }));
+
+    live.window.dispatchEvent(new live.window.MessageEvent('message', {
+      source: live.window as unknown as Window,
+      origin: 'https://chatgpt.com',
+      data: { type: 'cos-request-origin', conversationId, requestIds: [requestId], observedAt: 1_700_000_001_000 }
+    }));
+    await settle();
+    expect(live.sent.filter((message) => message.type === 'correlate')).toEqual([]);
+
+    live.window.history.replaceState({}, '', `/c/${conversationId}`);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    await settle();
+
+    expect(live.sent.filter((message) => message.type === 'correlate')).toEqual([
+      expect.objectContaining({
+        conversationId,
+        calls: [{ requestId, messageId: null, createTime: 1_700_000_001 }]
+      })
+    ]);
+  });
+
   it('does not grant stream identity from another route or malformed requests', async () => {
     live = await harness();
     const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -7931,6 +7931,49 @@ describe('evidence from the page context', () => {
     expect(live.sent.filter((message) => message.type === 'correlate')).toHaveLength(1);
   });
 
+  it('confirms an exact request from the live response stream before Fiber publishes it', async () => {
+    live = await harness();
+    const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const requestId = 'wfr_stream_early_exact';
+    live.reply.set('correlate', () => ({
+      ok: true,
+      status: 200,
+      data: { ok: true, conversationId, confirmed: [requestId], complete: true }
+    }));
+
+    live.window.dispatchEvent(new live.window.MessageEvent('message', {
+      source: live.window as unknown as Window,
+      origin: 'https://chatgpt.com',
+      data: { type: 'cos-request-origin', conversationId, requestIds: [requestId], observedAt: 1_700_000_001_000 }
+    }));
+    await settle();
+
+    expect(live.sent.filter((message) => message.type === 'correlate')).toEqual([
+      expect.objectContaining({
+        conversationId,
+        calls: [{ requestId, messageId: null, createTime: 1_700_000_001 }]
+      })
+    ]);
+  });
+
+  it('does not grant stream identity from another route or malformed requests', async () => {
+    live = await harness();
+    const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    for (const data of [
+      { type: 'cos-request-origin', conversationId: '11111111-2222-3333-4444-555555555555', requestIds: ['wfr_foreign'] },
+      { type: 'cos-request-origin', conversationId, requestIds: ['not-a-workflow'] },
+      { type: 'cos-request-origin', conversationId, requestIds: Array.from({ length: 17 }, (_, i) => `wfr_${i}`) }
+    ]) {
+      live.window.dispatchEvent(new live.window.MessageEvent('message', {
+        source: live.window as unknown as Window,
+        origin: 'https://chatgpt.com',
+        data
+      }));
+    }
+    await settle();
+    expect(live.sent.filter((message) => message.type === 'correlate')).toEqual([]);
+  });
+
   it('does not let a stale owned Fiber turn bypass a rejected live ownership handshake', async () => {
     live = await harness();
     const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';

--- a/test/usage-observer.test.ts
+++ b/test/usage-observer.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 const script = readFileSync(new URL('../extension/usage.js', import.meta.url), 'utf8');
 function harness() {
-  const posts: Array<{ type: string; observedAt: number; rows: Array<Record<string, unknown>> }> = [];
+  const posts: Array<Record<string, any>> = [];
   let now = Date.parse('2026-09-05T12:00:00Z');
   class Clock extends Date { static override now() { return now; } }
   let response: unknown;
@@ -16,7 +16,7 @@ function harness() {
     addEventListener: (_type: string, handler: typeof listener) => { listener = handler; }
   };
   runInNewContext(script, { window, location: { origin: 'https://chatgpt.com' }, URL, Date: Clock, TextDecoder, setTimeout, clearTimeout });
-  async function feed(data: unknown, url = 'https://chatgpt.com/backend-api/wham/usage') {
+  async function feed(data: unknown, url = 'https://chatgpt.com/backend-api/wham/usage', init: Record<string, unknown> = {}) {
     let done: () => void = () => {};
     const inspected = new Promise<void>(resolve => { done = resolve; });
     let read = false;
@@ -27,12 +27,32 @@ function harness() {
       cancel: async () => { done(); }
     }) } }) };
     const expectedResponse = response;
-    const returned = await window.fetch('/endpoint', { headers: { Authorization: 'private-test-value' } });
+    const returned = await window.fetch('/endpoint', { headers: { Authorization: 'private-test-value' }, ...init });
     expect(returned).toBe(expectedResponse);
     if (new URL(url).origin === 'https://chatgpt.com' && /^\/backend-api\/(wham\/usage|conversation\/init|conversation\/prepare|models)$/.test(new URL(url).pathname)) await inspected;
     else await new Promise(resolve => setTimeout(resolve, 0));
   }
-  return { posts, feed, holdNextBody: () => { let release = () => {}; nextBodyGate = new Promise<void>(resolve => { release = resolve; }); return () => release(); }, advance: (ms: number) => { now += ms; }, request: (source: unknown = window, origin = 'https://chatgpt.com') => listener({ source, origin, data: { type: 'cos-usage-request' } }) };
+  async function feedSse(chunks: string[], init: Record<string, unknown> = { method: 'POST' }) {
+    let done: () => void = () => {};
+    const inspected = new Promise<void>(resolve => { done = resolve; });
+    let at = 0;
+    response = {
+      url: 'https://chatgpt.com/backend-api/conversation',
+      ok: true,
+      headers: { get: () => 'text/event-stream; charset=utf-8' },
+      clone: () => ({ body: { getReader: () => ({
+        read: async () => at < chunks.length
+          ? { done: false, value: new TextEncoder().encode(chunks[at++]!) }
+          : { done: true },
+        cancel: async () => { done(); }
+      }) } })
+    };
+    const returned = await window.fetch('/backend-api/conversation', init);
+    expect(returned).toBe(response);
+    if (String(init.method || 'GET').toUpperCase() === 'POST') await inspected;
+    else await new Promise(resolve => setTimeout(resolve, 0));
+  }
+  return { posts, feed, feedSse, holdNextBody: () => { let release = () => {}; nextBodyGate = new Promise<void>(resolve => { release = resolve; }); return () => release(); }, advance: (ms: number) => { now += ms; }, request: (source: unknown = window, origin = 'https://chatgpt.com') => listener({ source, origin, data: { type: 'cos-usage-request' } }) };
 }
 
 describe('MAIN-world usage projection', () => {
@@ -129,5 +149,33 @@ describe('MAIN-world usage projection', () => {
     });
     expect(h.posts[1]?.rows).toHaveLength(80);
     expect(JSON.stringify(h.posts)).not.toMatch(/private@example|<script>/);
+  });
+
+  it('publishes an exact conversation/request pair from a chunked live response before React renders it', async () => {
+    const h = harness();
+    const conversationId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    await h.feedSse([
+      `data: {"conversation_id":"${conversationId}","message":{"metadata":{"request_`,
+      'id":"wfr_early_exact"},"content":{"parts":["private prompt and tool args"]}}}\n\n',
+      `data: {"conversation_id":"${conversationId}","message":{"metadata":{"request_id":"wfr_early_exact"}}}\n\n`,
+      `data: {"conversation_id":"${conversationId}","message":{"metadata":{"request_id":"wfr_second"}}}\n\n`
+    ]);
+
+    expect(h.posts).toEqual([
+      { type: 'cos-request-origin', conversationId, requestIds: ['wfr_early_exact'], observedAt: expect.any(Number) },
+      { type: 'cos-request-origin', conversationId, requestIds: ['wfr_second'], observedAt: expect.any(Number) }
+    ]);
+    expect(JSON.stringify(h.posts)).not.toContain('private prompt');
+    expect(JSON.stringify(h.posts)).not.toContain('tool args');
+  });
+
+  it('ignores non-POST, foreign, malformed and contradictory stream identity', async () => {
+    const h = harness();
+    const a = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    const b = '11111111-2222-4333-8444-555555555555';
+    await h.feedSse([`data: {"conversation_id":"${a}","request_id":"wfr_get"}\n\n`], { method: 'GET' });
+    await h.feedSse([`data: {"conversation_id":"${a}","request_id":"not-a-workflow"}\n\n`]);
+    await h.feedSse([`data: {"conversation_id":"${a}","nested":{"conversation_id":"${b}"},"request_id":"wfr_conflict"}\n\n`]);
+    expect(h.posts).toEqual([]);
   });
 });


### PR DESCRIPTION
Normal browser Pro turns can call Core before ChatGPT publishes `metadata.request_id` into the React message tree. The app then spends its caller-evidence window and rejects the operation even though the same exact `wfr_` ID appears later.

This change passively observes `conversation_id` and `wfr_ request_id` only when both occur in the same complete SSE frame of a successful same-origin `POST /backend-api/conversation` response. It forwards only those opaque identifiers through the existing correlation handshake. For a fresh chat, the pair is retained for at most 30 seconds until the address bar publishes the exact `/c/<conversation-id>` route; a different concrete route, malformed ID, oversized frame, or ambiguous frame is rejected.

Privacy bounds remain fail closed: request bodies, prompt text, tool arguments, headers, cookies, and credentials are never forwarded.

Validation:
- `vitest run test/content-script.test.ts test/usage-observer.test.ts` — 482 passed
- `npm run typecheck`
- `npm run verify:privacy`
- `npm run rg`
- `npm run build`
- `npm run dist:dir:x64`

Live reproduction for #108 remains preserved: two fresh 5.6 / Pro controller canaries received exact stable `wfr_` IDs, exhausted the 20-second evidence wait, were refused with `CALLER_IDENTITY_REQUIRED`, and were only attributed after the stock recovery reload. No workspace operation ran and neither request was replayed. The patched extension bytes are staged locally; a post-reload live canary is still pending before this draft is marked ready.

Addresses #108.
