### PR TITLE
Read a nested authored block once, not once per enclosing block

### DIFF
--- a/extension/chatgpt-dom.js
+++ b/extension/chatgpt-dom.js
@@ -174,7 +174,19 @@ var CLF_DOM = (() => {
     return safe(() => {
       if (!node) return '';
       if (role === 'user') {
+        // Only blocks that nothing else here already contains. `querySelectorAll` also
+        // returns a match nested inside an earlier match, and `text()` reads a whole
+        // subtree, so an inner block was read twice: once as part of its container and
+        // once on its own. The recorded message then carried that passage twice, and every
+        // reader comparing authored text against what was submitted saw a message longer
+        // than the one it sent. `node` itself never counts as a container: the query cannot
+        // return it, and treating it as one would empty this preferred path.
         const parts = [...node.querySelectorAll('.whitespace-pre-wrap')]
+          .filter((part) => {
+            const outer = part.parentElement && part.parentElement.closest &&
+              part.parentElement.closest('.whitespace-pre-wrap');
+            return !outer || outer === node || !(node.contains && node.contains(outer));
+          })
           .filter(part => !part.hasAttribute?.('data-clf-user-text'))
           .map((part) => text(part))
           .filter(Boolean);

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -2600,6 +2600,33 @@ describe('recording authored message text', () => {
   });
 
   /**
+   * One authored block that contains another.
+   *
+   * `messageText` collects `.whitespace-pre-wrap` with `querySelectorAll`, which also
+   * returns matches nested inside an earlier match, and `text()` reads a node's whole
+   * subtree. So an inner block was read twice: once as part of its container and once on
+   * its own account. The recorded message then carried a second copy of that passage, and
+   * every reader that compares authored text against what was submitted saw a message
+   * longer than the one it sent and refused to recognise it.
+   */
+  it('reads a nested authored block once, not once per enclosing block', async () => {
+    live = await harness();
+    const section = userTurn(live.document, 'turn-user-nested', 'the opening passage');
+    const body = section.querySelector('.whitespace-pre-wrap')!;
+    const nested = live.document.createElement('div');
+    nested.className = 'whitespace-pre-wrap';
+    nested.textContent = 'the quoted passage';
+    body.append(nested);
+
+    live.hook.observe();
+    await settle();
+
+    const messages = emitted(live.sent, 'user_message');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.event.text).toBe('the opening passagethe quoted passage');
+  });
+
+  /**
    * A turn that streamed commentary and called tools but never produced authored prose.
    *
    * The preferred path reads `.markdown`, which excludes commentary by construction. The


### PR DESCRIPTION
`messageText()` collects a user message's `.whitespace-pre-wrap` blocks with `querySelectorAll`, which also returns a match nested inside an earlier match, and `text()` reads a whole subtree. An inner block is therefore read twice: once as part of its container and once on its own account.

The recorded message then carries that passage a second time, so every reader that compares authored text against what was submitted sees a message longer than the one it sent.

Measured on a resumed handoff: the rendered bubble came back **9079 characters longer** than the 60425 that were sent, and the exact-text comparison refused to recognise it. An established chat, where nothing nests, compared cleanly in the same data set. Reproduced in the harness: a nested 9000-character block on a 59000-character message yields exactly `diff=+9000`.

`node` itself never counts as a container — the query cannot return it, and treating it as one would empty this preferred path for any message whose own element carries the class.

Test in `test/content-script.test.ts`, red before the change (`…the quoted passage` appended a second time), green after. 828 tests pass across `content-script`, `chatgpt-dom-input`, `extension`, `fiber` and `plugin-refresh-dom`.