### PR TITLE
Release a handoff's claim with the command that held it

### DIFF
--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -7080,7 +7080,8 @@ function describe(command: Command, client: string | null, claimedSummary?: stri
 
 function drop(command: Command, why: string): boolean {
   if (!commands.includes(command)) return false;
-  const automaticEntry = command.spec.type === 'resume' ? continuationByToken(command.spec.token) : null;
+  const resumeToken = command.spec.type === 'resume' ? command.spec.token : null;
+  const automaticEntry = resumeToken ? continuationByToken(resumeToken) : null;
   const automaticResume =
     automaticEntry?.automatic === true && automaticEntry.state !== 'committing' && automaticEntry.state !== 'committed';
   if (automaticResume) {
@@ -7090,6 +7091,26 @@ function drop(command: Command, why: string): boolean {
     logWarn(`bridge: released ${specKey(command.spec)} browser attempt without closing its ticket — ${why}`);
     changed();
     persistCommands();
+    // The claim goes with the command, exactly as it does when a page reports the loss itself.
+    //
+    // Redeeming is what claims the brief, and the claim names *this* command. Keeping the
+    // ticket while retiring the command it is claimed by leaves a ticket no later pickup can
+    // ever redeem: every pickup is a fresh id, `claimedBy` never matches one again, and
+    // `claimContinuationNow` refuses for the rest of the six-hour TTL. Observed on 2026-09-09
+    // as four pickups, four opened tabs and four pages that stopped without typing, without an
+    // ack and without a log line — the retry this branch exists to allow, made impossible by
+    // the same branch.
+    //
+    // `destinationLost` takes this transition already, but only a page that survived its send
+    // sends it; a page that dies before one never does. Gated on `not-attempted` so this can
+    // only ever release a brief that provably was not submitted — releasing a dispatched one
+    // is the double-send that `releaseContinuationDestinationSendNow` refuses for `sent`.
+    if (resumeToken && automaticEntry?.destinationSend?.state === 'not-attempted') {
+      void releaseContinuationDestinationSendNow(resumeToken)
+        .catch(() => undefined)
+        .finally(() => scheduleDeliver());
+      return true;
+    }
     scheduleDeliver();
     return true;
   }

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -190,6 +190,30 @@ async function compactedSession(from: string, brief: string): Promise<{ sessionI
   return { sessionId, token: await readyContinuation(sessionId, brief, from) };
 }
 
+/**
+ * The same, but the ticket the app files for itself rather than one the user asked for.
+ *
+ * Automatic tickets take a different failure path: a manual resume that never reports back is
+ * aborted, an automatic one keeps its ticket for a later pickup. Only the automatic one can
+ * reach the state this file's claim test is about.
+ */
+async function automaticCompactedSession(from: string, brief: string): Promise<{ sessionId: string; token: string }> {
+  const reply = await request('POST', '/events', {
+    body: {
+      conversationId: from,
+      events: [{ kind: 'user_message', time: Date.now(), text: 'do the work', messageId: `m-${from}` }]
+    }
+  });
+  const sessionId = reply.body.sessionId as string;
+  expect(sessionId, 'the chat was not recorded, so there is no session to compact').toBeTruthy();
+  const ticket = await openContinuationNow(sessionId, from, true);
+  const stored = await attachSummary(ticket.token, `${brief}
+
+${SAMPLE_BRIEF}`);
+  expect(stored, 'the brief was not stored, so there is no resume to queue').not.toBeNull();
+  return { sessionId, token: ticket.token };
+}
+
 /** Every URL the app asked the OS to open, in order. Stands in for Electron's shell. */
 const opened: string[] = [];
 let anonymousRedeemIndex = 0;
@@ -4437,6 +4461,58 @@ describe('targeted open', () => {
       expect(continuationByToken(token)?.state).toBe('aborted');
       // And no second tab was opened for it on the way out.
       expect(opened).toEqual([commandUrl(command.id)]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  /**
+   * The claim outliving the command that made it.
+   *
+   * Redeeming is what claims the brief: the app records the redeeming command as `claimedBy` so
+   * a second tab on the same marker cannot be handed the same handoff twice. An *automatic*
+   * ticket deliberately survives a failed attempt — `drop()` retires the command and keeps the
+   * ticket, so a later pickup can try again — but the claim was never released with it, and
+   * every later pickup is a *new* command id which can therefore never equal `claimedBy`.
+   *
+   * `claimContinuationNow` then returns null for the rest of the ticket's six-hour life, the
+   * command is handed out with an empty brief, and the page stops without typing, without an
+   * ack and without a log line. Observed on 2026-09-09: four pickups, four opened tabs, four
+   * silent stops, `claimedBy` still naming the first tab's command hours after it was closed.
+   *
+   * Nothing here was ever submitted — `destinationSend` never leaves `not-attempted` — so
+   * releasing the claim cannot re-send anything.
+   */
+  it('lets the next pickup claim a brief whose first chat died before typing anything', async () => {
+    vi.useFakeTimers();
+    try {
+      setBrowserOpener(async (url) => {
+        opened.push(url);
+      });
+      await pair();
+      const { sessionId, token } = await automaticCompactedSession(
+        '55555555-6666-7777-8888-999999999999',
+        'the wedged brief'
+      );
+      const first = queueResume(sessionId, token)!;
+      await waitForOpened(1);
+
+      // The chat opens and its page redeems, which is the act that claims the brief. Then the
+      // tab is closed: nothing is typed, nothing is acked, nothing is reported.
+      expect((await redeem(first.id, 'tab-1')).text).toContain('the wedged brief');
+      expect(continuationByToken(token)?.destinationSend.state).toBe('not-attempted');
+
+      // The command's own deadline passes with nothing reported.
+      await vi.advanceTimersByTimeAsync(16 * 60_000);
+
+      // An automatic ticket is kept on purpose — this is the state a later pickup exists for.
+      expect(continuationByToken(token)?.state).not.toBe('aborted');
+      expect(pendingCommands().some((entry) => entry.id === first.id)).toBe(false);
+
+      // So the next pickup, whose id is necessarily different, has to be able to carry it.
+      const second = queueResume(sessionId, token)!;
+      expect(second.id).not.toBe(first.id);
+      expect((await redeem(second.id, 'tab-2')).text).toContain('the wedged brief');
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
An automatic compaction opens tab after tab and never types into any of them, for the ticket's whole six-hour life.

### Mechanism

Redeeming a resume is what *claims* its brief. `claimContinuationNow(token, claimant)` records the redeeming **command id** as `claimedBy`, so a second tab on the same marker cannot be handed the same handoff twice:

```ts
// src/main/session/continuation.ts
if (entry.claimedBy !== null && entry.claimedBy !== claimant) return null;
```

An *automatic* ticket then deliberately outlives a failed attempt. `drop()` retires the command but keeps the ticket, precisely so a later pickup can try again:

```ts
if (automaticResume) {
  commands = commands.filter((entry) => entry !== command);
  logWarn(`bridge: released ${specKey(command.spec)} browser attempt without closing its ticket — ${why}`);
  …
}
```

The claim was **not** retired with it. Every later pickup is a fresh command id, which can therefore never equal the `claimedBy` the dead command left behind — so `claimContinuationNow` refuses for the rest of the TTL, the command is handed out with an empty brief, and the page stops without typing, without an ack and without a log line.

### Field evidence

`state/continuations.json`, hours after the first tab was closed:

```json
{
  "state": "claimed",
  "claimedBy": "253b3fcea4dce828",
  "sourceSend":      { "state": "sent", "messageId": "…" },
  "destinationSend": { "state": "not-attempted", "conversationId": null, "messageId": null }
}
```

`253b3fcea4dce828` was the command from pickup 1; the live command at that moment was `1cf2cea330d67876`. `destinationSend` never left `not-attempted`, so nothing was ever submitted under that claim.

The app log, heartbeats filtered — four attempts, no acks, no failures:

```
20:24:51  captured the compaction brief for <session>; opening the replacement chat
20:39:52  released resume:<session> browser attempt without closing its ticket — the chat this app opened did not report back in time
20:40:04  compaction ticket … opening pickup 1 of 3
20:55:06  released … did not report back in time
20:55:35  compaction ticket … opening pickup 2 of 3
```

### The change

`releaseContinuationDestinationSendNow` is already exactly this transition, and its own comment states the requirement:

> The claim goes with the dispatch. It named the one command whose page was to send the brief; that page has sent nothing and its command is retired, so the next command — a fresh id — must be able to claim, or the released brief could never be offered again.

It was only ever reached from the `/compact destinationLost` route — which a page sends **after surviving its send**. A page that dies before one never sends it. `drop()` now takes the same transition.

Gated on `destinationSend` still being `not-attempted`, so it can only release a brief that provably was not submitted. A dispatched one is left exactly as before, because releasing that is the double send the function already refuses for `sent`.

### Verified

Fails before the change on `main`:

```
× lets the next pickup claim a brief whose first chat died before typing anything
  AssertionError: redeem 4ab768436548d43b failed: expected 409 to be 200
```

The test drives the real bridge: an automatic ticket, a page that redeems and then never reports, the command's deadline, and a second pickup that must still carry the same brief.

`npm run typecheck` clean. Full suite 3442 passed. Of the six failures, four are `renderer-usage` (locale-dependent number formatting) and one `mcp` shell test, which fail identically on unmodified `main` on this Windows machine; the other two (`codex-runtime-parity`, `session`) pass 152/152 in isolation and are load flakes here. None touches this code.

### Related

This is one of several defects from the same investigation. #164 covers the one that produces the visible symptom most often — a replacement chat that opens and stays empty — and is independent of this.
