### PR TITLE
Fix reload final leaving prime turn active

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -3197,11 +3197,18 @@
    * position or "nearest turn" guess takes part: the answer is a single turn id or nothing.
    */
   function settledTurnOwner(turn) {
-    const requests = new Set();
-    for (const call of (turn && turn.calls) || []) if (call && call.requestId) requests.add(call.requestId);
-    if (requests.size !== 1) return null;
-    const requestId = requests.values().next().value;
+    const requests = requestIdsForTurn(turn);
+    if (requests.length !== 1) return null;
+    const requestId = requests[0];
     return streamRequestTurnOwners.get(requestId) || null;
+  }
+
+  /** Stable exact request set carried by one Fiber page-turn descriptor. */
+  function requestIdsForTurn(turn) {
+    return [...new Set(
+      ((turn && turn.calls) || []).map((call) => call && call.requestId)
+        .filter((requestId) => typeof requestId === 'string' && /^[a-z0-9_-]{1,100}$/i.test(requestId))
+    )].sort();
   }
 
   /**
@@ -3674,6 +3681,21 @@
     for (const [turn, owner] of settledOwners) {
       if ((ownerClaims.get(owner) || 0) > 1) settledOwners.delete(turn);
     }
+    // Reload recovery may need to identify a final whose local generation binding was lost.
+    // A request set is usable for that narrower job only when exactly one Fiber page turn in
+    // this complete scan carries it. Retry/regenerate can reuse request ids across distinct
+    // page turns; forwarding the set without this page-specific uniqueness proof lets an old
+    // final close the newer live turn. Count descriptors, not messages, because one page turn
+    // can legitimately contain several assistant revisions.
+    const requestIdsByTurn = new Map();
+    const requestSetClaims = new Map();
+    for (const pageTurn of answer.turns) {
+      const requestIds = requestIdsForTurn(pageTurn);
+      requestIdsByTurn.set(pageTurn, requestIds);
+      if (requestIds.length === 0) continue;
+      const key = JSON.stringify(requestIds);
+      requestSetClaims.set(key, (requestSetClaims.get(key) || 0) + 1);
+    }
     for (let index = 0; index < answer.turns.length; index++) {
       const turn = answer.turns[index];
       // The live generation owns the turn it is writing; a settled one is claimed only by
@@ -3763,6 +3785,14 @@
         // were the dedupe key, that first unowned snapshot permanently prevented the later
         // exact local turn id from reaching the recorder. The recorder upsert is expressly
         // able to promote the same canonical message when stronger ownership arrives.
+        // One visible answer may span several connector/server requests. Keep the whole
+        // bounded Fiber set: collapsing it to one id made a multi-request final lose every
+        // bit of recovery identity after reload. Sorted so a page-model reorder alone does
+        // not manufacture a new message revision.
+        const responseRequestIds = requestIdsByTurn.get(turn) || [];
+        const responseRequestId = responseRequestIds.length === 1 ? responseRequestIds[0] : null;
+        const requestSetUniqueToPageTurn = responseRequestIds.length > 0 &&
+          requestSetClaims.get(JSON.stringify(responseRequestIds)) === 1;
         const priorMessage = messagesReported.get(message.messageId);
         const ownerConflict = Boolean(
           priorMessage?.conflicted || (localOwner && priorMessage?.owner && priorMessage.owner !== localOwner)
@@ -3774,7 +3804,8 @@
         // claim is different and fails closed instead of choosing either generation.
         const signature =
           `${state}\u0000${message.rawText}\u0000${message.renderedHtml}\u0000${owner}` +
-          `\u0000${message.createTime || ''}\u0000${message.rawMessageId || ''}`;
+          `\u0000${message.createTime || ''}\u0000${message.rawMessageId || ''}\u0000${responseRequestIds.join(',')}` +
+          `\u0000${requestSetUniqueToPageTurn ? '1' : '0'}`;
         if (priorMessage?.signature === signature) continue;
         messagesReported.set(message.messageId, { signature, owner, conflicted: ownerConflict });
         if (state === 'streaming') noteTurnProgress();
@@ -3785,6 +3816,9 @@
           kind: 'assistant_message',
           messageId: message.messageId,
           providerMessageId: message.rawMessageId,
+          ...(responseRequestIds.length ? { requestIds: responseRequestIds } : {}),
+          ...(responseRequestId ? { requestId: responseRequestId } : {}),
+          ...(requestSetUniqueToPageTurn ? { requestSetUniqueToPageTurn: true } : {}),
           turnId: localOwner || undefined,
           text: message.rawText,
           renderedHtml: message.renderedHtml,

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -866,6 +866,24 @@ function parseObservations(input: unknown): ChatObservation[] {
     if (item['authoredTime'] === true) observation.authoredTime = true;
     if (item['authoredNow'] === true && kind === 'user_message') observation.authoredNow = true;
     if (item['activeNow'] === true && kind === 'assistant_message') observation.activeNow = true;
+    if (kind === 'assistant_message') {
+      const requestIds: string[] = [];
+      const seenRequestIds = new Set<string>();
+      if (Array.isArray(item['requestIds'])) {
+        for (const value of item['requestIds'].slice(0, MAX_CALL_EVIDENCE)) {
+          if (typeof value !== 'string' || !/^[a-z0-9_-]{1,100}$/i.test(value) || seenRequestIds.has(value)) continue;
+          seenRequestIds.add(value);
+          requestIds.push(value);
+        }
+      }
+      if (requestIds.length === 0 && typeof item['requestId'] === 'string' &&
+          /^[a-z0-9_-]{1,100}$/i.test(item['requestId'])) {
+        requestIds.push(item['requestId']);
+      }
+      if (requestIds.length) observation.requestIds = requestIds;
+      if (requestIds.length === 1) observation.requestId = requestIds[0];
+      if (item['requestSetUniqueToPageTurn'] === true) observation.requestSetUniqueToPageTurn = true;
+    }
     if (kind === 'model_selection') {
       if (typeof item['model'] !== 'string' || !/^[a-zA-Z0-9 ._-]{1,80}$/.test(item['model'])) continue;
       observation.model = item['model'];

--- a/src/main/session/recorder.ts
+++ b/src/main/session/recorder.ts
@@ -327,6 +327,7 @@ async function initializeSessionForConversation(
         lastTurnStartedAt: null,
         activeTurnId: null,
         activeTurnStartedAt: null,
+        activeTurnRequestIds: new Set<string>(),
         pageTools: new Map<string, ProgressRecord>()
       };
 
@@ -359,7 +360,7 @@ async function initializeSessionForConversation(
     knownTurnEnds: history.knownTurnEnds,
     lastTurnOutcome: summary.lastTurnOutcome,
     lastTurnStartedAt: history.lastTurnStartedAt,
-    turnRequestIds: new Set<string>(),
+    turnRequestIds: history.activeTurnRequestIds,
     endedTurn: null,
     pageTools: history.pageTools
   });
@@ -486,6 +487,8 @@ interface StoredHistory {
   activeTurnId: string | null;
   /** Durable start time of activeTurnId. */
   activeTurnStartedAt: number | null;
+  /** Exact request ids durably recorded under activeTurnId. */
+  activeTurnRequestIds: Set<string>;
   /** Latest stable ChatGPT-native activity row by website thought/message identity. */
   pageTools: Map<string, ProgressRecord>;
 }
@@ -509,9 +512,10 @@ async function storedHistory(sessionId: string): Promise<StoredHistory> {
   let lastTurnStartedAt: number | null = null;
   const turnStarts = new Map<string, number>();
   const pageTools = new Map<string, ProgressRecord>();
+  const requestIdsByTurn = new Map<string, Set<string>>();
   try {
     const events = await readRecentEvents(sessionId, 4096, {
-      kinds: ['turn_start', 'turn_end', 'page_tool'],
+      kinds: ['turn_start', 'turn_end', 'page_tool', 'tool_call'],
       maxBytes: 2 * 1024 * 1024
     });
     // Presentation groups a turn's starts before its end. Lifecycle replay must
@@ -548,6 +552,10 @@ async function storedHistory(sessionId: string): Promise<StoredHistory> {
           held.text = event.label;
           if (!held.turnId && event.turnId) held.turnId = event.turnId;
         }
+      } else if (event.kind === 'tool_call' && event.turnId && event.call.requestId) {
+        const held = requestIdsByTurn.get(event.turnId);
+        if (held) held.add(event.call.requestId);
+        else requestIdsByTurn.set(event.turnId, new Set([event.call.requestId]));
       }
     }
   } catch (err) {
@@ -563,7 +571,8 @@ async function storedHistory(sessionId: string): Promise<StoredHistory> {
       activeTurnStartedAt = startedAt;
     }
   }
-  return { openTurns, knownTurnStarts, knownTurnEnds, lastTurnStartedAt, activeTurnId, activeTurnStartedAt, pageTools };
+  return { openTurns, knownTurnStarts, knownTurnEnds, lastTurnStartedAt, activeTurnId, activeTurnStartedAt,
+    activeTurnRequestIds: activeTurnId ? requestIdsByTurn.get(activeTurnId) ?? new Set<string>() : new Set<string>(), pageTools };
 }
 
 async function ensureUnattributedSession(): Promise<string | null> {
@@ -1607,6 +1616,12 @@ export interface ChatObservation {
   authoredNow?: boolean;
   /** True only when the current page generation owns this assistant revision now. */
   activeNow?: boolean;
+  /** Exact server request carried by this assistant's Fiber turn, when unambiguous. */
+  requestId?: string;
+  /** Every exact server request carried by this assistant's Fiber turn, bounded by the bridge. */
+  requestIds?: string[];
+  /** True only when the page proved this exact request set occurs on one Fiber page turn. */
+  requestSetUniqueToPageTurn?: boolean;
   text?: string;
   /** Exact native user-message attachment metadata; no remote URL or image bytes. */
   attachments?: import('../../shared/input.js').InputAttachment[];
@@ -1730,6 +1745,18 @@ export async function recordRequestEvidence(
   for (const item of observations) {
     if (item.kind === 'tool_evidence' && item.calls?.length) {
       noteCallEvidence(conversationId, sessionId, item.fiberConversationId, item.calls, item.time);
+      // The page can prove a request before its MCP call is filed, or while that call still
+      // lives in the Unattributed repair bucket. Preserve the exact local-turn binding here:
+      // after reload, the same request on a distinct final can then close only this turn.
+      const live = conversations.get(conversationId);
+      if (
+        item.turnId &&
+        live?.sessionId === sessionId &&
+        live.turnId === item.turnId &&
+        live.turnStartedAt !== null
+      ) {
+        for (const call of item.calls) if (call.requestId) live.turnRequestIds.add(call.requestId);
+      }
     }
   }
   return sessionId;
@@ -1944,10 +1971,6 @@ async function recordChatObservationsNow(
             ? live.lastTurnStartedAt
             : null;
         const uncertainTurnStartedAt = batchUncertainStartedAt ?? priorUncertainStartedAt;
-        const terminalActivity =
-          state === 'final' &&
-          (item.activeNow === true ||
-            (uncertainTurnStartedAt !== null && item.time >= uncertainTurnStartedAt));
         const recoveredGoalEligible =
           state === 'final' &&
           !item.turnId &&
@@ -1971,6 +1994,34 @@ async function recordChatObservationsNow(
           ...(goalEligible && state === 'final' ? { goalEligible: true } : {})
         }, { preferTime: item.authoredTime === true });
         const canonicalTurn = written.event.turnId;
+        // A reload can split one generation into separate canonical messages: commentary
+        // observed before the reload and the final answer observed afterwards may have
+        // different provider/message ids. Position/`activeNow` cannot identify that final:
+        // a new question may already be generating while the previous answer remains the
+        // newest finished Fiber message. Require the exact server-request set shared by this
+        // page turn and the locally open turn, plus proof that no second Fiber page turn in
+        // the scan reuses that set; the post-loop work/user/tool fences below then decide
+        // whether it is still safe to close.
+        const finalRequestIds = item.requestIds?.length
+          ? item.requestIds
+          : item.requestId
+            ? [item.requestId]
+            : [];
+        const activeRecoveredTurn =
+          state === 'final' &&
+          item.activeNow === true &&
+          item.requestSetUniqueToPageTurn === true &&
+          finalRequestIds.length > 0 &&
+          finalRequestIds.length === live?.turnRequestIds.size &&
+          finalRequestIds.every((requestId) => live?.turnRequestIds.has(requestId)) &&
+          !canonicalTurn &&
+          live?.turnId &&
+          live.turnStartedAt !== null &&
+          item.time >= live.turnStartedAt &&
+          recoverableTurns.has(live.turnId) &&
+          !explicitEnds.has(live.turnId)
+            ? live.turnId
+            : null;
         // A stopped partial answer stays streaming in history. Re-observing its
         // DOM after restart cannot renew work, nor can an old message borrow a
         // newer page turn. Preserve the revision while using its canonical owner
@@ -1978,9 +2029,14 @@ async function recordChatObservationsNow(
         const workingActivity = state !== 'final' && item.activeNow === true &&
           (!canonicalTurn || canonicalTurn === live?.turnId) &&
           !(live?.turnStartedAt === null && (live.lastTurnOutcome === 'stopped' || live.lastTurnOutcome === 'completed'));
-        if (state === 'final' && written.event.kind === 'assistant_message' && canonicalTurn && recoverableTurns.has(canonicalTurn) &&
-            !explicitEnds.has(canonicalTurn) && live?.turnId === canonicalTurn) {
-          recoveredFinal = { turnId: canonicalTurn, time: item.time,
+        const recoveredTurn = canonicalTurn ?? activeRecoveredTurn;
+        const terminalActivity =
+          state === 'final' &&
+          (recoveredTurn === live?.turnId ||
+            (uncertainTurnStartedAt !== null && item.time >= uncertainTurnStartedAt));
+        if (state === 'final' && written.event.kind === 'assistant_message' && recoveredTurn && recoverableTurns.has(recoveredTurn) &&
+            !explicitEnds.has(recoveredTurn) && live?.turnId === recoveredTurn) {
+          recoveredFinal = { turnId: recoveredTurn, time: item.time,
             seq: written.event.finalContentSeq ?? written.event.origin ?? written.event.seq,
             origin: written.event.origin ?? written.event.seq, native: Boolean(written.event.providerMessageId) };
         }

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -792,6 +792,33 @@ describe('observations', () => {
     expect(events[0]!.time).toBe(historical);
   });
 
+  it('validates and preserves a bounded multi-request assistant identity', async () => {
+    await pair();
+    const conversationId = 'bbbbbbbb-cccc-dddd-eeee-fffffffffff1';
+    const requestIds = ['wfr_bridge_first', 'wfr_bridge_second'];
+    const opened = await request('POST', '/events', { body: { conversationId, events: [
+      { kind: 'turn_start', time: Date.now(), turnId: 'bridge-multi-turn' },
+      { kind: 'assistant_message', time: Date.now(), turnId: 'bridge-multi-turn',
+        messageId: 'bridge-commentary', text: 'Working.', state: 'streaming' }
+    ] } });
+    for (const requestId of requestIds) {
+      await recordToolCall({ tool: 'read', args: {}, content: [{ type: 'text', text: 'ok' }],
+        outcome: 'ok', durationMs: 1, requestId, startedAt: Date.now(),
+        conversationId, sessionId: opened.body.sessionId });
+    }
+    await closeConversation(conversationId);
+
+    await request('POST', '/events', { body: { conversationId, events: [{
+      kind: 'assistant_message', time: Date.now(), messageId: 'bridge-multi-final',
+      providerMessageId: '11111111-2222-4333-8444-555555555555',
+      text: 'Done.', state: 'final', final: true, activeNow: true,
+      requestIds: [...requestIds, requestIds[0], 'invalid request id'],
+      requestSetUniqueToPageTurn: true
+    }] } });
+
+    expect((await getSession(opened.body.sessionId))?.activeTurnId).toBeNull();
+  });
+
   it('stores a message once when a reloaded tab reports it twice', async () => {
     await pair();
     const conversationId = '11111111-2222-3333-4444-555555555555';

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -2709,6 +2709,47 @@ describe('canonical Fiber transcript ingestion in 1.8', () => {
     expect(new Set(revisions.map((entry) => entry.messageId))).toEqual(new Set(['assistant-first-interim-raw-id']));
   });
 
+  it('re-publishes an assistant revision when its exact request id arrives later', async () => {
+    live = await harness();
+    startGenerating(live.document);
+    assistantTurn(live.document, 'page-turn-late-request', []);
+    live.hook.observe();
+    await settle();
+    const message = {
+      messageId: 'assistant-late-request', rawMessageId: 'assistant-late-request', role: 'assistant', stable: true,
+      rawText: 'Waiting for request identity.', renderedHtml: '<p>Waiting for request identity.</p>'
+    };
+    const descriptor = {
+      turnId: 'page-turn-late-request',
+      conversationId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      calls: [], messages: [message], activities: []
+    };
+    await replyFiber([], [descriptor]);
+    await live.hook.flush();
+    await settle();
+    await replyFiber([], [{ ...descriptor, calls: [{
+      messageId: 'call-late-request', tool: 'read_file', order: 0, answered: true, requestId: 'wfr-late-request'
+    }] }]);
+    await live.hook.flush();
+    await settle();
+    await replyFiber([], [{ ...descriptor, calls: [{
+      messageId: 'call-late-request', tool: 'read_file', order: 0, answered: true, requestId: 'wfr-late-request'
+    }, {
+      messageId: 'call-second-request', tool: 'read_file', order: 1, answered: true, requestId: 'wfr-second-request'
+    }] }]);
+    await live.hook.flush();
+    await settle();
+
+    const revisions = emitted(live.sent, 'assistant_message').map((entry) => entry.event);
+    expect(revisions).toHaveLength(3);
+    expect(revisions[0]!.requestId).toBeUndefined();
+    expect(revisions[1]).toMatchObject({ requestId: 'wfr-late-request', requestIds: ['wfr-late-request'],
+      requestSetUniqueToPageTurn: true });
+    expect(revisions[2]).toMatchObject({ requestIds: ['wfr-late-request', 'wfr-second-request'],
+      requestSetUniqueToPageTurn: true });
+    expect(revisions[2]!.requestId).toBeUndefined();
+  });
+
   it('records a page-model user message even when the DOM has not exposed data-message-id yet', async () => {
     live = await harness();
     assistantTurn(live.document, 'page-turn-model-user', []);
@@ -3150,6 +3191,8 @@ describe('canonical Fiber transcript ingestion in 1.8', () => {
     await settle();
     expect(emitted(live.sent, 'assistant_message').at(-1)!.event).toMatchObject({
       turnId: undefined,
+      requestId: 'wfr-late-owner',
+      requestIds: ['wfr-late-owner'],
       state: 'streaming',
       final: false
     });
@@ -12973,6 +13016,7 @@ describe('a request id ChatGPT reused across retries', () => {
     // ChatGPT responses under one local turn and render the same answer twice.
     expect(answers.map((event) => event.messageId)).toEqual(['msg-first', 'msg-second']);
     expect(answers.map((event) => event.turnId)).toEqual([undefined, undefined]);
+    expect(answers.map((event) => event.requestSetUniqueToPageTurn)).toEqual([undefined, undefined]);
   });
 
   it('still gives its turn id to the one page turn that claims it', async () => {
@@ -12986,6 +13030,7 @@ describe('a request id ChatGPT reused across retries', () => {
 
     const answers = emitted(live.sent, 'assistant_message').map((entry) => entry.event);
     expect(answers.map((event) => [event.messageId, event.turnId])).toEqual([['msg-only', 'g-retried-8-11']]);
+    expect(answers[0]).toMatchObject({ requestIds: [requestId], requestSetUniqueToPageTurn: true });
   });
 });
 

--- a/test/recorder-final-identity.test.ts
+++ b/test/recorder-final-identity.test.ts
@@ -77,6 +77,191 @@ it.each(['missing', 'replaced', 'matching', 'restart'])('closes the canonical re
   expect(await readEvents(sessionId, { kinds: ['turn_end'] })).toHaveLength(1);
 });
 
+it('closes the open turn when reload gives the current final answer a distinct message identity', async () => {
+  const conversationId = 'distinct-active-final-after-reload';
+  const turnId = 'original-turn';
+  const requestId = 'wfr_distinct_final';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId },
+    { kind: 'assistant_message', time: 11, turnId, messageId: 'commentary-before-reload',
+      providerMessageId: 'provider-commentary', text: 'I am working.', state: 'streaming' }
+  ]);
+  await recordChatObservations(conversationId, [
+    { kind: 'tool_evidence', time: 12, turnId, fiberConversationId: conversationId,
+      calls: [{ messageId: 'call', tool: 'read', order: 0, answered: false, requestId }] }
+  ]);
+  await recordToolCall({ tool: 'read', args: {}, content: [{ type: 'text', text: 'ok' }],
+    outcome: 'ok', durationMs: 1, requestId, startedAt: 13 });
+  await closeConversation(conversationId);
+
+  const recovered = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, messageId: 'answer-after-reload',
+    providerMessageId: 'provider-answer', text: 'The final answer.', state: 'final', final: true,
+    activeNow: true, requestId, requestSetUniqueToPageTurn: true
+  }]);
+
+  const sessionId = opened.sessionId!;
+  expect((await getSession(sessionId))?.activeTurnId).toBeNull();
+  expect(liveConversations().find(row => row.conversationId === conversationId)?.activeTurnId).toBeNull();
+  expect(recovered.activity).toMatchObject({ terminal: true, endedTurnId: turnId });
+  expect(await readEvents(sessionId, { kinds: ['turn_end'] })).toEqual([
+    expect.objectContaining({ turnId, outcome: 'completed' })
+  ]);
+});
+
+it('uses exact page request evidence while an attributed call is still pending repair', async () => {
+  const conversationId = 'distinct-final-page-evidence';
+  const turnId = 'page-evidence-turn';
+  const requestId = 'wfr_page_evidence_final';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId },
+    { kind: 'assistant_message', time: 11, turnId, messageId: 'commentary',
+      providerMessageId: 'provider-commentary', text: 'I am working.', state: 'streaming' }
+  ]);
+  await recordChatObservations(conversationId, [
+    { kind: 'tool_evidence', time: 12, turnId, fiberConversationId: conversationId,
+      calls: [{ messageId: 'call', tool: 'read', order: 0, answered: false, requestId }] }
+  ]);
+
+  const recovered = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, messageId: 'answer',
+    providerMessageId: 'provider-answer', text: 'The final answer.', state: 'final', final: true,
+    activeNow: true, requestId, requestSetUniqueToPageTurn: true
+  }]);
+
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBeNull();
+  expect(recovered.activity).toMatchObject({ terminal: true, endedTurnId: turnId });
+});
+
+it('recovers a distinct final carrying every request from a multi-request turn', async () => {
+  const conversationId = 'distinct-final-multi-request';
+  const turnId = 'multi-request-turn';
+  const requestIds = ['wfr_multi_first', 'wfr_multi_second'];
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId },
+    { kind: 'assistant_message', time: 11, turnId, messageId: 'multi-commentary',
+      providerMessageId: 'provider-multi-commentary', text: 'I am working.', state: 'streaming' },
+    { kind: 'tool_evidence', time: 12, turnId, fiberConversationId: conversationId,
+      calls: requestIds.map((requestId, order) => ({
+        messageId: `multi-call-${order}`, tool: 'read', order, answered: true, requestId
+      })) }
+  ]);
+  for (const [order, requestId] of requestIds.entries()) {
+    await recordToolCall({ tool: 'read', args: { order }, content: [{ type: 'text', text: 'ok' }],
+      outcome: 'ok', durationMs: 1, requestId, startedAt: 13 + order });
+  }
+  await closeConversation(conversationId);
+
+  const recovered = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, messageId: 'multi-final',
+    providerMessageId: 'provider-multi-final', text: 'The final answer.', state: 'final', final: true,
+    activeNow: true, requestIds, requestSetUniqueToPageTurn: true
+  }]);
+
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBeNull();
+  expect(recovered.activity).toMatchObject({ terminal: true, endedTurnId: turnId });
+});
+
+it('does not assign a previous distinct final to a newly open turn from activeNow alone', async () => {
+  const conversationId = 'distinct-old-final-during-new-turn';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'old-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'old-turn', messageId: 'old-answer',
+      providerMessageId: 'old-provider', text: 'Old result.', state: 'final', final: true },
+    { kind: 'turn_end', time: 12, turnId: 'old-turn', outcome: 'completed' },
+    { kind: 'turn_start', time: 20, turnId: 'new-turn' }
+  ]);
+
+  const observed = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 30, messageId: 'old-answer-after-reload',
+    providerMessageId: 'old-provider-after-reload', text: 'Old result.', state: 'final', final: true,
+    activeNow: true
+  }]);
+
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('new-turn');
+  expect(observed.activity.terminal).toBe(false);
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(1);
+});
+
+it('does not attach stale page request evidence to a newer open turn', async () => {
+  const conversationId = 'stale-page-evidence-during-new-turn';
+  const requestId = 'wfr_old_page_evidence';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'old-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'old-turn', messageId: 'old-answer',
+      providerMessageId: 'old-provider', text: 'Old result.', state: 'final', final: true },
+    { kind: 'turn_end', time: 12, turnId: 'old-turn', outcome: 'completed' },
+    { kind: 'turn_start', time: 20, turnId: 'new-turn' }
+  ]);
+  await recordChatObservations(conversationId, [
+    { kind: 'tool_evidence', time: 21, turnId: 'old-turn', fiberConversationId: conversationId,
+      calls: [{ messageId: 'old-call', tool: 'read', order: 0, answered: true, requestId }] }
+  ]);
+
+  const observed = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 30, messageId: 'old-answer-after-reload',
+    providerMessageId: 'old-provider-after-reload', text: 'Old result.', state: 'final', final: true,
+    activeNow: true, requestId
+  }]);
+
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('new-turn');
+  expect(observed.activity.terminal).toBe(false);
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(1);
+});
+
+it('does not recover an old final from a request id reused by the current turn', async () => {
+  const conversationId = 'stale-overlap-multi-request';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'old-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'old-turn', messageId: 'old-answer',
+      providerMessageId: 'old-provider', text: 'Old result.', state: 'final', final: true },
+    { kind: 'turn_end', time: 12, turnId: 'old-turn', outcome: 'completed' },
+    { kind: 'turn_start', time: 20, turnId: 'new-turn' }
+  ]);
+  for (const requestId of ['wfr_shared_request', 'wfr_current_only']) {
+    await recordToolCall({ tool: 'read', args: {}, content: [{ type: 'text', text: 'ok' }],
+      outcome: 'ok', durationMs: 1, requestId, startedAt: 21,
+      conversationId, sessionId: opened.sessionId! });
+  }
+
+  const observed = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 30, messageId: 'old-multi-final',
+    providerMessageId: 'old-multi-provider', text: 'Old result.', state: 'final', final: true,
+    activeNow: true, requestIds: ['wfr_shared_request']
+  }]);
+
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('new-turn');
+  expect(observed.activity.terminal).toBe(false);
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(1);
+});
+
+it('does not recover an old final when two page turns reuse the same request set', async () => {
+  const conversationId = 'stale-exact-request-set-reuse';
+  const requestId = 'wfr_exact_reused_request';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'old-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'old-turn', messageId: 'old-commentary',
+      providerMessageId: 'old-commentary-provider', text: 'Old work.', state: 'streaming' },
+    { kind: 'tool_evidence', time: 12, turnId: 'old-turn', fiberConversationId: conversationId,
+      calls: [{ messageId: 'old-call', tool: 'read', order: 0, answered: true, requestId }] },
+    { kind: 'turn_end', time: 13, turnId: 'old-turn', outcome: 'completed' },
+    { kind: 'turn_start', time: 20, turnId: 'new-turn' }
+  ]);
+  await recordToolCall({ tool: 'read', args: {}, content: [{ type: 'text', text: 'ok' }],
+    outcome: 'ok', durationMs: 1, requestId, startedAt: 21,
+    conversationId, sessionId: opened.sessionId! });
+
+  const observed = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 30, messageId: 'old-final-after-reload',
+    providerMessageId: 'old-final-provider', text: 'Old result.', state: 'final', final: true,
+    activeNow: true, requestId, requestSetUniqueToPageTurn: false
+  }]);
+
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('new-turn');
+  expect(observed.activity.terminal).toBe(false);
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(1);
+});
+
 it.each(['missing', 'current-page-id'])('never closes newer work from an old canonical answer with %s identity', async mode => {
   const conversationId = `historical-final-${mode}`;
   const opened = await recordChatObservations(conversationId, [


### PR DESCRIPTION
## Summary
- recover an already-open prime turn when reload reports its current final answer under a distinct message identity
- carry the bounded set of server request IDs for multi-request turns instead of discarding identity
- require exact request-set equality plus proof that the set belongs to exactly one Fiber page turn, so Retry/regenerate request reuse cannot close newer work
- retain the newer-user, running-tool, explicit-end, and durable work-order fences before closing the turn

## Live reproduction
A fresh GPT-6 Pro chat called the session tool, was reloaded for delayed request attribution, then rendered a final answer. The final answer had a different provider/message identity from the pre-reload commentary. It was recorded with no turn ID, leaving the original turn active indefinitely and blocking queued resume input.

## Verification
- focused content/recorder regression run: 557 passed
- focused bridge boundary run: 1 passed, 315 skipped
- full npm run verify: 3,818 passed, 131 skipped
- typecheck, public-history privacy, third-party notices, native-source packaging, and Electron load checks passed