### PR TITLE
Preserve request attribution and fast-response send receipts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,6 +405,13 @@ Chrome sender document/epoch; bridge `/correlations` files exact pairs through r
 reads them back before returning `confirmed[]`. `/events` may publish the same exact evidence.
 Ownership acknowledgement is separate from slow transcript/image writes.
 
+`usage.js` can also project an exact conversation/request pair from a complete live POST
+conversation SSE event before Fiber exposes it. Reads are bounded to 4 MiB / 90 seconds and
+16 request ids; only server metadata is accepted. Content requires the matching route and
+document epoch, using the existing observer for brief fresh-route convergence. Missing stream
+metadata retains the Fiber path. Fetch reattachment at DOM readiness captures each downstream
+wrapper separately and deduplicates responses to avoid recursion through page instrumentation.
+
 For a newly created chat, an exact locally owned provisional Fiber turn can acquire the durable
 native conversation id as the route/server identity materializes. A `WEB:` local id, unmatched
 historical Fiber object, conflicting durable ids, active tab, timing, tool name, arrival order
@@ -865,7 +872,7 @@ while leaving ChatGPT's messages, model execution and account permissions with t
 | --- | --- |
 | `chatgpt-dom.js` | All provider selectors and DOM-shape assumptions, composer/upload/model/turn primitives. |
 | `fiber.js` | Bounded MAIN-world React evidence: messages, request ids, generation/model state and installed connector declarations. |
-| `usage.js` | Bounded allowlisted account-usage observation. |
+| `usage.js` | Bounded account-usage and exact live stream request-origin observation. |
 | `content.js` | Isolated-world recording, exact turn/navigation ownership, input/command execution, native-page companion UI. |
 | `background.js` | MV3 journal and HTTP transport, tab/document registry, command elections and durable ACK custody. |
 | `popup.*`, `overlay.css` | Pair/reconnect status and extension-owned presentation; no local tool authority. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -655,6 +655,10 @@ editor/route identity and attachment changes still do.
 The witnessed Send receipt captures the pre-send assistant baseline. If app identity or native
 message source arrives after a fast reply has rendered, that question still owns its reply and
 exact final marker. A later observation must not classify its own answer as old history.
+While an exact send receipt still has a bounded evidence reader, the existing observation also
+requests canonical MAIN-world text even after native generation stops. Rendered Markdown can
+remove submitted bytes; recognizing the generation must not be a prerequisite for reading the
+source needed to recognize its Send. Route, epoch and stable message identity still decide acceptance.
 
 Page-reply waits are bounded: reuse/close observations get three seconds; New Chat preparation
 gets fifteen seconds. Missing preparation replies retain the elected tab and grant no fallback.

--- a/extension/content.js
+++ b/extension/content.js
@@ -1066,7 +1066,7 @@
   }
 
   /** Talks to the service worker. Returns null once the extension is reloaded. */
-  async function ask(message) {
+  async function ask(message, current = null) {
     // A new/reloaded document claims its browser-supplied MessageSender.documentId before
     // any observation or mutation. This is what lets the worker retain a terminal tombstone
     // across external navigation and still admit the genuinely new page, without accepting
@@ -1080,6 +1080,7 @@
       observed.blocked = (registered && registered.error) || 'worker_unreachable';
       return registered;
     }
+    if (current && !current()) return null;
     observed.blocked = null;
     return sendToWorker({ ...message, navigationEpoch: epoch });
   }
@@ -1606,6 +1607,7 @@
     pageToolsReported.clear();
     callsReported.clear();
     requestOwnersConfirmed.clear();
+    pendingStreamOrigins.clear();
     requestOwnersPending.clear();
     requestOwnerRetryAt.clear();
     requestOwnerAttempts.clear();
@@ -2183,6 +2185,7 @@
         }
       }
     }
+    flushStreamRequestOrigins();
     // Route assignment and authored text can arrive in either order. This receipt is
     // evaluated on the existing observer, rather than only on the one route-change edge.
     if (id && pendingObjectiveSend?.accepted && pendingObjectiveSend.current()) {
@@ -2899,6 +2902,7 @@
   const callsReported = new Map();
   /** Exact request ids the app has ACKed as owned by a concrete conversation. */
   const requestOwnersConfirmed = new Map();
+  const pendingStreamOrigins = new Map();
   /** One in-flight ownership handshake per conversation/request id. */
   const requestOwnersPending = new Set();
   /** Failed handshakes back off briefly instead of retrying on every Fiber mutation. */
@@ -3276,7 +3280,8 @@
     return found;
   }
 
-  async function confirmLiveRequestOwners(calls, ownerConversation) {
+  async function confirmLiveRequestOwners(calls, ownerConversation, current = null) {
+    if (current && !current()) return;
     if (!Array.isArray(calls) || calls.length === 0 || !ownerConversation) return;
     const byRequest = new Map();
     for (const call of calls) {
@@ -3294,7 +3299,8 @@
         type: 'correlate',
         conversationId: ownerConversation,
         calls: batch
-      });
+      }, current);
+      if (current && !current()) return;
       const data = reply && reply.ok === true && reply.data && typeof reply.data === 'object' ? reply.data : null;
       const confirmed = new Set(data && Array.isArray(data.confirmed) ? data.confirmed : []);
       for (const call of batch) {
@@ -10008,6 +10014,41 @@
     const encoded = JSON.stringify({ rows, observedAt });
     if (encoded.length > 24000 || encoded === lastUsageProjection) return;
     void ask({ type: 'usage_observation', rows, observedAt }).then((reply) => { if (reply?.ok) lastUsageProjection = encoded; });
+  });
+  function flushStreamRequestOrigins() {
+    const route = CLF_DOM.conversationId();
+    for (const [requestId, pending] of pendingStreamOrigins) {
+      if (!alive || pending.epoch !== epoch || Date.now() >= pending.deadline || (route && route !== pending.conversationId)) {
+        pendingStreamOrigins.delete(requestId);
+        continue;
+      }
+      if (route !== pending.conversationId || conversationId !== route) continue;
+      pendingStreamOrigins.delete(requestId);
+      const current = () => alive && epoch === pending.epoch && CLF_DOM.conversationId() === route;
+      void confirmLiveRequestOwners([{ requestId, messageId: null, createTime: pending.observedAt / 1000 }], route, current);
+    }
+  }
+  function confirmStreamRequestOrigin(claimed, requestIds, observedAt) {
+    const route = CLF_DOM.conversationId();
+    if (route && route !== claimed) return;
+    // New chats can receive their stream id before /c/<id>. The existing observer
+    // drains a bounded set when that exact route appears; navigation retires it.
+    for (const requestId of requestIds) {
+      if (pendingStreamOrigins.has(requestId) || pendingStreamOrigins.size >= 16) continue;
+      pendingStreamOrigins.set(requestId, { conversationId: claimed, observedAt, epoch, deadline: Date.now() + 30_000 });
+    }
+    flushStreamRequestOrigins();
+  }
+  window.addEventListener('message', (event) => {
+    if (!alive || event.source !== window || event.origin !== location.origin || event.data?.type !== 'cos-request-origin') return;
+    const claimed = typeof event.data.conversationId === 'string' ? event.data.conversationId : '';
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(claimed)) return;
+    const raw = Array.isArray(event.data.requestIds) ? event.data.requestIds : [];
+    if (raw.length === 0 || raw.length > 16) return;
+    const requestIds = [...new Set(raw.filter((id) => typeof id === 'string' && /^wfr_[a-zA-Z0-9_-]{1,96}$/.test(id)))];
+    if (requestIds.length === 0) return;
+    const observedAt = Number.isFinite(event.data.observedAt) ? event.data.observedAt : Date.now();
+    confirmStreamRequestOrigin(claimed, requestIds, observedAt);
   });
   window.postMessage({ type: 'cos-usage-request' }, location.origin);
   let desktopDecision = null;

--- a/extension/content.js
+++ b/extension/content.js
@@ -2413,9 +2413,14 @@
       void bindConversation(conversationId);
     }
 
-    if (continuationJournalPending) {
-      void refreshFiber();
-    } else if (generating) {
+    // A fast answer can finish before the first observation, while native Markdown has
+    // already removed bytes from the submitted bubble. The existing receipt wait still
+    // needs canonical MAIN-world text; requiring a recognized generation here would make
+    // recognizing that generation depend on a scan we never admit. This only reads evidence
+    // while an exact send receipt is pending; the usual route/message checks still decide it.
+    const pendingSendEvidence = pageViewChecks.size > 0 && userSendReceipt &&
+      Date.now() - userSendReceipt.at < USER_SEND_RECEIPT_MS;
+    if (continuationJournalPending || generating || pendingSendEvidence) {
       void refreshFiber();
     } else if (fiberTerminalMessageId && nowGenerating) {
       const terminalTurn = currentAssistantTurn(observedTurns);

--- a/extension/usage.js
+++ b/extension/usage.js
@@ -1,12 +1,22 @@
-/** Passive, bounded usage projection. Never reads request headers, cookies or credentials. */
+/**
+ * Passive, bounded page-response projection.
+ *
+ * Never reads request headers, cookies, credentials or request bodies. Besides
+ * quota metadata, it observes the two opaque identifiers ChatGPT itself puts in the live
+ * conversation event stream: `conversation_id` and `metadata.request_id`. The latter can
+ * reach the stream tens of seconds before React publishes it, which is the difference between
+ * an exact Core caller and CALLER_IDENTITY_REQUIRED. Only that pair crosses worlds.
+ */
 (() => {
   'use strict';
   if (window.__cosUsageObserver) return;
   window.__cosUsageObserver = true;
-  const originalFetch = window.fetch;
   const post = window.postMessage.bind(window);
   let latest = null;
   let requestOrder = 0, latestOrder = 0;
+  const CONVERSATION = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const REQUEST = /^wfr_[a-zA-Z0-9_-]{1,96}$/;
+  const CONVERSATION_FIELD = /(?:^|[,{\s])\"conversation_id\"\s*:\s*\"([0-9a-f-]{36})\"/gi;
   const project = (data, observedAt, order) => {
     if (!data || typeof data !== 'object') return;
     const rows = [];
@@ -60,13 +70,105 @@
     } catch { /* Unsupported metadata is unavailable, never guessed. */ }
     finally { clearTimeout(timer); void reader.cancel().catch(() => {}); }
   }
-  window.fetch = function (...args) {
-    // Request order fences late responses, not accounts. No account identity is inferred.
-    const observedAt = Date.now(), order = ++requestOrder;
-    const result = originalFetch.apply(this, args);
-    void result.then((response) => inspect(response, observedAt, order)).catch(() => {});
-    return result;
+  /**
+   * Reads bounded complete SSE events from a clone without changing the page's response.
+   * Only a conversation id and server request metadata from the same event are projected.
+   */
+  async function inspectRequestOrigins(response, observedAt) {
+    let url;
+    try { url = new URL(response.url); } catch { return; }
+    if (url.origin !== location.origin || !/^\/backend-api\/(?:f\/)?conversation$/.test(url.pathname)) return;
+    if (!response.ok || !response.headers.get('content-type')?.includes('text/event-stream')) return;
+    const copy = response.clone(), reader = copy.body?.getReader();
+    if (!reader) return;
+    const timer = setTimeout(() => void reader.cancel().catch(() => {}), 90_000);
+    const decoder = new TextDecoder();
+    const emitted = new Set();
+    let bytes = 0, buffer = '';
+    const scan = (frame) => {
+      if (!frame || frame.length > 512 * 1024) return;
+      const conversations = new Set();
+      CONVERSATION_FIELD.lastIndex = 0;
+      for (let match; (match = CONVERSATION_FIELD.exec(frame));) {
+        if (CONVERSATION.test(match[1])) conversations.add(match[1]);
+      }
+      // One complete server event must carry both sides of the join. Retaining an id from a
+      // prior frame would turn response order into authority; a contradictory frame abstains.
+      if (conversations.size !== 1) return;
+      const conversationId = conversations.values().next().value;
+      // Only server metadata in a complete JSON event owns a request id. A key in
+      // quoted model text, tool arguments or an unrelated nested object is not proof.
+      let event;
+      try {
+        const data = frame.split(/\r?\n/).filter(line => line.startsWith('data:'))
+          .map(line => line.slice(5).trimStart()).join('\n');
+        event = JSON.parse(data);
+      } catch { return; }
+      if (event?.conversation_id !== conversationId) return;
+      const requestIds = new Set([event.metadata?.request_id, event.message?.metadata?.request_id]
+        .filter(id => typeof id === 'string' && REQUEST.test(id)));
+      const fresh = [...requestIds].filter((id) => !emitted.has(id)).slice(0, 16 - emitted.size);
+      if (fresh.length === 0) return;
+      for (const id of fresh) emitted.add(id);
+      post({ type: 'cos-request-origin', conversationId, requestIds: fresh, observedAt }, location.origin);
+    };
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        bytes += value.byteLength;
+        if (bytes > 4 * 1024 * 1024) return;
+        buffer += decoder.decode(value, { stream: true });
+        for (;;) {
+          const lf = buffer.indexOf('\n\n');
+          const crlf = buffer.indexOf('\r\n\r\n');
+          const split = lf < 0 ? crlf : crlf < 0 ? lf : Math.min(lf, crlf);
+          if (split < 0) break;
+          const width = buffer.startsWith('\r\n\r\n', split) ? 4 : 2;
+          scan(buffer.slice(0, split));
+          buffer = buffer.slice(split + width);
+        }
+        if (buffer.length > 512 * 1024) return;
+      }
+      buffer += decoder.decode();
+      scan(buffer);
+    } catch { /* A missing stream observation leaves the existing Fiber path in charge. */ }
+    finally { clearTimeout(timer); void reader.cancel().catch(() => {}); }
+  }
+  let observedFetch = null;
+  const inspectedResponses = new WeakSet();
+  const installFetchObserver = () => {
+    if (window.fetch === observedFetch || typeof window.fetch !== 'function') return;
+    // A page wrapper may still call our earlier wrapper. Capture its downstream
+    // function per installation; changing a shared pointer would create a cycle.
+    const downstreamFetch = window.fetch;
+    observedFetch = function (...args) {
+      // Request order fences late responses, not accounts. No account identity is inferred.
+      const observedAt = Date.now(), order = ++requestOrder;
+      const result = downstreamFetch.apply(this, args);
+      void result.then((response) => {
+        if (inspectedResponses.has(response)) return;
+        inspectedResponses.add(response);
+        void inspect(response, observedAt, order).catch(() => {});
+        let method = 'GET';
+        try {
+          const explicit = args[1] && typeof args[1].method === 'string' ? args[1].method : null;
+          const inherited = args[0] && typeof args[0] === 'object' && typeof args[0].method === 'string' ? args[0].method : null;
+          method = String(explicit || inherited || 'GET').toUpperCase();
+        } catch { return; }
+        if (method === 'POST') void inspectRequestOrigins(response, observedAt).catch(() => {});
+      }).catch(() => {});
+      return result;
+    };
+    // ChatGPT installs its own fetch instrumentation after document_start. Keep that owner in
+    // the chain and reattach once at the page-ready boundary; otherwise our flag remains set
+    // while the live response observer has silently been replaced.
+    window.fetch = observedFetch;
   };
+  installFetchObserver();
+  if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', installFetchObserver, { once: true });
+  }
   window.addEventListener('message', (event) => {
     if (event.source === window && event.origin === location.origin && event.data?.type === 'cos-usage-request' && latest) post(latest, location.origin);
   });

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -1100,6 +1100,36 @@ describe('desktop input delivery and helper ownership', () => {
     expect(clicks).toBe(1);
   });
 
+  it('reads canonical Markdown for a pending fresh send even when native generation already ended', async () => {
+    const prompt = 'Inspect `src/main/bridge.ts` and reply briefly.';
+    live = await harness(`https://chatgpt.com/?cos-input=${inputId}`, {
+      desktop_input: message => ({ ok: true, data: message.authorize || message.ack
+        ? { ok: true } : { input: claimed({ text: prompt }) } })
+    }, undefined, false, true);
+    let user!: HTMLElement;
+    let clicked!: () => void;
+    let clicks = 0;
+    const click = new Promise<void>(resolve => { clicked = resolve; });
+    live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+      clicks++;
+      live!.dom.reconfigure({ url: `https://chatgpt.com/c/${chatA}` });
+      user = userTurn(live!.document, 'fast-markdown-user', prompt.replaceAll('`', ''), { sent: false });
+      live!.document.querySelector('#prompt-textarea')!.textContent = '';
+      clicked();
+    });
+    const delivery = live.runtimeMessage({ type: 'clf-desktop-input', id: inputId, conversationId: null });
+    await click;
+    user.setAttribute('data-clf-fiber-turn', '0');
+    await replyFiber([], [{ conversationId: chatA, turnId: 'fast-markdown-user', messages: [{
+      role: 'user', stable: true, messageId: 'm-fast-markdown-user', rawMessageId: 'm-fast-markdown-user', rawText: prompt
+    }] }], null, true, live, true);
+    expect(live.sent.filter(message => message.ack)).toEqual([
+      expect.objectContaining({ messageId: 'm-fast-markdown-user' })
+    ]);
+    expect(await delivery).toEqual({ ok: true });
+    expect(clicks).toBe(1);
+  });
+
   it.each([false, true])('acknowledges a helper Markdown prompt with delayed provider evidence (fresh: %s)', async (fresh) => {
     const prompt = ('Inspect `src/main/bridge.ts` and report the exact next step.\n').repeat(1800);
     const rendered = prompt.replaceAll('`', '');
@@ -1619,7 +1649,8 @@ async function replyFiber(
   restamp = true,
   // Describe blocks that keep their own harness variable pass it; everything else uses the
   // shared one.
-  harnessed: Harness | null = null
+  harnessed: Harness | null = null,
+  observeOnly = false
 ): Promise<void> {
   const active = harnessed ?? live!;
   const window = active.window as any;
@@ -1657,7 +1688,10 @@ async function replyFiber(
   };
   window.addEventListener('message', onAsk);
   try {
-    await active.hook.refreshFiber(settled);
+    if (observeOnly) {
+      active.hook.observe();
+      await new Promise(resolve => globalThis.setTimeout(resolve, 100));
+    } else await active.hook.refreshFiber(settled);
   } finally {
     window.removeEventListener('message', onAsk);
     window.setTimeout = instant;

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -8165,6 +8165,94 @@ describe('evidence from the page context', () => {
     expect(live.sent.filter((message) => message.type === 'correlate')).toHaveLength(1);
   });
 
+  it('confirms an exact request from the live response stream before Fiber publishes it', async () => {
+    live = await harness();
+    const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const requestId = 'wfr_stream_early_exact';
+    live.reply.set('correlate', () => ({
+      ok: true,
+      status: 200,
+      data: { ok: true, conversationId, confirmed: [requestId], complete: true }
+    }));
+
+    live.window.dispatchEvent(new live.window.MessageEvent('message', {
+      source: live.window as unknown as Window,
+      origin: 'https://chatgpt.com',
+      data: { type: 'cos-request-origin', conversationId, requestIds: [requestId], observedAt: 1_700_000_001_000 }
+    }));
+    await settle();
+
+    expect(live.sent.filter((message) => message.type === 'correlate')).toEqual([
+      expect.objectContaining({
+        conversationId,
+        calls: [{ requestId, messageId: null, createTime: 1_700_000_001 }]
+      })
+    ]);
+  });
+
+  it('keeps a fresh-chat stream identity until the address bar publishes its exact route', async () => {
+    live = await harness('https://chatgpt.com/?cos-input=aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee');
+    const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const requestId = 'wfr_fresh_route_convergence';
+    live.reply.set('correlate', () => ({
+      ok: true,
+      status: 200,
+      data: { ok: true, conversationId, confirmed: [requestId], complete: true }
+    }));
+
+    live.window.dispatchEvent(new live.window.MessageEvent('message', {
+      source: live.window as unknown as Window,
+      origin: 'https://chatgpt.com',
+      data: { type: 'cos-request-origin', conversationId, requestIds: [requestId], observedAt: 1_700_000_001_000 }
+    }));
+    await settle();
+    expect(live.sent.filter((message) => message.type === 'correlate')).toEqual([]);
+
+    live.window.history.replaceState({}, '', `/c/${conversationId}`);
+    live.hook.observe();
+    await settle();
+
+    expect(live.sent.filter((message) => message.type === 'correlate')).toEqual([
+      expect.objectContaining({
+        conversationId,
+        calls: [{ requestId, messageId: null, createTime: 1_700_000_001 }]
+      })
+    ]);
+  });
+
+  it('retires fresh-chat stream proof when another concrete route wins first', async () => {
+    live = await harness('https://chatgpt.com/');
+    const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    live.window.dispatchEvent(new live.window.MessageEvent('message', {
+      source: live.window as unknown as Window, origin: 'https://chatgpt.com',
+      data: { type: 'cos-request-origin', conversationId, requestIds: ['wfr_retired_route'] }
+    }));
+    live.window.history.replaceState({}, '', '/c/11111111-2222-3333-4444-555555555555');
+    live.hook.observe();
+    live.window.history.replaceState({}, '', '/c/' + conversationId);
+    live.hook.observe();
+    await settle();
+    expect(live.sent.filter(message => message.type === 'correlate')).toEqual([]);
+  });
+
+  it('does not grant stream identity from another route or malformed requests', async () => {
+    live = await harness();
+    const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    for (const data of [
+      { type: 'cos-request-origin', conversationId: '11111111-2222-3333-4444-555555555555', requestIds: ['wfr_foreign'] },
+      { type: 'cos-request-origin', conversationId, requestIds: ['not-a-workflow'] },
+      { type: 'cos-request-origin', conversationId, requestIds: Array.from({ length: 17 }, (_, i) => `wfr_${i}`) }
+    ]) {
+      live.window.dispatchEvent(new live.window.MessageEvent('message', {
+        source: live.window as unknown as Window,
+        origin: 'https://chatgpt.com',
+        data
+      }));
+    }
+    await settle();
+    expect(live.sent.filter((message) => message.type === 'correlate')).toEqual([]);
+  });
+
   it('does not let a stale owned Fiber turn bypass a rejected live ownership handshake', async () => {
     live = await harness();
     const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -818,9 +818,8 @@ describe('desktop input delivery and helper ownership', () => {
     });
     const delivery = live.runtimeMessage({ type: 'clf-desktop-input', id: inputId, conversationId: null });
     await click;
-    live.hook.observe();
     await bindFiberTurns([{ section: user, turn: { turnId: 'framed-app-user', conversationId: chatA,
-      messages: [{ role: 'user', stable: true, messageId: 'm-framed-app-user', rawMessageId: 'm-framed-app-user', rawText: prompt }] } }]);
+      messages: [{ role: 'user', stable: true, messageId: 'm-framed-app-user', rawMessageId: 'm-framed-app-user', rawText: prompt }] } }], true);
     expect(await delivery).toEqual({ ok: true });
     live.hook.observe(); await live.hook.flush();
     expect(live.sent.filter(message => message.ack)).toEqual([expect.objectContaining({ conversationId: chatA, messageId: 'm-framed-app-user' })]);
@@ -1153,8 +1152,7 @@ describe('desktop input delivery and helper ownership', () => {
     expect(live.sent.filter(message => message.ack)).toEqual([]);
     const userProof = { turnId: 'long-helper-user', conversationId: chatA, messages: [{ role: 'user', stable: true,
       messageId: 'm-long-helper-user', rawMessageId: 'm-long-helper-user', rawText: prompt }] };
-    if (fresh) live.hook.observe();
-    await bindFiberTurns([{ section: user, turn: userProof }]);
+    await bindFiberTurns([{ section: user, turn: userProof }], fresh);
     expect(await delivery).toEqual({ ok: true });
     expect(live.sent.filter(message => message.ack)).toEqual([expect.objectContaining({ messageId: 'm-long-helper-user' })]);
     const section = assistantTurn(live.document, 'long-helper-final', []);
@@ -3465,7 +3463,8 @@ function renderingOn(): void {
  * The numeric index is test plumbing only; production never persists it as identity.
  */
 async function bindFiberTurns(
-  bindings: Array<{ section: HTMLElement; turn: Record<string, unknown> }>
+  bindings: Array<{ section: HTMLElement; turn: Record<string, unknown> }>,
+  observeOnly = false
 ): Promise<void> {
   bindings.forEach(({ section }, index) => section.setAttribute('data-clf-fiber-turn', String(index)));
   await replyFiber(
@@ -3477,7 +3476,7 @@ async function bindFiberTurns(
       messages: [],
       activities: [],
       ...turn
-    }))
+    })), null, true, null, observeOnly
   );
   await settle();
 }

--- a/test/usage-observer.test.ts
+++ b/test/usage-observer.test.ts
@@ -4,19 +4,29 @@ import { describe, expect, it } from 'vitest';
 
 const script = readFileSync(new URL('../extension/usage.js', import.meta.url), 'utf8');
 function harness() {
-  const posts: Array<{ type: string; observedAt: number; rows: Array<Record<string, unknown>> }> = [];
+  const posts: Array<Record<string, any>> = [];
   let now = Date.parse('2026-09-05T12:00:00Z');
   class Clock extends Date { static override now() { return now; } }
   let response: unknown;
   let nextBodyGate: Promise<void> | null = null;
-  let listener: (event: unknown) => void = () => {};
+  const listeners = new Map<string, Array<{ handler: (event: unknown) => void; once: boolean }>>();
+  const document = { readyState: 'loading' };
   const window = {
     fetch: (..._args: unknown[]) => Promise.resolve(response),
     postMessage: (data: unknown) => posts.push(JSON.parse(JSON.stringify(data))),
-    addEventListener: (_type: string, handler: typeof listener) => { listener = handler; }
+    addEventListener: (type: string, handler: (event: unknown) => void, options?: { once?: boolean }) => {
+      const rows = listeners.get(type) ?? [];
+      rows.push({ handler, once: options?.once === true });
+      listeners.set(type, rows);
+    }
   };
-  runInNewContext(script, { window, location: { origin: 'https://chatgpt.com' }, URL, Date: Clock, TextDecoder, setTimeout, clearTimeout });
-  async function feed(data: unknown, url = 'https://chatgpt.com/backend-api/wham/usage') {
+  const dispatch = (type: string, event: unknown) => {
+    const rows = listeners.get(type) ?? [];
+    listeners.set(type, rows.filter(row => !row.once));
+    for (const row of rows) row.handler(event);
+  };
+  runInNewContext(script, { window, document, location: { origin: 'https://chatgpt.com' }, URL, Date: Clock, TextDecoder, setTimeout, clearTimeout });
+  async function feed(data: unknown, url = 'https://chatgpt.com/backend-api/wham/usage', init: Record<string, unknown> = {}) {
     let done: () => void = () => {};
     const inspected = new Promise<void>(resolve => { done = resolve; });
     let read = false;
@@ -27,12 +37,47 @@ function harness() {
       cancel: async () => { done(); }
     }) } }) };
     const expectedResponse = response;
-    const returned = await window.fetch('/endpoint', { headers: { Authorization: 'private-test-value' } });
+    const returned = await window.fetch('/endpoint', { headers: { Authorization: 'private-test-value' }, ...init });
     expect(returned).toBe(expectedResponse);
     if (new URL(url).origin === 'https://chatgpt.com' && /^\/backend-api\/(wham\/usage|conversation\/init|conversation\/prepare|models)$/.test(new URL(url).pathname)) await inspected;
     else await new Promise(resolve => setTimeout(resolve, 0));
   }
-  return { posts, feed, holdNextBody: () => { let release = () => {}; nextBodyGate = new Promise<void>(resolve => { release = resolve; }); return () => release(); }, advance: (ms: number) => { now += ms; }, request: (source: unknown = window, origin = 'https://chatgpt.com') => listener({ source, origin, data: { type: 'cos-usage-request' } }) };
+  async function feedSse(chunks: string[], init: Record<string, unknown> = { method: 'POST' }, url = 'https://chatgpt.com/backend-api/conversation') {
+    let done: () => void = () => {};
+    const inspected = new Promise<void>(resolve => { done = resolve; });
+    let at = 0;
+    response = {
+      url,
+      ok: true,
+      headers: { get: () => 'text/event-stream; charset=utf-8' },
+      clone: () => ({ body: { getReader: () => ({
+        read: async () => at < chunks.length
+          ? { done: false, value: new TextEncoder().encode(chunks[at++]!) }
+          : { done: true },
+        cancel: async () => { done(); }
+      }) } })
+    };
+    const returned = await window.fetch('/backend-api/conversation', init);
+    expect(returned).toBe(response);
+    if (String(init.method || 'GET').toUpperCase() === 'POST' && new URL(url).origin === 'https://chatgpt.com' && /^\/backend-api\/(?:f\/)?conversation$/.test(new URL(url).pathname)) await inspected;
+    else await new Promise(resolve => setTimeout(resolve, 0));
+  }
+  return {
+    posts,
+    feed,
+    feedSse,
+    replaceFetch: (wrapExisting = false) => {
+      const previous = window.fetch;
+      const replacement = (...args: unknown[]) => wrapExisting ? previous(...args) : Promise.resolve(response);
+      window.fetch = replacement;
+      return replacement;
+    },
+    ready: () => { document.readyState = 'interactive'; dispatch('DOMContentLoaded', {}); },
+    currentFetch: () => window.fetch,
+    holdNextBody: () => { let release = () => {}; nextBodyGate = new Promise<void>(resolve => { release = resolve; }); return () => release(); },
+    advance: (ms: number) => { now += ms; },
+    request: (source: unknown = window, origin = 'https://chatgpt.com') => dispatch('message', { source, origin, data: { type: 'cos-usage-request' } })
+  };
 }
 
 describe('MAIN-world usage projection', () => {
@@ -129,5 +174,82 @@ describe('MAIN-world usage projection', () => {
     });
     expect(h.posts[1]?.rows).toHaveLength(80);
     expect(JSON.stringify(h.posts)).not.toMatch(/private@example|<script>/);
+  });
+
+  it('publishes an exact conversation/request pair from a chunked live response before React renders it', async () => {
+    const h = harness();
+    const conversationId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    await h.feedSse([
+      `data: {"conversation_id":"${conversationId}","message":{"metadata":{"request_`,
+      'id":"wfr_early_exact"},"content":{"parts":["private prompt and tool args"]}}}\n\n',
+      `data: {"conversation_id":"${conversationId}","message":{"metadata":{"request_id":"wfr_early_exact"}}}\n\n`,
+      `data: {"conversation_id":"${conversationId}","message":{"metadata":{"request_id":"wfr_second"}}}\n\n`
+    ]);
+
+    expect(h.posts).toEqual([
+      { type: 'cos-request-origin', conversationId, requestIds: ['wfr_early_exact'], observedAt: expect.any(Number) },
+      { type: 'cos-request-origin', conversationId, requestIds: ['wfr_second'], observedAt: expect.any(Number) }
+    ]);
+    expect(JSON.stringify(h.posts)).not.toContain('private prompt');
+    expect(JSON.stringify(h.posts)).not.toContain('tool args');
+  });
+
+  it('reattaches after the page runtime replaces fetch during startup', async () => {
+    const h = harness();
+    const replacement = h.replaceFetch();
+    expect(h.currentFetch()).toBe(replacement);
+    h.ready();
+    expect(h.currentFetch()).not.toBe(replacement);
+    const conversationId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+    await h.feedSse([`data: {"conversation_id":"${conversationId}","metadata":{"request_id":"wfr_after_runtime_wrap"}}\n\n`]);
+
+    expect(h.posts).toEqual([
+      { type: 'cos-request-origin', conversationId, requestIds: ['wfr_after_runtime_wrap'], observedAt: expect.any(Number) }
+    ]);
+  });
+
+  it('preserves a page wrapper that delegates to the earlier observer without recursion or duplicate inspection', async () => {
+    const h = harness();
+    h.replaceFetch(true);
+    h.ready();
+    const conversationId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    await h.feedSse([`data: {"conversation_id":"${conversationId}","metadata":{"request_id":"wfr_nested_wrapper"}}\n\n`]);
+    expect(h.posts).toEqual([
+      { type: 'cos-request-origin', conversationId, requestIds: ['wfr_nested_wrapper'], observedAt: expect.any(Number) }
+    ]);
+  });
+
+  it('supports the f/conversation endpoint and bounds request ids to sixteen per stream', async () => {
+    const h = harness();
+    const conversationId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    await h.feedSse(Array.from({ length: 20 }, (_, i) =>
+      'data: ' + JSON.stringify({ conversation_id: conversationId, message: { metadata: { request_id: 'wfr_limit_' + i } } }) + '\r\n\r\n'
+    ), { method: 'POST' }, 'https://chatgpt.com/backend-api/f/conversation');
+    expect(h.posts).toHaveLength(16);
+  });
+
+  it('does not turn quoted text, tool arguments or cross-event identifiers into ownership', async () => {
+    const h = harness();
+    const a = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    for (const event of [
+      { conversation_id: a, tool_arguments: { request_id: 'wfr_argument' } },
+      { conversation_id: a, message: { content: { parts: ['{"request_id":"wfr_quoted"}'] } } },
+      { conversation_id: a },
+      { metadata: { request_id: 'wfr_separate_event' } }
+    ]) await h.feedSse(['data: ' + JSON.stringify(event) + '\n\n']);
+    await h.feedSse(['data: ' + JSON.stringify({ conversation_id: a, metadata: { request_id: 'wfr_foreign' } }) + '\n\n'],
+      { method: 'POST' }, 'https://example.com/backend-api/conversation');
+    expect(h.posts).toEqual([]);
+  });
+
+  it('ignores non-POST, foreign, malformed and contradictory stream identity', async () => {
+    const h = harness();
+    const a = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+    const b = '11111111-2222-4333-8444-555555555555';
+    await h.feedSse([`data: {"conversation_id":"${a}","request_id":"wfr_get"}\n\n`], { method: 'GET' });
+    await h.feedSse([`data: {"conversation_id":"${a}","request_id":"not-a-workflow"}\n\n`]);
+    await h.feedSse([`data: {"conversation_id":"${a}","nested":{"conversation_id":"${b}"},"request_id":"wfr_conflict"}\n\n`]);
+    expect(h.posts).toEqual([]);
   });
 });


### PR DESCRIPTION
ChatGPT can publish MCP request metadata before React exposes it, and a fast response can finish before the extension reads the canonical submitted Markdown. These gaps can leave a valid tool call unattributed or an accepted Goal opening waiting for delivery confirmation.

Project only same-event stream metadata through the existing document/route handshake, with bounded reads and pending identities. Preserve fetch instrumentation without recursion or duplicate inspection. Admit the existing MAIN-world scan while an exact bounded send-receipt reader remains, even after native generation ends. Stable message, route and epoch evidence still decides acceptance.

The existing New Chat recovery and Fiber attribution remain in place. No new opening authority, timer or delivery retry is introduced. Release/updater workflows are unchanged.

Validation: 3,911 tests passed, 40 skipped; production Windows x64 package installed and verified against its payload. Live Chrome passed sending, model selection, Core execution, one worker, Compact & Resume, and Goal from stage 1 through automatic stage 2 to a verified goal-met decision with no further send. The new receipt regression fails before the correction. Stream handoffs without request metadata continue to use Fiber; the live Chrome check does not establish Linux provider behavior.
