### PR TITLE
Judge a replacement chat's checkpoints on its lease, not on its route

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -2849,8 +2849,27 @@ const HANDLERS = {
     // ChatGPT assigns /c/B through an SPA transition. Read Chrome's current tab and
     // retain the exact document/epoch lease across that await before accepting its route.
     const tab = await chrome.tabs.get(source.tab).catch(() => null);
-    if (!ownsDocument(source) || !tab || tab.pendingUrl || tab.status === 'loading' ||
-        !isChatGptUrl(tab.url) || conversationFromUrl(tab.url) !== cleanConversationId(message.conversationId))
+    if (!ownsDocument(source) || !tab || !isChatGptUrl(tab.url || tab.pendingUrl))
+      return { ok: false, error: 'stale_document' };
+    const named = cleanConversationId(message.conversationId);
+    // A checkpoint that names a chat has a route to verify, and an unsettled tab cannot prove
+    // it: wait for the navigation rather than accept a message about a chat this tab may be
+    // leaving. A checkpoint that names none is the opposite case and has to be judged
+    // differently — the two destination checkpoints come from a replacement chat that ChatGPT
+    // has not created yet, so there is no id to compare and no navigation to lose.
+    //
+    // Refusing those on `loading` cost a whole handoff every time the fresh tab was slower than
+    // the page asking for its permit. Measured on 2026-09-10: the tab redeemed its brief at
+    // 04:39:55.218 and asked for `destinationAttempt` at 04:39:58.262, three seconds into a
+    // ChatGPT that was still loading. The refusal never reached the app, content.js read it as
+    // a denied permit, cleared the composer and returned without an ack, and the app waited out
+    // its deadline with nothing anywhere to say why.
+    //
+    // `ownsDocument` already proved this is the document the worker leased; all that is left to
+    // exclude is a tab that is actually showing some other conversation.
+    if (named
+      ? (tab.pendingUrl || tab.status === 'loading' || conversationFromUrl(tab.url) !== named)
+      : conversationFromUrl(tab.url) !== null)
       return { ok: false, error: 'stale_document' };
     const sourceUrl = tab.url;
     const result = await call('/compact', {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1460,6 +1460,82 @@ describe('worker settings authority', () => {
   });
 
   /**
+   * The half of this route that no test covered: the replacement chat's own checkpoints.
+   *
+   * Every case above sends `conversationId` alongside the token, because every one of them is
+   * the *source* chat — a conversation that exists. The destination is the opposite by
+   * construction: content.js asks for its permit from a page opened at `/?clf=<id>`, before
+   * ChatGPT has assigned anything, so it sends a token and a flag and no conversation id at
+   * all. Nothing here ever exercised that shape, and it is the shape the whole handoff depends
+   * on: refuse it and the page clears its composer and stops, with no ack and no log line
+   * anywhere — which is exactly what a stuck handoff looks like from the outside.
+   */
+  /**
+   * The replacement chat asks for its permit while ChatGPT is still loading.
+   *
+   * Measured in the browser on 2026-09-10: the tab redeemed at 04:39:55.218 and got the whole
+   * 48,975-character brief, then asked for `destinationAttempt` at 04:39:58.262 — three seconds
+   * into a freshly opened ChatGPT, which is still `loading`. The worker refused it as a stale
+   * document without ever calling the app, content.js read that as a denied permit, cleared the
+   * composer and returned without an ack. The app then waited out its whole deadline and gave up
+   * with "the chat this app opened did not report back in time", and nothing anywhere said why.
+   *
+   * The loading/pendingUrl guard is for a tab navigating *away* from what the message names. A
+   * checkpoint that names no conversation, from a document the worker still owns, is the
+   * opposite case: there is nothing to navigate away from yet.
+   */
+  it.each(['loading', 'pending'])('forwards a replacement chat permit while the tab is still %s', async state => {
+    const posted: Record<string, unknown>[] = [];
+    const fetch = vi.fn(async (input: string, init: Record<string, unknown> = {}) => {
+      const url = new URL(input);
+      if (url.pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
+      if (url.pathname === '/compact' && init.method === 'POST') {
+        posted.push(JSON.parse(String(init.body || '{}')));
+        return response(200, { allowed: true });
+      }
+      return response(404, {});
+    });
+    const tab = state === 'loading'
+      ? { id: 47, url: 'https://chatgpt.com/?clf=cmd-successor', status: 'loading' }
+      : { id: 47, url: 'https://chatgpt.com/?clf=cmd-successor', pendingUrl: 'https://chatgpt.com/?clf=cmd-successor' };
+    const worker = loadWorker({ local: new FakeStorageArea(paired), session: new FakeStorageArea(), fetch,
+      tabsGet: async () => tab });
+    await worker.registerTab(47);
+    const token = '0123456789abcdef0123456789abcdef';
+
+    const reply = await worker.send({ type: 'compact', token, destinationAttempt: true }, 47);
+
+    expect(reply).not.toMatchObject({ error: 'stale_document' });
+    expect(posted).toEqual([expect.objectContaining({ token, destinationAttempt: true })]);
+  });
+
+  it('forwards the destination checkpoints a replacement chat sends, which name no conversation', async () => {
+    const posted: Record<string, unknown>[] = [];
+    const fetch = vi.fn(async (input: string, init: Record<string, unknown> = {}) => {
+      const url = new URL(input);
+      if (url.pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
+      if (url.pathname === '/compact' && init.method === 'POST') {
+        posted.push(JSON.parse(String(init.body || '{}')));
+        return response(200, { allowed: true });
+      }
+      return response(404, {});
+    });
+    const worker = loadWorker({ local: new FakeStorageArea(paired), session: new FakeStorageArea(), fetch,
+      tabsGet: async () => ({ id: 46, url: 'https://chatgpt.com/?clf=cmd-successor' }) });
+    await worker.registerTab(46);
+    const token = '0123456789abcdef0123456789abcdef';
+
+    await worker.send({ type: 'compact', token, destinationAttempt: true }, 46);
+    await worker.send({ type: 'compact', token, destinationDispatch: true }, 46);
+
+    expect(posted).toEqual([
+      expect.objectContaining({ token, destinationAttempt: true }),
+      expect.objectContaining({ token, destinationDispatch: true })
+    ]);
+  });
+
+
+  /**
    * The mode a goal was written in, which the app turns into a durable per-chat switch.
    *
    * Both halves matter. It has to cross — a goal written with "add specific loop" that arrives


### PR DESCRIPTION
**This is the one that produces the common symptom: a replacement chat opens, and nothing is ever typed into it.**

### Measured, from the replacement tab itself

Shipped extension 2.0.8, 2026-09-10:

```json
{"at":"04:39:55.218","type":"redeem","ok":true,"hasCommand":true,"textLen":48975,"url":"/?clf=42c8b63e3001a081"}
{"at":"04:39:58.262","type":"compact","flags":["destinationAttempt"],"ok":false,"error":"stale_document","url":"/?clf=42c8b63e3001a081"}
```

The brief was delivered in full and thrown away three seconds later. Four consecutive handoffs failed exactly this way.

### Mechanism

`content.js` asks the app for permission before the irreversible send, and reads any non-ok reply as a denied permit:

```js
const permit = await ask({ type: 'compact', token, destinationAttempt: true });
if (!permit || permit.ok !== true || !permit.data || permit.data.allowed !== true) {
  CLF_DOM.clearPromptExact(boot.text);
  return;                               // silent: no ack, no log, empty composer
}
```

The service worker never forwards it. Its route guard:

```js
if (!ownsDocument(source) || !tab || tab.pendingUrl || tab.status === 'loading' ||
    !isChatGptUrl(tab.url) || conversationFromUrl(tab.url) !== cleanConversationId(message.conversationId))
  return { ok: false, error: 'stale_document' };
```

That is written for checkpoints that *name* a chat: the tab has to prove it settled on that exact route. The two destination checkpoints name none — they come from a page opened at `/?clf=<id>`, before ChatGPT has created anything — and a ChatGPT opened seconds ago is still `loading`. So the normal case is refused.

Nothing downstream can see it, because the refusal is the worker's own and no request reaches the app. `fail()` would travel the same call, so no ack escapes either. The app waits out its deadline and reports `the chat this app opened did not report back in time`, which names the timeout rather than the cause.

That timing is also why it is intermittent rather than total: whether the tab has finished loading when the permit is asked for depends on the machine and the network.

### The change

The guard splits on what the message claims. A checkpoint naming a chat still has to prove the tab settled on that route — **unchanged**. One naming none is judged on the document lease `ownsDocument` has already established, and refused only if the tab turns out to be showing some other conversation.

21 lines in `extension/background.js`.

### Verified

Fails before the change:

```
× forwards a replacement chat permit while the tab is still loading
× forwards a replacement chat permit while the tab is still pending
  AssertionError: expected Object{ ok: false, …(1) } to not match object { error: 'stale_document' }
```

Passes after, plus `forwards the destination checkpoints a replacement chat sends, which name no conversation`.

**Worth flagging:** every prior `/compact` test passes `conversationId` alongside the token, because every one of them is the *source* chat. The destination's shape — token and flag, no conversation — was untested, and it is the shape the whole handoff depends on.

Full suite 3442 passed. Four of the five failures are `renderer-usage` (locale-dependent number formatting) and one `mcp` shell test, identical on unmodified `main` here; the fifth, `codex-runtime-parity`, passes 17/17 in isolation and is a load flake on this machine — none of them touches the extension.

### Provenance

The measurement and the fix are from a field investigation on macOS; the report lists this as **verified in production**. I verified the fail-before/pass-after on `main` on Windows before submitting.
