### PR TITLE
Add thin authenticated controller ingress

### DIFF
--- a/src/main/control.ts
+++ b/src/main/control.ts
@@ -108,7 +108,12 @@ export async function controlRequestView(deps: ControlDependencies, entry: Input
   };
   if (entry.state !== 'sent' || !sessionId) return base;
 
-  const events = await deps.events(sessionId);
+  // Request/result ownership follows the recorder's durable sequence, never provider clocks.
+  // A freshly opened ChatGPT page can report its final DOM snapshot with an earlier provider
+  // timestamp than the delivery acknowledgement even though the recorder assigned it the next
+  // sequence. Presentation chronology is useful in the UI, but would strand that exact answer
+  // before its owning user message here.
+  const events = (await deps.events(sessionId)).sort((left, right) => left.seq - right.seq);
   const authored = events.findIndex(event => event.kind === 'user_message' && event.inputId === entry.id &&
     event.inputDelivery === 'confirmed');
   if (authored < 0) return base;

--- a/src/main/control.ts
+++ b/src/main/control.ts
@@ -118,13 +118,14 @@ async function recordedInputBoundary(deps: ControlDependencies, entry: InputEntr
   // but before its /input/ack reaches the app. The stock outbox correctly refuses to resend and
   // eventually records delivery ambiguity. Recover only from one unique recorder-owned user row
   // inside the exact authorized-send window; duplicates or merely similar text fail closed.
-  if (entry.state !== 'cancelled' || entry.deliveredAt !== undefined || sessionId || !entry.owner ||
+  if (entry.state !== 'cancelled' || entry.deliveredAt !== undefined || !entry.owner ||
       entry.error !== AMBIGUOUS_DELIVERY_ERROR || entry.sendAuthorizedAt === undefined) return null;
   const expected = comparableInputText(entry.deliveryText ?? entry.text);
   const from = entry.sendAuthorizedAt;
   const until = from + LATE_DELIVERY_WINDOW_MS;
   const matches: RecordedInputBoundary[] = [];
-  const summaries = (await deps.sessions()).filter(summary => summary.updatedAt >= from && summary.startedAt <= until);
+  const summaries = (await deps.sessions()).filter(summary =>
+    (!sessionId || summary.id === sessionId) && summary.updatedAt >= from && summary.startedAt <= until);
   for (const summary of summaries) {
     const events = (await deps.events(summary.id)).sort((left, right) => left.seq - right.seq);
     for (let index = 0; index < events.length; index += 1) {

--- a/src/main/control.ts
+++ b/src/main/control.ts
@@ -1,0 +1,322 @@
+/** Authenticated loopback ingress for external controllers.
+ *
+ * The controller owns no ChatGPT lifecycle. It only publishes one existing desktop input and
+ * reads the exact recorded reply joined to that input's durable UUID.
+ */
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import http from 'node:http';
+import type { Socket } from 'node:net';
+import path from 'node:path';
+import { z } from 'zod';
+import { REASONING_EFFORTS, type SessionEvent, type SessionSummary, type StoredText } from '../shared/session.js';
+import { getConfig } from './config.js';
+import { cancelDesktopInput, sendDesktopInput } from './session/start-input.js';
+import { listInputs, type InputArgs, type InputEntry } from './session/input.js';
+import { getSession, readEvents, readOverflowText } from './session/store.js';
+import { APP_VERSION } from './version.js';
+
+export const CONTROL_PROTOCOL_VERSION = 1;
+export const CONTROL_VERSION_HEADER = 'x-cos-control-version';
+const MAX_BODY_BYTES = 64 * 1024;
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+const submitSchema = z.object({
+  requestId: z.string().uuid(),
+  sessionId: z.string().min(8).max(64).nullable().optional(),
+  projectId: z.string().uuid().nullable().optional(),
+  text: z.string().trim().min(1).max(16_000),
+  model: z.string().min(1).max(80).nullable().optional(),
+  reasoningEffort: z.enum(REASONING_EFFORTS).nullable().optional()
+}).strict();
+
+export type ControlRequestState = 'queued' | 'delivering' | 'running' | 'completed' | 'failed' | 'cancelled';
+export interface ControlRequestView {
+  requestId: string;
+  sessionId: string | null;
+  state: ControlRequestState;
+  createdAt: number;
+  deliveredAt: number | null;
+  requestedSelection: { model: string | null; reasoningEffort: InputArgs['reasoningEffort'] };
+  observedSelection: { model: string; reasoningEffort: InputArgs['reasoningEffort'] } | null;
+  error?: string;
+  result?: { text: string; chars: number; truncated: boolean };
+}
+
+export interface ControlDependencies {
+  send(input: InputArgs): Promise<InputEntry>;
+  cancel(id: string): Promise<boolean>;
+  inputs(): Promise<InputEntry[]>;
+  session(id: string): Promise<SessionSummary | null>;
+  events(id: string): Promise<SessionEvent[]>;
+  overflow(id: string, assetId: string): Promise<string | null>;
+  recording(): boolean;
+}
+
+const productionDependencies: ControlDependencies = {
+  send: sendDesktopInput,
+  cancel: cancelDesktopInput,
+  inputs: listInputs,
+  session: getSession,
+  events: id => readEvents(id, { kinds: ['user_message', 'assistant_message', 'turn_start', 'turn_end'] }),
+  overflow: readOverflowText,
+  recording: () => getConfig().sessions.record
+};
+
+function inputIdentity(input: Pick<InputArgs, 'sessionId' | 'projectId' | 'text' | 'mode' | 'model' | 'reasoningEffort'> &
+  Partial<Pick<InputArgs, 'automation' | 'objective' | 'stages' | 'images' | 'attachments' | 'afterTurn'>>): string {
+  return JSON.stringify({
+    sessionId: input.sessionId,
+    projectId: input.projectId ?? null,
+    text: input.text,
+    mode: input.mode,
+    model: input.model,
+    reasoningEffort: input.reasoningEffort,
+    automation: input.automation ?? null,
+    objective: input.objective ?? null,
+    stages: input.stages ?? null,
+    images: input.images ?? null,
+    attachments: input.attachments ?? null,
+    afterTurn: input.afterTurn ?? null
+  });
+}
+
+function targetSessionId(entry: InputEntry): string | null {
+  return entry.sessionId ?? entry.deliveredSessionId ?? null;
+}
+
+async function resultText(deps: ControlDependencies, sessionId: string, stored: StoredText): Promise<ControlRequestView['result']> {
+  if (!stored.truncated || !stored.assetId) return { text: stored.text, chars: stored.chars, truncated: stored.truncated };
+  const full = await deps.overflow(sessionId, stored.assetId);
+  if (full === null) return { text: stored.text, chars: stored.chars, truncated: true };
+  const text = full.slice(0, 1_000_000);
+  return { text, chars: stored.chars, truncated: text.length !== stored.chars };
+}
+
+export async function controlRequestView(deps: ControlDependencies, entry: InputEntry): Promise<ControlRequestView> {
+  const sessionId = targetSessionId(entry);
+  const base: ControlRequestView = {
+    requestId: entry.id,
+    sessionId,
+    state: entry.state === 'queued' ? 'queued' : ['browser', 'tool'].includes(entry.state) ? 'delivering' :
+      entry.state === 'failed' ? 'failed' : entry.state === 'cancelled' ? 'cancelled' : 'running',
+    createdAt: entry.createdAt,
+    deliveredAt: entry.deliveredAt ?? null,
+    requestedSelection: { model: entry.model, reasoningEffort: entry.reasoningEffort },
+    observedSelection: null,
+    ...(entry.error ? { error: entry.error } : {})
+  };
+  if (entry.state !== 'sent' || !sessionId) return base;
+
+  const events = await deps.events(sessionId);
+  const authored = events.findIndex(event => event.kind === 'user_message' && event.inputId === entry.id &&
+    event.inputDelivery === 'confirmed');
+  if (authored < 0) return base;
+  const user = events[authored]!;
+  const observedSelection = user.model
+    ? { model: user.model, reasoningEffort: user.reasoningEffort ?? null }
+    : null;
+  const nextUser = events.findIndex((event, index) => index > authored && event.kind === 'user_message');
+  const span = events.slice(authored + 1, nextUser < 0 ? undefined : nextUser);
+  const generations = new Set(span.flatMap(event => event.kind === 'turn_start' && event.turnId ? [event.turnId] : []));
+  const belongs = (event: SessionEvent): boolean => generations.size === 0 || !event.turnId || generations.has(event.turnId);
+  const final = span.findLast(event => event.kind === 'assistant_message' && belongs(event) &&
+    (event.final === true || event.state === 'final'));
+  if (final?.kind === 'assistant_message') {
+    return { ...base, state: 'completed', observedSelection, result: await resultText(deps, sessionId, final.message) };
+  }
+  const ended = span.findLast(event => event.kind === 'turn_end' && belongs(event));
+  if (ended?.kind === 'turn_end' && ended.outcome === 'stopped') return { ...base, state: 'cancelled', observedSelection };
+  if (ended?.kind === 'turn_end' && ended.outcome !== 'completed') {
+    return { ...base, state: 'failed', observedSelection, error: ended.detail || `ChatGPT turn ended ${ended.outcome}` };
+  }
+  const summary = await deps.session(sessionId);
+  if (summary?.endedAt !== null && summary?.endedAt !== undefined) {
+    return { ...base, state: 'failed', observedSelection, error: 'ChatGPT session ended without an exact recorded final answer' };
+  }
+  return { ...base, observedSelection };
+}
+
+class ControlError extends Error {
+  constructor(readonly status: number, readonly code: string, message: string) { super(message); }
+}
+
+function json(res: http.ServerResponse, status: number, value: unknown): void {
+  const bytes = Buffer.from(JSON.stringify(value));
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': bytes.length,
+    'cache-control': 'no-store'
+  });
+  res.end(bytes);
+}
+
+async function readBody(req: http.IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  for await (const chunk of req) {
+    const part = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    bytes += part.length;
+    if (bytes > MAX_BODY_BYTES) throw new ControlError(413, 'body_too_large', 'The request body is too large');
+    chunks.push(part);
+  }
+  try { return JSON.parse(Buffer.concat(chunks).toString('utf8')); }
+  catch { throw new ControlError(400, 'invalid_json', 'The request body is not valid JSON'); }
+}
+
+function authenticated(req: http.IncomingMessage, token: string): boolean {
+  const authorization = req.headers.authorization;
+  if (typeof authorization !== 'string' || !authorization.startsWith('Bearer ')) return false;
+  const supplied = Buffer.from(authorization.slice(7));
+  const expected = Buffer.from(token);
+  return supplied.length === expected.length && timingSafeEqual(supplied, expected);
+}
+
+export function createControlHandler(deps: ControlDependencies, token: string): http.RequestListener {
+  const submitting = new Map<string, { identity: string; work: Promise<InputEntry> }>();
+  return (req, res) => {
+    void (async () => {
+      if (!authenticated(req, token)) throw new ControlError(401, 'unauthorized', 'A valid control bearer token is required');
+      if (req.headers[CONTROL_VERSION_HEADER] !== String(CONTROL_PROTOCOL_VERSION)) {
+        throw new ControlError(426, 'incompatible_version', `Control protocol ${CONTROL_PROTOCOL_VERSION} is required`);
+      }
+      if (req.headers.origin) throw new ControlError(403, 'browser_origin_forbidden', 'Browser-origin control requests are forbidden');
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+
+      if (req.method === 'GET' && url.pathname === '/v1/capabilities') {
+        return json(res, 200, {
+          protocolVersion: CONTROL_PROTOCOL_VERSION,
+          appVersion: APP_VERSION,
+          recording: deps.recording(),
+          operations: ['submit', 'status', 'result', 'cancel']
+        });
+      }
+      if (req.method === 'POST' && url.pathname === '/v1/requests') {
+        if (!deps.recording()) throw new ControlError(409, 'recording_required', 'Session recording must be enabled for exact result attribution');
+        const submitted = submitSchema.parse(await readBody(req));
+        const input: InputArgs = {
+          id: submitted.requestId,
+          sessionId: submitted.sessionId ?? null,
+          ...(submitted.projectId !== undefined ? { projectId: submitted.projectId } : {}),
+          text: submitted.text,
+          mode: 'auto',
+          dueAt: Date.now(),
+          model: submitted.model ?? null,
+          reasoningEffort: submitted.reasoningEffort ?? null
+        };
+        const identity = inputIdentity(input);
+        const prior = (await deps.inputs()).find(entry => entry.id === input.id);
+        if (prior) {
+          const original = { ...prior, mode: prior.requestedMode ?? prior.mode };
+          if (inputIdentity(original) !== identity) throw new ControlError(409, 'request_id_conflict', 'The request id already belongs to different input');
+          return json(res, 200, { idempotent: true, request: await controlRequestView(deps, prior) });
+        }
+        const active = submitting.get(input.id);
+        if (active && active.identity !== identity) throw new ControlError(409, 'request_id_conflict', 'The request id already belongs to different input');
+        if (!active) {
+          const operation = { identity, work: deps.send(input) };
+          submitting.set(input.id, operation);
+          operation.work.finally(() => {
+            if (submitting.get(input.id) === operation) submitting.delete(input.id);
+          }).catch(() => undefined);
+        }
+        const entry = await submitting.get(input.id)!.work;
+        return json(res, 202, { idempotent: active !== undefined, request: await controlRequestView(deps, entry) });
+      }
+
+      const match = url.pathname.match(/^\/v1\/requests\/([0-9a-f-]{36})(?:\/(cancel))?$/i);
+      if (match && req.method === 'GET' && !match[2]) {
+        const entry = (await deps.inputs()).find(row => row.id === match[1]);
+        if (!entry) throw new ControlError(404, 'unknown_request', 'The control request does not exist');
+        return json(res, 200, { request: await controlRequestView(deps, entry) });
+      }
+      if (match && req.method === 'POST' && match[2] === 'cancel') {
+        const entry = (await deps.inputs()).find(row => row.id === match[1]);
+        if (!entry) throw new ControlError(404, 'unknown_request', 'The control request does not exist');
+        const accepted = await deps.cancel(entry.id);
+        const current = (await deps.inputs()).find(row => row.id === entry.id) ?? entry;
+        return json(res, 200, { cancelAccepted: accepted, request: await controlRequestView(deps, current) });
+      }
+      throw new ControlError(404, 'not_found', 'The control route does not exist');
+    })().catch(error => {
+      if (res.headersSent) return res.destroy();
+      if (error instanceof ControlError) return json(res, error.status, { error: { code: error.code, message: error.message } });
+      if (error instanceof z.ZodError) return json(res, 400, { error: { code: 'invalid_request', message: 'The request fields are invalid' } });
+      return json(res, 500, { error: { code: 'internal_error', message: error instanceof Error ? error.message : 'Control request failed' } });
+    });
+  };
+}
+
+async function tokenAt(file: string): Promise<string> {
+  try {
+    const token = (await fs.readFile(file, 'utf8')).trim();
+    if (!TOKEN_PATTERN.test(token)) throw new Error('The control token file is invalid');
+    await fs.chmod(file, 0o600);
+    return token;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  const token = randomBytes(32).toString('base64url');
+  const handle = await fs.open(file, 'wx', 0o600);
+  try { await handle.writeFile(`${token}\n`, 'utf8'); await handle.sync(); }
+  finally { await handle.close(); }
+  return token;
+}
+
+export interface ControlServer {
+  port: number;
+  tokenFile: string;
+  discoveryFile: string;
+  close(): Promise<void>;
+}
+
+export async function startControlServer(userDataDir: string, deps: ControlDependencies = productionDependencies): Promise<ControlServer> {
+  await fs.mkdir(userDataDir, { recursive: true });
+  const tokenFile = path.join(userDataDir, 'control-token');
+  const discoveryFile = path.join(userDataDir, 'control.json');
+  const token = await tokenAt(tokenFile);
+  const server = http.createServer(createControlHandler(deps, token));
+  const sockets = new Set<Socket>();
+  server.on('connection', socket => { sockets.add(socket); socket.once('close', () => sockets.delete(socket)); });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => { server.off('error', reject); resolve(); });
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('The control server did not bind a TCP port');
+  const temporary = `${discoveryFile}.${process.pid}.tmp`;
+  await fs.writeFile(temporary, `${JSON.stringify({ port: address.port, protocolVersion: CONTROL_PROTOCOL_VERSION })}\n`, { encoding: 'utf8', mode: 0o600 });
+  await fs.rename(temporary, discoveryFile);
+  await fs.chmod(discoveryFile, 0o600);
+  let closed = false;
+  return {
+    port: address.port,
+    tokenFile,
+    discoveryFile,
+    close: async () => {
+      if (closed) return;
+      closed = true;
+      server.closeIdleConnections?.();
+      const stopped = new Promise<void>(resolve => server.close(() => resolve()));
+      const timer = setTimeout(() => { for (const socket of sockets) socket.destroy(); }, 5_000);
+      timer.unref?.();
+      await stopped;
+      clearTimeout(timer);
+      try {
+        const descriptor = JSON.parse(await fs.readFile(discoveryFile, 'utf8')) as { port?: unknown };
+        if (descriptor.port === address.port) await fs.unlink(discoveryFile);
+      } catch { /* Missing or replaced discovery already describes another lifecycle. */ }
+    }
+  };
+}
+
+let external: ControlServer | null = null;
+export async function startExternalControl(userDataDir: string): Promise<ControlServer> {
+  external ??= await startControlServer(userDataDir);
+  return external;
+}
+export async function shutdownExternalControl(): Promise<void> {
+  const current = external;
+  external = null;
+  await current?.close();
+}

--- a/src/main/control.ts
+++ b/src/main/control.ts
@@ -13,13 +13,15 @@ import { REASONING_EFFORTS, type SessionEvent, type SessionSummary, type StoredT
 import { getConfig } from './config.js';
 import { cancelDesktopInput, sendDesktopInput } from './session/start-input.js';
 import { listInputs, type InputArgs, type InputEntry } from './session/input.js';
-import { getSession, readEvents, readOverflowText } from './session/store.js';
+import { getSession, readEvents, readEverySummary, readOverflowText } from './session/store.js';
 import { APP_VERSION } from './version.js';
 
 export const CONTROL_PROTOCOL_VERSION = 1;
 export const CONTROL_VERSION_HEADER = 'x-cos-control-version';
 const MAX_BODY_BYTES = 64 * 1024;
 const TOKEN_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const AMBIGUOUS_DELIVERY_ERROR = 'Stopped waiting for delivery confirmation. The message may already have been sent; it will not be resent.';
+const LATE_DELIVERY_WINDOW_MS = 120_000;
 
 const submitSchema = z.object({
   requestId: z.string().uuid(),
@@ -47,6 +49,7 @@ export interface ControlDependencies {
   send(input: InputArgs): Promise<InputEntry>;
   cancel(id: string): Promise<boolean>;
   inputs(): Promise<InputEntry[]>;
+  sessions(): Promise<SessionSummary[]>;
   session(id: string): Promise<SessionSummary | null>;
   events(id: string): Promise<SessionEvent[]>;
   overflow(id: string, assetId: string): Promise<string | null>;
@@ -57,6 +60,7 @@ const productionDependencies: ControlDependencies = {
   send: sendDesktopInput,
   cancel: cancelDesktopInput,
   inputs: listInputs,
+  sessions: readEverySummary,
   session: getSession,
   events: id => readEvents(id, { kinds: ['user_message', 'assistant_message', 'turn_start', 'turn_end'] }),
   overflow: readOverflowText,
@@ -85,6 +89,55 @@ function targetSessionId(entry: InputEntry): string | null {
   return entry.sessionId ?? entry.deliveredSessionId ?? null;
 }
 
+function comparableInputText(text: string): string {
+  // ChatGPT's recorded plain-text user row omits Markdown code delimiters that were present in
+  // the submitted composer text. Keep every other character exact so late matching cannot drift
+  // into a merely similar user message.
+  return text.replace(/\r\n/g, '\n').replaceAll('`', '').trim();
+}
+
+interface RecordedInputBoundary {
+  sessionId: string;
+  events: SessionEvent[];
+  authored: number;
+  deliveredAt: number;
+  late: boolean;
+}
+
+async function recordedInputBoundary(deps: ControlDependencies, entry: InputEntry): Promise<RecordedInputBoundary | null> {
+  const sessionId = targetSessionId(entry);
+  if (entry.state === 'sent' && sessionId) {
+    const events = (await deps.events(sessionId)).sort((left, right) => left.seq - right.seq);
+    const authored = events.findIndex(event => event.kind === 'user_message' && event.inputId === entry.id &&
+      event.inputDelivery === 'confirmed');
+    if (authored >= 0) return { sessionId, events, authored, deliveredAt: entry.deliveredAt ?? events[authored]!.time, late: false };
+    return null;
+  }
+
+  // A new-chat navigation can destroy the sending document after ChatGPT accepted the message
+  // but before its /input/ack reaches the app. The stock outbox correctly refuses to resend and
+  // eventually records delivery ambiguity. Recover only from one unique recorder-owned user row
+  // inside the exact authorized-send window; duplicates or merely similar text fail closed.
+  if (entry.state !== 'cancelled' || entry.deliveredAt !== undefined || sessionId || !entry.owner ||
+      entry.error !== AMBIGUOUS_DELIVERY_ERROR || entry.sendAuthorizedAt === undefined) return null;
+  const expected = comparableInputText(entry.deliveryText ?? entry.text);
+  const from = entry.sendAuthorizedAt;
+  const until = from + LATE_DELIVERY_WINDOW_MS;
+  const matches: RecordedInputBoundary[] = [];
+  const summaries = (await deps.sessions()).filter(summary => summary.updatedAt >= from && summary.startedAt <= until);
+  for (const summary of summaries) {
+    const events = (await deps.events(summary.id)).sort((left, right) => left.seq - right.seq);
+    for (let index = 0; index < events.length; index += 1) {
+      const event = events[index]!;
+      if (event.kind !== 'user_message' || event.source !== 'extension' || event.time < from || event.time > until ||
+          (event.inputId !== undefined && event.inputId !== entry.id) || comparableInputText(event.message.text) !== expected) continue;
+      matches.push({ sessionId: summary.id, events, authored: index, deliveredAt: event.time, late: true });
+      if (matches.length > 1) return null;
+    }
+  }
+  return matches[0] ?? null;
+}
+
 async function resultText(deps: ControlDependencies, sessionId: string, stored: StoredText): Promise<ControlRequestView['result']> {
   if (!stored.truncated || !stored.assetId) return { text: stored.text, chars: stored.chars, truncated: stored.truncated };
   const full = await deps.overflow(sessionId, stored.assetId);
@@ -94,8 +147,9 @@ async function resultText(deps: ControlDependencies, sessionId: string, stored: 
 }
 
 export async function controlRequestView(deps: ControlDependencies, entry: InputEntry): Promise<ControlRequestView> {
-  const sessionId = targetSessionId(entry);
-  const base: ControlRequestView = {
+  const boundary = await recordedInputBoundary(deps, entry);
+  const sessionId = boundary?.sessionId ?? targetSessionId(entry);
+  let base: ControlRequestView = {
     requestId: entry.id,
     sessionId,
     state: entry.state === 'queued' ? 'queued' : ['browser', 'tool'].includes(entry.state) ? 'delivering' :
@@ -106,17 +160,19 @@ export async function controlRequestView(deps: ControlDependencies, entry: Input
     observedSelection: null,
     ...(entry.error ? { error: entry.error } : {})
   };
-  if (entry.state !== 'sent' || !sessionId) return base;
+  if (!boundary) return base;
+  const ownedSessionId = boundary.sessionId;
+  if (boundary.late) {
+    const { error: _error, ...recovered } = base;
+    base = { ...recovered, state: 'running', deliveredAt: boundary.deliveredAt };
+  }
 
   // Request/result ownership follows the recorder's durable sequence, never provider clocks.
   // A freshly opened ChatGPT page can report its final DOM snapshot with an earlier provider
   // timestamp than the delivery acknowledgement even though the recorder assigned it the next
   // sequence. Presentation chronology is useful in the UI, but would strand that exact answer
   // before its owning user message here.
-  const events = (await deps.events(sessionId)).sort((left, right) => left.seq - right.seq);
-  const authored = events.findIndex(event => event.kind === 'user_message' && event.inputId === entry.id &&
-    event.inputDelivery === 'confirmed');
-  if (authored < 0) return base;
+  const { events, authored } = boundary;
   const user = events[authored]!;
   const observedSelection = user.model
     ? { model: user.model, reasoningEffort: user.reasoningEffort ?? null }
@@ -128,14 +184,14 @@ export async function controlRequestView(deps: ControlDependencies, entry: Input
   const final = span.findLast(event => event.kind === 'assistant_message' && belongs(event) &&
     (event.final === true || event.state === 'final'));
   if (final?.kind === 'assistant_message') {
-    return { ...base, state: 'completed', observedSelection, result: await resultText(deps, sessionId, final.message) };
+    return { ...base, state: 'completed', observedSelection, result: await resultText(deps, ownedSessionId, final.message) };
   }
   const ended = span.findLast(event => event.kind === 'turn_end' && belongs(event));
   if (ended?.kind === 'turn_end' && ended.outcome === 'stopped') return { ...base, state: 'cancelled', observedSelection };
   if (ended?.kind === 'turn_end' && ended.outcome !== 'completed') {
     return { ...base, state: 'failed', observedSelection, error: ended.detail || `ChatGPT turn ended ${ended.outcome}` };
   }
-  const summary = await deps.session(sessionId);
+  const summary = await deps.session(ownedSessionId);
   if (summary?.endedAt !== null && summary?.endedAt !== undefined) {
     return { ...base, state: 'failed', observedSelection, error: 'ChatGPT session ended without an exact recorded final answer' };
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -75,6 +75,7 @@ import {
 import { trayGuidArgsForPlatform, trayImageSpec } from './tray-image.js';
 import { browserWindowIconPath } from './window-icon.js';
 import { editContextMenuTemplate } from './edit-context-menu.js';
+import { shutdownExternalControl, startExternalControl } from './control.js';
 
 /** Durable state file holding the multi-agent run. Hashes only, never credentials. */
 const SWARM_STATE = 'swarm';
@@ -426,6 +427,11 @@ void app.whenReady().then(async () => {
 
   logInfo('app started');
 
+  // External controllers publish through the same durable input path as the desktop UI. This
+  // listener owns no browser, model, session or retry lifecycle of its own.
+  try { await startExternalControl(userData); }
+  catch (error) { logError(`external control failed to start: ${error instanceof Error ? error.message : String(error)}`); }
+
   // Historical Unattributed repair may legitimately scan and rewrite a large legacy bucket.
   // It is maintenance, not a prerequisite for showing the app or accepting new exact-id
   // traffic, so never make startup/reload wait behind years of old session history.
@@ -492,7 +498,7 @@ app.on('will-quit', (event) => {
       // The budget has to clear the drains it contains, or it would silently defeat them:
       // the bridge force-closes wedged localhost sockets at 15s and the MCP endpoint forces
       // its own drain at 30s. This is the outer bound on both, not a competing one.
-      { name: 'admission/drain', budgetMs: 40_000, run: () => [shutdownConnection(), shutdownBridge()] },
+      { name: 'admission/drain', budgetMs: 40_000, run: () => [shutdownExternalControl(), shutdownConnection(), shutdownBridge()] },
       // Phase 2: only after request handlers are done may their owned child processes go.
       {
         name: 'process cleanup',

--- a/test/control.test.ts
+++ b/test/control.test.ts
@@ -144,6 +144,21 @@ describe('thin external control', () => {
     });
   });
 
+  it('uses durable sequence when provider timestamps put the exact final before its input', async () => {
+    const stored = session();
+    deps.sessions.set(stored.id, stored);
+    deps.recorded.set(stored.id, [
+      { seq: 3, time: 300, source: 'extension', kind: 'user_message', inputId: requestId, messageId: 'user-a',
+        inputDelivery: 'confirmed', model: 'gpt-5.6-sol', reasoningEffort: 'xhigh',
+        message: { text: 'Run', chars: 3, truncated: false } },
+      { seq: 4, time: 200, source: 'extension', kind: 'assistant_message', messageId: 'answer-a',
+        message: { text: 'Exact answer', chars: 12, truncated: false }, final: true, state: 'final' }
+    ]);
+
+    const view = await controlRequestView(deps, row('sent', { deliveredSessionId: stored.id, deliveredAt: 300 }));
+    expect(view).toMatchObject({ state: 'completed', result: { text: 'Exact answer', truncated: false } });
+  });
+
   it('does not guess completion from an unconfirmed handout or another turn', async () => {
     const stored = session();
     deps.sessions.set(stored.id, stored);

--- a/test/control.test.ts
+++ b/test/control.test.ts
@@ -184,6 +184,31 @@ describe('thin external control', () => {
     expect(view).not.toHaveProperty('error');
   });
 
+  it('recovers the exact known session when its delivery acknowledgement is lost', async () => {
+    const stored = session();
+    stored.startedAt = 100;
+    stored.updatedAt = 1_080;
+    deps.summaries.set(stored.id, stored);
+    deps.recorded.set(stored.id, [
+      { seq: 1, time: 1_020, source: 'extension', kind: 'user_message', messageId: 'known-late-user',
+        message: { text: 'Run (Get-Location).Path', chars: 22, truncated: false } },
+      { seq: 2, time: 1_070, source: 'extension', kind: 'assistant_message', messageId: 'known-late-answer',
+        message: { text: 'Known late answer', chars: 17, truncated: false }, final: true, state: 'final' }
+    ]);
+
+    const view = await controlRequestView(deps, row('cancelled', {
+      sessionId: stored.id, text: 'Run `(Get-Location).Path`', deliveryText: 'Run `(Get-Location).Path`',
+      owner: 'browser-owner', sendAuthorizedAt: 1_000,
+      error: 'Stopped waiting for delivery confirmation. The message may already have been sent; it will not be resent.'
+    }));
+
+    expect(view).toMatchObject({
+      state: 'completed', sessionId: stored.id, deliveredAt: 1_020,
+      result: { text: 'Known late answer', truncated: false }
+    });
+    expect(view).not.toHaveProperty('error');
+  });
+
   it('does not late-attribute duplicate recorder rows or ordinary cancellation', async () => {
     for (const id of ['session-one', 'session-two']) {
       const stored = session(id);

--- a/test/control.test.ts
+++ b/test/control.test.ts
@@ -31,14 +31,14 @@ function row(state: InputEntry['state'], overrides: Partial<InputEntry> = {}): I
 
 function dependencies(): ControlDependencies & {
   rows: InputEntry[];
-  sessions: Map<string, SessionSummary>;
+  summaries: Map<string, SessionSummary>;
   recorded: Map<string, SessionEvent[]>;
 } {
   const rows: InputEntry[] = [];
-  const sessions = new Map<string, SessionSummary>();
+  const summaries = new Map<string, SessionSummary>();
   const recorded = new Map<string, SessionEvent[]>();
   return {
-    rows, sessions, recorded,
+    rows, summaries, recorded,
     send: vi.fn(async input => {
       const entry = row('queued', { ...input, createdAt: Date.now() });
       rows.push(entry);
@@ -51,7 +51,8 @@ function dependencies(): ControlDependencies & {
       return true;
     }),
     inputs: async () => rows.map(entry => ({ ...entry })),
-    session: async id => sessions.get(id) ?? null,
+    sessions: async () => [...summaries.values()],
+    session: async id => summaries.get(id) ?? null,
     events: async id => recorded.get(id) ?? [],
     overflow: async () => null,
     recording: () => true
@@ -124,7 +125,7 @@ describe('thin external control', () => {
 
   it('returns only the final answer inside the exact confirmed input boundary', async () => {
     const stored = session();
-    deps.sessions.set(stored.id, stored);
+    deps.summaries.set(stored.id, stored);
     deps.recorded.set(stored.id, [
       { seq: 1, time: 1, source: 'app', kind: 'user_message', inputId: requestId, messageId: 'user-a',
         inputDelivery: 'confirmed', model: 'gpt-5.6-sol', reasoningEffort: 'xhigh', message: { text: 'Run', chars: 3, truncated: false } },
@@ -146,7 +147,7 @@ describe('thin external control', () => {
 
   it('uses durable sequence when provider timestamps put the exact final before its input', async () => {
     const stored = session();
-    deps.sessions.set(stored.id, stored);
+    deps.summaries.set(stored.id, stored);
     deps.recorded.set(stored.id, [
       { seq: 3, time: 300, source: 'extension', kind: 'user_message', inputId: requestId, messageId: 'user-a',
         inputDelivery: 'confirmed', model: 'gpt-5.6-sol', reasoningEffort: 'xhigh',
@@ -159,9 +160,48 @@ describe('thin external control', () => {
     expect(view).toMatchObject({ state: 'completed', result: { text: 'Exact answer', truncated: false } });
   });
 
+  it('recovers one uniquely recorded user send after a new-chat acknowledgement is lost', async () => {
+    const stored = session();
+    stored.startedAt = 1_010;
+    stored.updatedAt = 1_080;
+    deps.summaries.set(stored.id, stored);
+    deps.recorded.set(stored.id, [
+      { seq: 1, time: 1_020, source: 'extension', kind: 'user_message', messageId: 'late-user',
+        message: { text: 'Run (Get-Location).Path', chars: 22, truncated: false } },
+      { seq: 2, time: 1_070, source: 'extension', kind: 'assistant_message', messageId: 'late-answer',
+        message: { text: 'Exact late answer', chars: 17, truncated: false }, final: true, state: 'final' }
+    ]);
+
+    const view = await controlRequestView(deps, row('cancelled', {
+      text: 'Run `(Get-Location).Path`', deliveryText: 'Run `(Get-Location).Path`', owner: 'browser-owner',
+      sendAuthorizedAt: 1_000, error: 'Stopped waiting for delivery confirmation. The message may already have been sent; it will not be resent.'
+    }));
+
+    expect(view).toMatchObject({
+      state: 'completed', sessionId: stored.id, deliveredAt: 1_020,
+      result: { text: 'Exact late answer', truncated: false }
+    });
+    expect(view).not.toHaveProperty('error');
+  });
+
+  it('does not late-attribute duplicate recorder rows or ordinary cancellation', async () => {
+    for (const id of ['session-one', 'session-two']) {
+      const stored = session(id);
+      stored.startedAt = 1_010;
+      stored.updatedAt = 1_080;
+      deps.summaries.set(id, stored);
+      deps.recorded.set(id, [{ seq: 1, time: 1_020, source: 'extension', kind: 'user_message', messageId: `${id}-user`,
+        message: { text: 'Run the task', chars: 12, truncated: false } }]);
+    }
+    const ambiguous = row('cancelled', { owner: 'browser-owner', sendAuthorizedAt: 1_000,
+      error: 'Stopped waiting for delivery confirmation. The message may already have been sent; it will not be resent.' });
+    expect((await controlRequestView(deps, ambiguous)).state).toBe('cancelled');
+    expect((await controlRequestView(deps, { ...ambiguous, error: 'Input cancelled' })).state).toBe('cancelled');
+  });
+
   it('does not guess completion from an unconfirmed handout or another turn', async () => {
     const stored = session();
-    deps.sessions.set(stored.id, stored);
+    deps.summaries.set(stored.id, stored);
     deps.recorded.set(stored.id, [
       { seq: 1, time: 1, source: 'app', kind: 'user_message', inputId: requestId, messageId: `input:${requestId}`,
         inputDelivery: 'offered', message: { text: 'Run', chars: 3, truncated: false } },

--- a/test/control.test.ts
+++ b/test/control.test.ts
@@ -1,0 +1,167 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionEvent, SessionSummary } from '../src/shared/session.js';
+import {
+  CONTROL_PROTOCOL_VERSION,
+  CONTROL_VERSION_HEADER,
+  controlRequestView,
+  startControlServer,
+  type ControlDependencies,
+  type ControlServer
+} from '../src/main/control.js';
+import type { InputArgs, InputEntry } from '../src/main/session/input.js';
+
+const requestId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+function session(id = 'session-control'): SessionSummary {
+  return { id, title: 'Controlled task', conversationId: 'conversation-control', chatIds: ['conversation-control'],
+    startedAt: 1, updatedAt: 2, endedAt: null, events: 0, userMessages: 0, toolCalls: 0,
+    lastToolCallAt: null, processExitNonzero: 0, toolRejected: 0, toolInternalErrors: 0, errors: 0,
+    estimatedTokens: 0, contextTokens: 0, lastHandoffId: null, lastHandoffAt: null,
+    lastTurnOutcome: null, activeTurnId: null, agents: [], origin: null };
+}
+
+function row(state: InputEntry['state'], overrides: Partial<InputEntry> = {}): InputEntry {
+  const input: InputArgs = { id: requestId, sessionId: null, text: 'Run the task', mode: 'auto', dueAt: 100,
+    model: 'gpt-5.6-sol', reasoningEffort: 'xhigh' };
+  return { ...input, state, owner: null, createdAt: 100, conversationId: null, ...overrides };
+}
+
+function dependencies(): ControlDependencies & {
+  rows: InputEntry[];
+  sessions: Map<string, SessionSummary>;
+  recorded: Map<string, SessionEvent[]>;
+} {
+  const rows: InputEntry[] = [];
+  const sessions = new Map<string, SessionSummary>();
+  const recorded = new Map<string, SessionEvent[]>();
+  return {
+    rows, sessions, recorded,
+    send: vi.fn(async input => {
+      const entry = row('queued', { ...input, createdAt: Date.now() });
+      rows.push(entry);
+      return entry;
+    }),
+    cancel: vi.fn(async id => {
+      const entry = rows.find(candidate => candidate.id === id);
+      if (!entry || !['queued', 'browser'].includes(entry.state)) return false;
+      entry.state = 'cancelled';
+      return true;
+    }),
+    inputs: async () => rows.map(entry => ({ ...entry })),
+    session: async id => sessions.get(id) ?? null,
+    events: async id => recorded.get(id) ?? [],
+    overflow: async () => null,
+    recording: () => true
+  };
+}
+
+describe('thin external control', () => {
+  let directory: string;
+  let server: ControlServer;
+  let deps: ReturnType<typeof dependencies>;
+  let token: string;
+  const call = (pathname: string, init: RequestInit = {}, auth = token, version = String(CONTROL_PROTOCOL_VERSION)) =>
+    fetch(`http://127.0.0.1:${server.port}${pathname}`, { ...init, redirect: 'error', headers: {
+      authorization: `Bearer ${auth}`,
+      [CONTROL_VERSION_HEADER]: version,
+      'content-type': 'application/json',
+      ...(init.headers ?? {})
+    } });
+
+  beforeEach(async () => {
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), 'cos-control-'));
+    deps = dependencies();
+    server = await startControlServer(directory, deps);
+    token = (await fs.readFile(server.tokenFile, 'utf8')).trim();
+  });
+  afterEach(async () => {
+    await server.close();
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+
+  it('publishes loopback discovery and rejects wrong authentication or protocol versions', async () => {
+    expect(JSON.parse(await fs.readFile(server.discoveryFile, 'utf8'))).toEqual({ port: server.port, protocolVersion: 1 });
+    expect((await call('/v1/capabilities', {}, 'wrong')).status).toBe(401);
+    const incompatible = await call('/v1/capabilities', {}, token, '2');
+    expect(incompatible.status).toBe(426);
+    expect(await incompatible.json()).toMatchObject({ error: { code: 'incompatible_version' } });
+    expect(await (await call('/v1/capabilities')).json()).toMatchObject({
+      protocolVersion: 1,
+      operations: ['submit', 'status', 'result', 'cancel']
+    });
+  });
+
+  it('uses the outbox UUID as the only submission identity', async () => {
+    const payload = { requestId, text: 'Run the task', model: 'gpt-5.6-sol', reasoningEffort: 'xhigh' };
+    expect((await call('/v1/requests', { method: 'POST', body: JSON.stringify(payload) })).status).toBe(202);
+    const duplicate = await call('/v1/requests', { method: 'POST', body: JSON.stringify(payload) });
+    expect(duplicate.status).toBe(200);
+    expect(await duplicate.json()).toMatchObject({ idempotent: true, request: { requestId, state: 'queued' } });
+    expect(deps.send).toHaveBeenCalledTimes(1);
+
+    const conflict = await call('/v1/requests', { method: 'POST', body: JSON.stringify({ ...payload, text: 'Different task' }) });
+    expect(conflict.status).toBe(409);
+    expect(await conflict.json()).toMatchObject({ error: { code: 'request_id_conflict' } });
+  });
+
+  it('rejects submission before side effects when exact result recording is off', async () => {
+    deps.recording = () => false;
+    const response = await call('/v1/requests', { method: 'POST', body: JSON.stringify({ requestId, text: 'Run the task' }) });
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: { code: 'recording_required' } });
+    expect(deps.send).not.toHaveBeenCalled();
+  });
+
+  it('delegates cancellation only to the existing durable input owner', async () => {
+    deps.rows.push(row('queued'));
+    const response = await call(`/v1/requests/${requestId}/cancel`, { method: 'POST' });
+    expect(await response.json()).toMatchObject({ cancelAccepted: true, request: { state: 'cancelled' } });
+    expect(deps.cancel).toHaveBeenCalledWith(requestId);
+  });
+
+  it('returns only the final answer inside the exact confirmed input boundary', async () => {
+    const stored = session();
+    deps.sessions.set(stored.id, stored);
+    deps.recorded.set(stored.id, [
+      { seq: 1, time: 1, source: 'app', kind: 'user_message', inputId: requestId, messageId: 'user-a',
+        inputDelivery: 'confirmed', model: 'gpt-5.6-sol', reasoningEffort: 'xhigh', message: { text: 'Run', chars: 3, truncated: false } },
+      { seq: 2, time: 2, source: 'extension', kind: 'turn_start', turnId: 'turn-a' },
+      { seq: 3, time: 3, source: 'extension', kind: 'assistant_message', messageId: 'answer-a', turnId: 'turn-a',
+        message: { text: 'Exact answer', chars: 12, truncated: false }, final: true, state: 'final' },
+      { seq: 4, time: 4, source: 'extension', kind: 'user_message', messageId: 'user-b', message: { text: 'Later', chars: 5, truncated: false } },
+      { seq: 5, time: 5, source: 'extension', kind: 'assistant_message', messageId: 'answer-b',
+        message: { text: 'Wrong later answer', chars: 18, truncated: false }, final: true, state: 'final' }
+    ]);
+    const view = await controlRequestView(deps, row('sent', { deliveredSessionId: stored.id, deliveredAt: 2 }));
+    expect(view).toMatchObject({
+      state: 'completed',
+      sessionId: stored.id,
+      observedSelection: { model: 'gpt-5.6-sol', reasoningEffort: 'xhigh' },
+      result: { text: 'Exact answer', truncated: false }
+    });
+  });
+
+  it('does not guess completion from an unconfirmed handout or another turn', async () => {
+    const stored = session();
+    deps.sessions.set(stored.id, stored);
+    deps.recorded.set(stored.id, [
+      { seq: 1, time: 1, source: 'app', kind: 'user_message', inputId: requestId, messageId: `input:${requestId}`,
+        inputDelivery: 'offered', message: { text: 'Run', chars: 3, truncated: false } },
+      { seq: 2, time: 2, source: 'extension', kind: 'assistant_message', messageId: 'unowned',
+        message: { text: 'Unowned answer', chars: 14, truncated: false }, final: true, state: 'final' }
+    ]);
+    const view = await controlRequestView(deps, row('sent', { deliveredSessionId: stored.id, deliveredAt: 2 }));
+    expect(view.state).toBe('running');
+    expect(view).not.toHaveProperty('result');
+  });
+
+  it('removes only its own discovery descriptor when the listener closes', async () => {
+    const discovery = JSON.parse(await fs.readFile(server.discoveryFile, 'utf8'));
+    expect(discovery.port).toBe(server.port);
+    await server.close();
+    await expect(fs.readFile(server.discoveryFile, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});


### PR DESCRIPTION
Codex currently has no narrow, durable way to submit work to Chat On Steroids and retrieve the exact recorded reply. Integrations therefore tend to duplicate browser/session lifecycle logic and become fragile across app updates.

This adds a loopback-only authenticated controller ingress that delegates command delivery to the existing durable desktop input queue and joins results through the existing recorder using the request UUID. The API is limited to capabilities, submit, status/result, and pre-send cancellation. It does not open or manage browser sessions, discover models, recover turns, or coordinate agents.

Security and identity properties:
- binds only to 127.0.0.1 on an ephemeral port
- uses a 256-bit bearer token stored beside a versioned discovery descriptor
- rejects browser-origin requests and incompatible protocol versions
- makes the caller-provided UUID the durable idempotency key
- rejects same-ID/different-payload submissions
- returns a result only after a confirmed recorded user row and a final assistant row in that exact request boundary
- recovers a lost delivery ACK only when one recorder-owned user row matches the exact authorized input in a bounded window
- when the target session is already known, searches only that exact session; when it is unknown, duplicate candidates fail closed

The late-recorder recovery addresses #168 without resubmitting an ambiguously accepted prompt.

Validation:
- `npm test -- --run test/control.test.ts` (11 passed)
- `npm test -- --run test/control.test.ts test/input-delivery-integration.test.ts test/session-input.test.ts` (172 passed before the known-session extension)
- `npm run typecheck`
- full Vitest suite with two workers (3,449 passed, 29 skipped) plus `test/mcp-shutdown.test.ts` (2 passed)
- `npm run build`

The ordinary `npm run verify` run hit an existing Windows shell test timeout under full parallel load; that exact test passed alone in 2.18s and the complete suite passed with two workers.
