### PR TITLE
Fix autonomous Loop recovery across reload and Pro quota

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -3123,6 +3123,21 @@ const HANDLERS = {
     });
     return ownsDocument(source) ? result : { ok: false, error: 'stale_document' };
   },
+  /** Persist a provider-quota pause without acknowledging or spending the ready draft. */
+  async goal_defer(message, _sender, source) {
+    await load();
+    if (!ownsDocument(source)) return { ok: false, error: 'stale_document' };
+    const result = await call('/goal/defer', {
+      method: 'POST',
+      body: JSON.stringify({
+        conversationId: message.conversationId,
+        turnId: String(message.turnId || ''),
+        token: String(message.token || ''),
+        clientId: String(source.tab)
+      })
+    });
+    return ownsDocument(source) ? result : { ok: false, error: 'stale_document' };
+  },
   /**
    * This chat's specific goal, set or cleared from the settings sheet.
    *
@@ -3300,6 +3315,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     'goal_draft',
     'focus_tab',
     'goal_ack',
+    'goal_defer',
     'goal_objective',
     'goal_open',
     'settings_set',

--- a/extension/content.js
+++ b/extension/content.js
@@ -359,6 +359,20 @@
   const seenErrors = new WeakMap();
   /** The generation an error node was first seen in, so an old banner cannot fail a later turn. */
   const errorFirstSeen = new WeakMap();
+  // errors() acknowledges ChatGPT's access-limit dialog as it reads it. Preserve that
+  // synchronous observation long enough for the next activity poll to durably pause an
+  // already-authorized Goal draft even if React removes the dialog in between.
+  const PROVIDER_LIMIT_EVIDENCE_MS = 5 * 60_000;
+  let providerLimitObservedUntil = 0;
+  function observedErrors() {
+    const errors = CLF_DOM.errors();
+    if (errors.some(error => error.blocking === true) && Date.now() >= providerLimitObservedUntil) {
+      // Re-reading the same still-mounted notice must not slide this window forever. A
+      // fresh notice after expiry starts a fresh bounded observation.
+      providerLimitObservedUntil = Date.now() + PROVIDER_LIMIT_EVIDENCE_MS;
+    }
+    return errors;
+  }
   /** The last label sent for each identified ChatGPT-native tool row of this generation. */
   const pageToolsReported = new Map();
 
@@ -895,6 +909,8 @@
   let goalBusy = false;
   /** When this tab started trying to type a ready draft, so a held composer eventually gives up. */
   let goalTypingSince = 0;
+  /** Ready Goal drafts and the durable time at which each may recheck the provider. */
+  const goalQuotaDeferred = new Map();
   /** Terminal Goal card the user dismissed. Keyed to its chat + finished turn across repaints. */
   let dismissedGoalStage = null;
   /**
@@ -1823,7 +1839,7 @@
     // Only this turn's failures. An error inside another turn's section is that turn's,
     // and a toast still on screen from an earlier failure was already on screen when this
     // turn began — neither says anything about how this one ended.
-    const failures = CLF_DOM.errors().filter(
+    const failures = observedErrors().filter(
       (error) => !isStale(error.node) && Boolean(turnId) && localErrorGeneration(error) === turnId
     );
     if (failures.length > 0) return { outcome: 'failed', detail: failures[0].text };
@@ -2383,7 +2399,7 @@
     // apart in the same tick. At millisecond resolution they tie, and a tie read as "this
     // turn's" — so an undismissed banner from an earlier failure could fail the next turn,
     // which is the exact thing that comparison exists to prevent.
-    const visibleErrors = CLF_DOM.errors();
+    const visibleErrors = observedErrors();
     for (const error of visibleErrors) {
       if (!errorFirstSeen.has(error.node)) errorFirstSeen.set(error.node, turnId);
     }
@@ -2860,7 +2876,7 @@
   // 6: adds request-id ownership evidence used by deterministic MCP attribution.
   // 7: keys streaming commentary and native activity by ChatGPT thought/message identity,
   //    so React row replacement, raw text UUID rotation and refresh cannot mint duplicates.
-  const FIBER_VERSION = 10;
+  const FIBER_VERSION = 11;
   const FIBER_TIMEOUT_MS = 1500;
   const FIBER_MAX_ROWS = 400;
   /** Assistant turns whose per-call evidence is accepted from one scan. */
@@ -3046,6 +3062,8 @@
         rawMessageId: cap(entry.rawMessageId, 200),
         role: entry.role === 'user' ? 'user' : 'assistant',
         stable: entry.stable === true,
+        responseWorkingId: cap(entry.workingTurnId, 200),
+        responseExchangeId: cap(entry.turnExchangeId, 200),
         order:
           Number.isInteger(entry.order) && entry.order >= 0 && entry.order < FIBER_MAX_MESSAGES * 4
             ? entry.order
@@ -3785,7 +3803,8 @@
         // claim is different and fails closed instead of choosing either generation.
         const signature =
           `${state}\u0000${message.rawText}\u0000${message.renderedHtml}\u0000${owner}` +
-          `\u0000${message.createTime || ''}\u0000${message.rawMessageId || ''}`;
+          `\u0000${message.createTime || ''}\u0000${message.rawMessageId || ''}` +
+          `\u0000${message.responseWorkingId || ''}\u0000${message.responseExchangeId || ''}`;
         if (priorMessage?.signature === signature) continue;
         messagesReported.set(message.messageId, { signature, owner, conflicted: ownerConflict });
         if (state === 'streaming') noteTurnProgress();
@@ -3796,6 +3815,8 @@
           kind: 'assistant_message',
           messageId: message.messageId,
           providerMessageId: message.rawMessageId,
+          ...(message.responseWorkingId ? { responseWorkingId: message.responseWorkingId } : {}),
+          ...(message.responseExchangeId ? { responseExchangeId: message.responseExchangeId } : {}),
           turnId: localOwner || undefined,
           text: message.rawText,
           renderedHtml: message.renderedHtml,
@@ -5311,7 +5332,7 @@
    * Exact names, never a prefix: `Chat On Steroids Backup` would be somebody else's
    * connector, and a prefix test would have this app vouch for its traffic.
    */
-  const OUR_CONNECTORS = ['Chat On Steroids Core', 'Chat On Steroids Desktop', 'TobisComputer'];
+  const OUR_CONNECTORS = ['Chat On Steroids Core', 'Chat On Steroids Desktop', 'Chat On Steroids Plugins', 'TobisComputer'];
 
   function ourConnectorApp(name) {
     return typeof name === 'string' && OUR_CONNECTORS.includes(name);
@@ -8932,6 +8953,38 @@
     if (!draft || !conversationId || draft.conversationId !== conversationId) return;
     const target = conversationId, forEpoch = epoch;
     const onDocument = () => alive && epoch === forEpoch && conversationId === target && CLF_DOM.conversationId() === target;
+    const providerLimited = () => {
+      const visible = observedErrors().some(error => error.blocking === true);
+      return visible || Date.now() < providerLimitObservedUntil;
+    };
+    const deferForProviderLimit = async () => {
+      if (!providerLimited()) return false;
+      // This is a pre-Send refusal, so retain the exact ready draft and its durable obligation.
+      // The app schedules a durable short recheck whose only action is to inspect this same
+      // dialog again. No Pro message is attempted while the block remains visible, and
+      // restart cannot lose the pending continuation.
+      goalTypingSince = 0;
+      setGoalPhase('retrying', 'ChatGPT access is limited; this Loop will recheck shortly.');
+      const key = `${target}\u0000${draft.token}`;
+      const deferredUntil = goalQuotaDeferred.get(key) || 0;
+      if (Date.now() >= deferredUntil) {
+        // Infinity closes duplicate-poll overlap while the durable write is in flight. A
+        // successful response replaces it with the actual wake time, so the same still-
+        // blocked payload renews its pause after that deadline instead of staying cached
+        // forever and waking the watchdog behind the visible access dialog.
+        goalQuotaDeferred.set(key, Infinity);
+        while (goalQuotaDeferred.size > 64) goalQuotaDeferred.delete(goalQuotaDeferred.keys().next().value);
+        const deferred = await ask({
+          type: 'goal_defer', conversationId: target, turnId: draft.turnId, token: draft.token
+        }).catch(() => null);
+        const resumeAt = Number(deferred?.data?.resumeAt);
+        if (deferred?.ok && Number.isFinite(resumeAt) && resumeAt > Date.now()) {
+          goalQuotaDeferred.set(key, resumeAt);
+        }
+        else goalQuotaDeferred.delete(key);
+      }
+      return true;
+    };
     if (goalBusy) return;
     if (goalWasSpent(conversationId, draft.token)) {
       // The message already crossed the browser's irreversible boundary. A lost ACK may make
@@ -8998,6 +9051,7 @@
       await ask({ type: 'goal_ack', conversationId, token: draft.token }).catch(() => undefined);
       return;
     }
+    if (await deferForProviderLimit()) return;
     goalBusy = true;
     const composerBefore = CLF_DOM.composer()?.textContent || '';
     let preparedDraft = null, sendAttempted = false;
@@ -9026,6 +9080,11 @@
       const sent = await sendSubmittedText(current, true, async sendCurrent => {
         // Off or a replacement task retires this exact token in the app. Re-read it
         // when native Send is ready, including after a delayed React update.
+        if (!sendCurrent() || !current()) return false;
+        // React may mount the access-limit dialog during composer preparation or while
+        // native Send is disabled. This is the last reversible boundary: persist the
+        // exact draft's pause here, before the click can spend or discard it.
+        if (await deferForProviderLimit()) return false;
         const authorization = await ask({ type: 'activity', conversationId: target, since });
         if (!sendCurrent() || !current() || !authorization?.ok || !authorization.data) return false;
         const allowed = authorization.data.goal;
@@ -9034,18 +9093,33 @@
             !(allowed.enabled === true || (allowed.own !== true && allowed.objective)) || allowed.hasKey !== true ||
             allowed.blocked || authorization.data.job?.busy || authorization.data.pendingTools > 0 ||
             generating || CLF_DOM.generating() || nativeBusy || job?.busy) return false;
+        // Authorization is asynchronous. Check once more after it returns, synchronously
+        // adjacent to the irreversible click, so a dialog mounted during that request wins.
+        if (providerLimited()) {
+          await deferForProviderLimit();
+          return false;
+        }
         rememberUserSend();
         sendAttempted = true;
         return true;
       });
       if (!onDocument() || !sendAttempted) return;
       const ownsDraft = goalDraft?.token === draft.token;
-      if (ownsDraft) goalDraft = null;
       if (!sent) {
+        // A click can be the event that makes ChatGPT reveal its access-limit dialog. No
+        // accepted user message means this boundary is still reversible: durably defer the
+        // same token, retain it unacknowledged, and let finally remove only our unchanged
+        // insertion. This is also the renewal path after an acknowledged dialog stayed gone.
+        if (await deferForProviderLimit()) {
+          sendAttempted = false;
+          return;
+        }
+        if (ownsDraft) goalDraft = null;
         await ask({ type: 'goal_ack', conversationId: target, token: draft.token }).catch(() => undefined);
         if (ownsDraft) setGoalPhase('sending', 'ChatGPT would not send the message');
         return;
       }
+      if (ownsDraft) goalDraft = null;
       // Sending is the irreversible step. Record it before the fallible ACK hop so a lost
       // receipt can never turn the same ready draft into a second user message.
       rememberGoalSpent(target, draft.token);
@@ -10212,7 +10286,7 @@
         await waitPageView(() => CLF_DOM.temporaryChatReady(), onTarget, 3000);
       }
       if (temporary && (!temporaryPlannerPage() || !CLF_DOM.temporaryChatReady())) return fail('Temporary Chat was not confirmed. Open the planner tab and complete its Temporary Chat introduction.');
-      const providerLimitation = () => CLF_DOM.errors().find(error => error.blocking === true)?.text;
+      const providerLimitation = () => observedErrors().find(error => error.blocking === true)?.text;
       const limitation = providerLimitation();
       if (limitation) return fail(limitation);
       if (!(await CLF_DOM.selectModelSettings(input.model, input.reasoningEffort, onTarget))) return fail(providerLimitation() || 'Requested model or reasoning could not be confirmed');

--- a/extension/fiber.js
+++ b/extension/fiber.js
@@ -41,7 +41,7 @@
   'use strict';
 
   /** Bumped when the descriptor shape changes, so a stale pair cannot half-understand. */
-  const VERSION = 10;
+  const VERSION = 11;
   // The MAIN world survives an extension reload because the ChatGPT document survives it.
   // Recovery may therefore execute this file again in a page that still has an older helper
   // listener. Keep at most one listener for this protocol version; content.js rejects older
@@ -108,7 +108,7 @@
    * Exact names, never a prefix: `Chat On Steroids Backup` would be somebody else's
    * connector, and a prefix test would have this app vouch for its traffic.
    */
-  const OUR_APPS = ['Chat On Steroids Core', 'Chat On Steroids Desktop', 'TobisComputer'];
+  const OUR_APPS = ['Chat On Steroids Core', 'Chat On Steroids Desktop', 'Chat On Steroids Plugins', 'TobisComputer'];
 
   /** Whether an `invoked_resource.app_name` names one of this app's own connectors. */
   function ourApp(name) {
@@ -516,6 +516,8 @@
         messageId: logicalId,
         role: 'assistant',
         stable,
+        ...(workingTurnId ? { workingTurnId } : {}),
+        ...(turnExchangeId ? { turnExchangeId } : {}),
         rawText,
         order: index,
         createTime
@@ -739,6 +741,8 @@
         rawMessageId: assistantCandidates[c].id,
         role: 'assistant',
         stable: assistantCandidates[c].stable,
+        ...(assistantCandidates[c].workingTurnId ? { workingTurnId: assistantCandidates[c].workingTurnId } : {}),
+        ...(assistantCandidates[c].turnExchangeId ? { turnExchangeId: assistantCandidates[c].turnExchangeId } : {}),
         order: assistantCandidates[c].order,
         createTime: assistantCandidates[c].createTime,
         rawText: assistantCandidates[c].rawText,

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -52,6 +52,7 @@ import {
   ackGoalDraftNow,
   applyGoalSwitch,
   beginGoalDraft,
+  deferGoalReplyForQuotaNow,
   discardPreparedGoalDraft,
   draftOpeningMessage,
   goalKeyPresent,
@@ -62,6 +63,7 @@ import {
   goalArmedFor,
   goalObjectiveFor,
   goalPendingReplyFor,
+  goalReplyResumeAtFor,
   goalSwitchFor,
   goalViewFor,
   pendingGoalReplies,
@@ -866,6 +868,16 @@ function parseObservations(input: unknown): ChatObservation[] {
     if (item['authoredTime'] === true) observation.authoredTime = true;
     if (item['authoredNow'] === true && kind === 'user_message') observation.authoredNow = true;
     if (item['activeNow'] === true && kind === 'assistant_message') observation.activeNow = true;
+    if (kind === 'assistant_message') {
+      const responseWorkingId = item['responseWorkingId'];
+      const responseExchangeId = item['responseExchangeId'];
+      if (typeof responseWorkingId === 'string' && /^[a-z0-9_-]{1,200}$/i.test(responseWorkingId)) {
+        observation.responseWorkingId = responseWorkingId;
+      }
+      if (typeof responseExchangeId === 'string' && /^[a-z0-9_-]{1,200}$/i.test(responseExchangeId)) {
+        observation.responseExchangeId = responseExchangeId;
+      }
+    }
     if (kind === 'model_selection') {
       if (typeof item['model'] !== 'string' || !/^[a-zA-Z0-9 ._-]{1,80}$/.test(item['model'])) continue;
       observation.model = item['model'];
@@ -2676,6 +2688,10 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
     const clientId = typeof body['clientId'] === 'string' ? body['clientId'].slice(0, 100) : '';
     if (!id) return json(res, 400, { error: 'bad_conversation_id' }, origin);
     if (!turnId) return json(res, 400, { error: 'bad_turn_id' }, origin);
+    const quotaResumeAt = goalReplyResumeAtFor(id, turnId);
+    if (quotaResumeAt) {
+      return json(res, 409, { error: 'goal_quota_paused', retryable: true, resumeAt: quotaResumeAt }, origin);
+    }
     const astraSession = await findSessionByConversation(id, { requireUnique: true });
     if (astraSession && await astraFinishOnly(astraSession.id, id)) return json(res, 409, { error: 'astra_finish_only', retryable: false }, origin);
     if (turnId.startsWith('g-silence-') && goalPendingReplyFor(id)?.turnId !== turnId) {
@@ -2801,6 +2817,24 @@ async function handle(req: http.IncomingMessage, res: http.ServerResponse): Prom
     } catch (err) {
       logWarn(`bridge: Goal acknowledgement for ${id} is not durable yet — ${err instanceof Error ? err.message : String(err)}`);
       return json(res, 503, { error: 'goal_ack_not_durable', retryable: true }, origin);
+    }
+  }
+
+  if (route === '/goal/defer' && req.method === 'POST') {
+    let body: Record<string, unknown>;
+    try { body = (await readBody(req)) as Record<string, unknown>; }
+    catch { return json(res, 400, { error: 'bad_request' }, origin); }
+    const id = conversationId(body['conversationId']);
+    const turnId = typeof body['turnId'] === 'string' ? body['turnId'].slice(0, 200) : '';
+    const token = typeof body['token'] === 'string' ? body['token'].slice(0, 200) : '';
+    const clientId = typeof body['clientId'] === 'string' ? body['clientId'].slice(0, 100) : '';
+    if (!id || !turnId || !token || !clientId) return json(res, 400, { error: 'bad_goal_defer' }, origin);
+    try {
+      const resumeAt = await deferGoalReplyForQuotaNow(id, turnId, token, clientId);
+      return json(res, resumeAt ? 200 : 409, resumeAt ? { deferred: true, resumeAt } : { error: 'goal_not_pending' }, origin);
+    } catch (err) {
+      logWarn(`bridge: Goal quota pause for ${id} is not durable — ${err instanceof Error ? err.message : String(err)}`);
+      return json(res, 503, { error: 'goal_defer_not_durable', retryable: true }, origin);
     }
   }
 

--- a/src/main/goal.ts
+++ b/src/main/goal.ts
@@ -400,6 +400,8 @@ interface GoalReplyObligation {
   eventSeq: number;
   /** When this app froze the decision. The row's whole lifetime is measured from here. */
   acceptedAt: number;
+  /** Provider quota pause. No browser pickup or watchdog send is allowed before this time. */
+  resumeAt?: number;
   state: 'pending' | 'handled';
 }
 
@@ -419,7 +421,19 @@ const goalReplies = new Map<string, GoalReplyObligation>();
  * unbounded ledger would make every reply in every chat pay for every chat that came before.
  */
 const GOAL_REPLY_TTL_MS = 12 * 60 * 60_000;
+const UNKNOWN_QUOTA_RECHECK_MS = 5 * 60_000;
 const MAX_GOAL_REPLIES = 200;
+
+function goalReplyClock(reply: GoalReplyObligation): number {
+  return Math.max(reply.acceptedAt, reply.resumeAt ?? 0);
+}
+
+/** Exact durable no-send fence for one pending turn. */
+export function goalReplyResumeAtFor(conversationId: string, turnId?: string, now = Date.now()): number | null {
+  const reply = goalReplies.get(conversationId);
+  if (!reply || reply.state !== 'pending' || (turnId && reply.turnId !== turnId)) return null;
+  return (reply.resumeAt ?? 0) > now ? reply.resumeAt! : null;
+}
 
 /** Retires expired pickups and caps the stable-final ledger to its newest conversations. */
 function boundGoalReplies(now: number): void {
@@ -427,7 +441,9 @@ function boundGoalReplies(now: number): void {
     // Expiry revokes automatic pickup authority; it does not erase the exact final assistant
     // identity. A later deliberate On may re-arm that tombstone, while leaving it handled here
     // prevents a stale page or watchdog from collecting it on its own.
-    if (reply.state === 'pending' && now - reply.acceptedAt >= GOAL_REPLY_TTL_MS) reply.state = 'handled';
+    if (reply.state === 'pending' && now >= (reply.resumeAt ?? 0) && now - goalReplyClock(reply) >= GOAL_REPLY_TTL_MS) {
+      reply.state = 'handled';
+    }
   }
   if (goalReplies.size <= MAX_GOAL_REPLIES) return;
   const oldestFirst = [...goalReplies.values()].sort((a, b) => a.acceptedAt - b.acceptedAt);
@@ -477,6 +493,7 @@ export function restoreGoalReplies(snapshot: GoalRepliesSnapshot | null): void {
         { silenceSourceTurnId: raw.silenceSourceTurnId.slice(0, 200) } : {}),
       eventSeq: raw.eventSeq,
       acceptedAt: raw.acceptedAt,
+      ...(Number.isSafeInteger(raw.resumeAt) && raw.resumeAt! > 0 ? { resumeAt: raw.resumeAt } : {}),
       state: raw.state
     });
   }
@@ -512,9 +529,9 @@ export function goalPendingReplyFor(
   // Expiry is read here as well as pruned on write, because the ledger is only pruned when
   // something writes to it. A chat reopened after the window must not be offered work the
   // next prune would have thrown away.
-  if (reply && Date.now() - reply.acceptedAt >= GOAL_REPLY_TTL_MS) return null;
+  if (reply && (Date.now() < (reply.resumeAt ?? 0) || Date.now() - goalReplyClock(reply) >= GOAL_REPLY_TTL_MS)) return null;
   return reply?.state === 'pending'
-    ? { replyId: reply.replyId, turnId: reply.turnId, eventSeq: reply.eventSeq, acceptedAt: reply.acceptedAt,
+    ? { replyId: reply.replyId, turnId: reply.turnId, eventSeq: reply.eventSeq, acceptedAt: goalReplyClock(reply),
       ...(reply.silenceSourceTurnId ? { silenceSourceTurnId: reply.silenceSourceTurnId } : {}) }
     : null;
 }
@@ -532,12 +549,12 @@ export function pendingGoalReplies(
 ): Array<{ conversationId: string; sessionId: string; replyId: string; acceptedAt: number }> {
   const owed: Array<{ conversationId: string; sessionId: string; replyId: string; acceptedAt: number }> = [];
   for (const reply of goalReplies.values()) {
-    if (reply.state !== 'pending' || now - reply.acceptedAt >= GOAL_REPLY_TTL_MS) continue;
+    if (reply.state !== 'pending' || now < (reply.resumeAt ?? 0) || now - goalReplyClock(reply) >= GOAL_REPLY_TTL_MS) continue;
     owed.push({
       conversationId: reply.conversationId,
       sessionId: reply.sessionId,
       replyId: reply.replyId,
-      acceptedAt: reply.acceptedAt
+      acceptedAt: goalReplyClock(reply)
     });
   }
   return owed.sort((a, b) => b.acceptedAt - a.acceptedAt);
@@ -563,13 +580,28 @@ export async function acceptGoalReplyNow(input: {
       current.replyId === `turn:${input.turnId}`.slice(0, 200)
   );
   const before = current ? { ...current } : null;
-  const bounded = snapshotGoalReplies().replies;
+  // A genuinely newer final replaces the old continuation obligation. Retire its payload
+  // before publishing the new row so no concurrent /activity poll can send A after B has
+  // advanced the conversation. A provisional-to-stable identity promotion is the same
+  // obligation and deliberately keeps its draft and quota deadline.
+  if (current && !provisionalUpgrade) {
+    const obsoleteDraft = drafts.get(input.conversationId);
+    if (obsoleteDraft) {
+      obsoleteDraft.acknowledged = true;
+      obsoleteDraft.abort?.abort();
+      if (obsoleteDraft.settledAt === 0) obsoleteDraft.settledAt = Date.now();
+      obsoleteDraft.text = '';
+      obsoleteDraft.reply = '';
+      drafts.delete(input.conversationId);
+      notifyGoalChange();
+    }
+  }
   const active =
     !input.blocked &&
     getConfig().sessions.record &&
     goalArmedFor(input.conversationId) &&
     await goalKeyPresent(goalSwitchFor(input.conversationId).mode);
-  goalReplies.set(input.conversationId, {
+  const accepted: GoalReplyObligation = {
     conversationId: input.conversationId,
     sessionId: input.sessionId,
     replyId: input.replyId.slice(0, 200),
@@ -580,18 +612,20 @@ export async function acceptGoalReplyNow(input: {
     // stable assistant id. The later id strengthens that same row; it must not re-evaluate
     // policy or reopen a decision the page already acknowledged in the meantime.
     acceptedAt: provisionalUpgrade ? current!.acceptedAt : Date.now(),
+    ...(provisionalUpgrade && current!.resumeAt !== undefined ? { resumeAt: current!.resumeAt } : {}),
     state: provisionalUpgrade ? current!.state : active ? 'pending' : 'handled'
-  });
+  };
+  goalReplies.set(input.conversationId, accepted);
   try {
     await writeDurableNow(GOAL_REPLIES_STATE, snapshotGoalReplies());
   } catch (error) {
-    // The rejected write is one whole revision, so the rollback is too: the row this accept
-    // added and the expired rows it pruned go back together, leaving the ledger exactly as the
-    // decision found it.
-    goalReplies.clear();
-    for (const reply of bounded) goalReplies.set(reply.conversationId, reply);
-    if (before) goalReplies.set(input.conversationId, before);
-    else goalReplies.delete(input.conversationId);
+    // Roll back only if this exact row is still current. A quota renewal or newer final may
+    // have replaced it and durably written a later snapshot while this fsync was pending;
+    // restoring the older revision would erase that no-send fence or revive obsolete work.
+    if (goalReplies.get(input.conversationId) === accepted) {
+      if (before) goalReplies.set(input.conversationId, before);
+      else goalReplies.delete(input.conversationId);
+    }
     persistGoalRepliesSoon();
     throw error;
   }
@@ -602,6 +636,55 @@ function handleGoalReply(conversationId: string, turnId?: string): void {
   if (!reply || reply.state !== 'pending' || (turnId && reply.turnId !== turnId)) return;
   reply.state = 'handled';
   persistGoalRepliesSoon();
+}
+
+/**
+ * Keeps one exact unsent automatic continuation dormant while ChatGPT refuses Pro traffic.
+ * A short recheck only re-reads the blocking dialog and never clicks Send while it remains.
+ */
+export async function deferGoalReplyForQuotaNow(
+  conversationId: string,
+  turnId: string,
+  token: string,
+  clientId: string
+): Promise<number | null> {
+  const reply = goalReplies.get(conversationId);
+  if (!reply || reply.state !== 'pending' || reply.turnId !== turnId) return null;
+  const draft = drafts.get(conversationId);
+  if (!draft || draft.token !== token || draft.turnId !== turnId || draft.clientId !== clientId ||
+      draft.stage !== 'ready' || draft.acknowledged) return null;
+  const now = Date.now();
+  // Page reloads can rediscover the same blocked draft. Keep its original wake deadline
+  // instead of sliding the pause forward forever on every rediscovery.
+  if ((reply.resumeAt ?? 0) > now) return reply.resumeAt!;
+  // Usage snapshots are global UI observations, not bound to this conversation, account, or
+  // selected model. Never borrow their reset time as send authority. A short durable recheck
+  // is safe for every provider dialog because it only republishes the draft for the page to
+  // inspect; the page defers again without Send while the block remains.
+  const resumeAt = now + UNKNOWN_QUOTA_RECHECK_MS;
+  if ((reply.resumeAt ?? 0) >= resumeAt - 1000) return reply.resumeAt ?? resumeAt;
+  const before = { ...reply };
+  // Replace rather than mutate the row. Object identity is the in-memory revision fence used
+  // by acceptGoalReplyNow's rollback when promotion and renewal writes overlap.
+  const paused: GoalReplyObligation = { ...reply, resumeAt };
+  goalReplies.set(conversationId, paused);
+  const beforeSettledAt = draft?.settledAt;
+  draft.settledAt = now;
+  try {
+    await writeDurableNow(GOAL_REPLIES_STATE, snapshotGoalReplies());
+  } catch (error) {
+    // Another request may have acknowledged this draft, switched the chat Off, or accepted a
+    // newer final while this fsync was pending. Roll back only the exact revision we wrote;
+    // restoring `before` over a newer row would revive obsolete automatic-send authority.
+    const current = goalReplies.get(conversationId);
+    if (current === paused && current.state === 'pending' && current.turnId === turnId && current.resumeAt === resumeAt) {
+      goalReplies.set(conversationId, before);
+      if (beforeSettledAt !== undefined && draft.settledAt === now) draft.settledAt = beforeSettledAt;
+      persistGoalRepliesSoon();
+    }
+    throw error;
+  }
+  return resumeAt;
 }
 
 /** Durable state file for per-chat Goal objectives. */
@@ -999,6 +1082,11 @@ function view(draft: GoalDraft): GoalDraftView {
 
 function expireDraftPayload(draft: GoalDraft): void {
   if (draft.settledAt === 0 || Date.now() - draft.settledAt <= DRAFT_TTL_MS) return;
+  // A quota-paused ready message has definitely not crossed Send. Its durable no-send fence
+  // outlives the ordinary delivery payload TTL, so keep the exact text until the page can
+  // recheck the provider. If the app stays down past the wake time, startGoalDraft recreates
+  // the payload from this same still-pending exact turn.
+  if (draft.stage === 'ready' && goalReplyResumeAtFor(draft.conversationId, draft.turnId)) return;
   // The TTL is for the *payload*, not the idempotency key. A ready draft can have crossed
   // ChatGPT's irreversible send boundary while its local ACK was lost. Keep this turn's token
   // as a spent tombstone until a genuinely newer generation supersedes it.
@@ -1018,8 +1106,17 @@ function expireDraftPayload(draft: GoalDraft): void {
 export function goalViewFor(conversationId: string, clientId?: string): GoalDraftView | null {
   const draft = drafts.get(conversationId);
   if (!draft) return null;
-  expireDraftPayload(draft);
   if (clientId !== undefined && draft.clientId !== clientId) return null;
+  // Defense in depth: the sole durable obligation is the conversation's current authority.
+  // Never publish a leftover payload for A after the ledger has advanced to B, even if an
+  // unexpected retirement path failed to remove that in-memory draft.
+  const obligation = goalReplies.get(conversationId);
+  if (obligation && obligation.turnId !== draft.turnId) return null;
+  expireDraftPayload(draft);
+  // This is an authorization fence, not display state. React may remove ChatGPT's access
+  // dialog immediately after it is observed; neither draft publication nor the final
+  // pre-Send activity check may expose the payload before the persisted deadline.
+  if (goalReplyResumeAtFor(conversationId, draft.turnId)) return null;
   // An acknowledged draft has already been acted on — typed, or decided against. It is kept
   // here only so the turn it belongs to cannot be drafted a second time, and reporting it
   // would leave the page polling fast and the panel above the composer describing something
@@ -1159,7 +1256,10 @@ export async function setGoalReplyActiveNow(conversationId: string, active: bool
   before.state = active ? 'pending' : 'handled';
   // A deliberate On is a new pickup episode for the same stable final reply. It gets the
   // recovery schedule from now, not from when that answer happened under an Off switch.
-  if (active) before.acceptedAt = Math.max(Date.now(), previous.acceptedAt + 1);
+  if (active) {
+    before.acceptedAt = Math.max(Date.now(), previous.acceptedAt + 1);
+    delete before.resumeAt;
+  }
   try {
     await writeDurableNow(GOAL_REPLIES_STATE, snapshotGoalReplies());
   } catch (error) {
@@ -1241,7 +1341,9 @@ export function startGoalDraft(input: StartGoalDraftInput): GoalDraftView {
   // its answer once the setting that broke it is fixed.
   const spentFailure =
     existing?.stage === 'failed' && existing.acknowledged && !SETTLED_FAILURE.test(existing.error ?? '');
-  if (existing && existing.turnId === input.turnId && !spentFailure) return view(existing);
+  const expiredReadyPayload = existing?.stage === 'ready' && existing.acknowledged &&
+    goalPendingReplyFor(input.conversationId)?.turnId === input.turnId;
+  if (existing && existing.turnId === input.turnId && !spentFailure && !expiredReadyPayload) return view(existing);
   // A different turn supersedes whatever the last one left behind, including an unfinished
   // request: the answer it was writing was about a conversation that has since moved on.
   if (existing) {

--- a/src/main/session/recorder.ts
+++ b/src/main/session/recorder.ts
@@ -47,6 +47,7 @@ import {
   endSession,
   findSessionByConversation,
   getSession,
+  hasCanonicalMessage,
   readAsset,
   readEvents,
   readRecentEvents,
@@ -89,10 +90,16 @@ interface LiveConversation {
   knownTurnEnds: Set<string>;
   /** Newest durable turn verdict, used only to interpret post-reload final/call evidence. */
   lastTurnOutcome: TurnOutcome | null;
+  /** Durable id of that newest ended turn, for exact post-reload recovery fences. */
+  lastTurnId: string | null;
   /** Start of that turn, so its final may predate a later detach/end while old finals cannot. */
   lastTurnStartedAt: number | null;
+  /** Provider response branches durably associated with lastTurnId. */
+  lastTurnResponseBranches: Set<string>;
   /** ChatGPT request ids — one per server turn — that called tools while the open turn ran. */
   turnRequestIds: Set<string>;
+  /** Exact provider response branches observed while the open local turn was still bound. */
+  turnResponseBranches: Set<string>;
   /**
    * The newest turn the page reported completed, with the server turns it was calling under.
    *
@@ -103,7 +110,13 @@ interface LiveConversation {
    * finished. See reopenFalselyEndedTurn. In-memory only: an app restart inside such a turn
    * loses the proof, and the turn stays closed as the page reported it.
    */
-  endedTurn: { turnId: string; startedAt: number | null; endedAt: number; requestIds: Set<string> } | null;
+  endedTurn: {
+    turnId: string;
+    startedAt: number | null;
+    endedAt: number;
+    requestIds: Set<string>;
+    responseBranches: Set<string>;
+  } | null;
   /** Visible ChatGPT-native activity rows, updated by the page's stable row identity. */
   pageTools: Map<string, ProgressRecord>;
 }
@@ -121,6 +134,12 @@ interface ProgressRecord {
 }
 
 const conversations = new Map<string, LiveConversation>();
+
+function responseBranchKey(exchangeId?: string, workingId?: string): string | null {
+  if (!exchangeId || !workingId) return null;
+  return `${exchangeId}\u0000${workingId}`;
+}
+const AMBIGUOUS_RESPONSE_BRANCH = '\u0000ambiguous-response-branch';
 /** One full first-sight initialization per ChatGPT conversation at a time. */
 const sessionInitializations = new Map<string, Promise<string | null>>();
 /**
@@ -325,8 +344,11 @@ async function initializeSessionForConversation(
         knownTurnStarts: new Set<string>(),
         knownTurnEnds: new Set<string>(),
         lastTurnStartedAt: null,
+        lastTurnId: null,
         activeTurnId: null,
         activeTurnStartedAt: null,
+        activeTurnResponseBranches: new Set<string>(),
+        lastTurnResponseBranches: new Set<string>(),
         pageTools: new Map<string, ProgressRecord>()
       };
 
@@ -358,8 +380,11 @@ async function initializeSessionForConversation(
     knownTurnStarts: history.knownTurnStarts,
     knownTurnEnds: history.knownTurnEnds,
     lastTurnOutcome: summary.lastTurnOutcome,
+    lastTurnId: history.lastTurnId,
     lastTurnStartedAt: history.lastTurnStartedAt,
+    lastTurnResponseBranches: history.lastTurnResponseBranches,
     turnRequestIds: new Set<string>(),
+    turnResponseBranches: history.activeTurnResponseBranches,
     endedTurn: null,
     pageTools: history.pageTools
   });
@@ -482,10 +507,16 @@ interface StoredHistory {
   knownTurnEnds: Set<string>;
   /** Durable start time of the newest turn that ended in the recovered tail. */
   lastTurnStartedAt: number | null;
+  /** Durable id of the newest turn that ended in the recovered tail. */
+  lastTurnId: string | null;
   /** Newest still-open local generation, so a reloaded page can adopt it after app restart. */
   activeTurnId: string | null;
   /** Durable start time of activeTurnId. */
   activeTurnStartedAt: number | null;
+  /** Provider response branches durably bound to activeTurnId. */
+  activeTurnResponseBranches: Set<string>;
+  /** Provider response branches durably bound to lastTurnId. */
+  lastTurnResponseBranches: Set<string>;
   /** Latest stable ChatGPT-native activity row by website thought/message identity. */
   pageTools: Map<string, ProgressRecord>;
 }
@@ -505,13 +536,14 @@ async function storedHistory(sessionId: string): Promise<StoredHistory> {
   const openTurns = new Set<string>();
   const knownTurnStarts = new Set<string>();
   const knownTurnEnds = new Set<string>();
-  let lastTurnEndedAt: number | null = null;
   let lastTurnStartedAt: number | null = null;
+  let lastTurnId: string | null = null;
   const turnStarts = new Map<string, number>();
   const pageTools = new Map<string, ProgressRecord>();
+  const responseBranchesByTurn = new Map<string, Set<string>>();
   try {
     const events = await readRecentEvents(sessionId, 4096, {
-      kinds: ['turn_start', 'turn_end', 'page_tool'],
+      kinds: ['turn_start', 'turn_end', 'page_tool', 'assistant_message'],
       maxBytes: 2 * 1024 * 1024
     });
     // Presentation groups a turn's starts before its end. Lifecycle replay must
@@ -529,10 +561,11 @@ async function storedHistory(sessionId: string): Promise<StoredHistory> {
           knownTurnEnds.add(event.turnId);
           openTurns.delete(event.turnId);
         }
-        if (lastTurnEndedAt === null || event.time >= lastTurnEndedAt) {
-          lastTurnEndedAt = event.time;
-          lastTurnStartedAt = event.turnId ? turnStarts.get(event.turnId) ?? null : null;
-        }
+        // The journal is authoritative by publication order, not provider wall-clock time.
+        // A delayed end may be appended after an older timestamp; summary recovery follows
+        // this same sequence, so retain the last end encountered in the seq-sorted stream.
+        lastTurnId = event.turnId ?? null;
+        lastTurnStartedAt = event.turnId ? turnStarts.get(event.turnId) ?? null : null;
       } else if (event.kind === 'page_tool' && event.messageId) {
         const held = pageTools.get(event.messageId);
         if (!held) {
@@ -548,6 +581,12 @@ async function storedHistory(sessionId: string): Promise<StoredHistory> {
           held.text = event.label;
           if (!held.turnId && event.turnId) held.turnId = event.turnId;
         }
+      } else if (event.kind === 'assistant_message' && event.turnId) {
+        const key = responseBranchKey(event.responseExchangeId, event.responseWorkingId);
+        const held = responseBranchesByTurn.get(event.turnId) ?? new Set<string>();
+        if (key) held.add(key);
+        if (event.responseBranchAmbiguous === true) held.add(AMBIGUOUS_RESPONSE_BRANCH);
+        if (held.size > 0) responseBranchesByTurn.set(event.turnId, held);
       }
     }
   } catch (err) {
@@ -563,7 +602,16 @@ async function storedHistory(sessionId: string): Promise<StoredHistory> {
       activeTurnStartedAt = startedAt;
     }
   }
-  return { openTurns, knownTurnStarts, knownTurnEnds, lastTurnStartedAt, activeTurnId, activeTurnStartedAt, pageTools };
+  return {
+    openTurns, knownTurnStarts, knownTurnEnds, lastTurnStartedAt, lastTurnId, activeTurnId, activeTurnStartedAt,
+    activeTurnResponseBranches: activeTurnId
+      ? responseBranchesByTurn.get(activeTurnId) ?? new Set<string>()
+      : new Set<string>(),
+    lastTurnResponseBranches: lastTurnId
+      ? responseBranchesByTurn.get(lastTurnId) ?? new Set<string>()
+      : new Set<string>(),
+    pageTools
+  };
 }
 
 async function ensureUnattributedSession(): Promise<string | null> {
@@ -1452,6 +1500,7 @@ async function reopenFalselyEndedTurn(
   live.turnStartedAt = ended.startedAt ?? startedAt;
   live.lastTurnOutcome = null;
   live.turnRequestIds = new Set(ended.requestIds);
+  live.turnResponseBranches = new Set(ended.responseBranches);
   logInfo(
     `session ${sessionId} reopened turn ${ended.turnId} — request ${requestId} kept calling tools after the page reported it completed`
   );
@@ -1615,6 +1664,10 @@ export interface ChatObservation {
   messageId?: string;
   /** Raw public provider message UUID, retained as evidence, never used to guess ownership. */
   providerMessageId?: string;
+  /** Exact provider response branch, stable across a page reload. */
+  responseExchangeId?: string;
+  /** Provider working branch, paired with responseExchangeId to reject contradictions. */
+  responseWorkingId?: string;
   turnId?: string;
   final?: boolean;
   state?: 'streaming' | 'final';
@@ -1862,17 +1915,21 @@ async function recordChatObservationsNow(
   let pageTitle: ChatObservation | undefined;
   const explicitEnds = new Set<string>();
   const batchTurnStarts = new Map<string, number>();
-  let batchUncertainEndId: string | null = null;
+  const batchUncertainEndIds: string[] = [];
+  const batchAuthoredUserIds = new Set<string>();
   // This batch is hot while ChatGPT is streaming. Collect the three facts needed before the
   // write loop in one pass instead of find + find + filter + map (the latter two also allocated
   // an intermediate array for every batch).
   for (const item of observations) {
     if (!firstUser && item.kind === 'user_message') firstUser = item;
+    if (item.kind === 'user_message' && item.authoredNow === true && item.messageId) {
+      batchAuthoredUserIds.add(item.messageId);
+    }
     if (item.kind === 'conversation_title') pageTitle = item;
     if (item.kind === 'turn_start' && item.turnId) batchTurnStarts.set(item.turnId, item.time);
     if (item.kind === 'turn_end' && item.turnId) {
       explicitEnds.add(item.turnId);
-      if (item.outcome !== 'completed' && item.outcome !== 'stopped') batchUncertainEndId = item.turnId;
+      if (item.outcome !== 'completed' && item.outcome !== 'stopped') batchUncertainEndIds.push(item.turnId);
     }
   }
   const sessionId = await sessionForConversation(
@@ -1890,7 +1947,88 @@ async function recordChatObservationsNow(
   // Only a turn already open before this batch qualifies; apply the end after all
   // observations so a newer turn or an explicit verdict cannot be overwritten.
   const recoverableTurns = new Set(live?.openTurns);
+  const preBatchTurnId = live?.turnId ?? null;
+  const preBatchTurnStartedAt = live?.turnStartedAt ?? null;
+  const preBatchResponseBranches = new Set(live?.turnResponseBranches);
+  const freshExplicitEnds = new Set(
+    [...explicitEnds].filter(turnId => !live?.knownTurnEnds.has(turnId))
+  );
+  let freshBatchUncertainEndId: string | null = null;
+  for (let index = batchUncertainEndIds.length - 1; index >= 0; index--) {
+    const candidate = batchUncertainEndIds[index]!;
+    if (!live?.knownTurnEnds.has(candidate)) {
+      freshBatchUncertainEndId = candidate;
+      break;
+    }
+  }
+  const freshBatchUncertainStartedAt = freshBatchUncertainEndId
+    ? batchTurnStarts.get(freshBatchUncertainEndId) ??
+      (live?.turnId === freshBatchUncertainEndId ? live.turnStartedAt : null)
+    : null;
+  const freshBatchTurnIds = new Set([...batchTurnStarts.keys()].filter(turnId =>
+    !live?.knownTurnStarts.has(turnId) && !live?.knownTurnEnds.has(turnId)
+  ));
+  const batchStartsFreshTurn = freshBatchTurnIds.size > 0;
+  const priorUncertainTurnId =
+    !batchStartsFreshTurn &&
+    live?.turnStartedAt === null &&
+    live.lastTurnOutcome !== null &&
+    live.lastTurnOutcome !== 'completed' &&
+    live.lastTurnOutcome !== 'stopped'
+      ? live.lastTurnId
+      : null;
+  const priorUncertainStartedAt = priorUncertainTurnId ? live?.lastTurnStartedAt ?? null : null;
+  const recoveryFenceTurns = new Set(recoverableTurns);
+  if (freshBatchUncertainEndId && freshBatchUncertainStartedAt !== null) {
+    recoveryFenceTurns.add(freshBatchUncertainEndId);
+  }
+  if (priorUncertainTurnId) recoveryFenceTurns.add(priorUncertainTurnId);
+  // A new authored row supersedes both a still-open pre-batch turn and the previous call's
+  // uncertain boundary. Do not apply this to a turn born wholly inside this batch: its opening
+  // user row belongs to that same turn and is not evidence of later work.
+  const hasPreexistingRecoveryFence = recoverableTurns.size > 0 || priorUncertainTurnId !== null;
+  const batchFreshUserSupersedesRecovery = hasPreexistingRecoveryFence &&
+    (await Promise.all([...batchAuthoredUserIds].map(messageId =>
+      hasCanonicalMessage(sessionId, 'user_message', messageId)
+    ))).some(exists => !exists);
+  const batchFreshTurnSupersedesRecovery = recoverableTurns.size > 0 &&
+    [...freshBatchTurnIds].some(turnId => !recoverableTurns.has(turnId));
+  const recoveryOwnerSupersededByBatch = (turnId: string | null): boolean =>
+    turnId !== null && !freshBatchTurnIds.has(turnId) &&
+    (batchFreshUserSupersedesRecovery || batchFreshTurnSupersedesRecovery);
+  const freshUncertainOwnsUnboundObservation = (item: ChatObservation): boolean => {
+    if (item.kind !== 'assistant_message' || item.turnId ||
+        freshBatchUncertainEndId === null || !freshBatchTurnIds.has(freshBatchUncertainEndId) ||
+        freshBatchUncertainStartedAt === null || item.time < freshBatchUncertainStartedAt) return false;
+    const branch = responseBranchKey(item.responseExchangeId, item.responseWorkingId);
+    // A complete branch already bound to stale O is stronger ownership evidence than T's
+    // timestamp fence. Provider/message aliases without branch metadata are rejected after the
+    // canonical upsert below, where their stable identity resolves to O.
+    return branch === null || !preBatchResponseBranches.has(branch);
+  };
+  const batchResponseBranches = new Set(preBatchResponseBranches);
+  for (const item of observations) {
+    if (item.kind !== 'assistant_message' || item.activeNow !== true) continue;
+    if ((item.turnId && freshBatchTurnIds.has(item.turnId)) || freshUncertainOwnsUnboundObservation(item)) continue;
+    const branch = responseBranchKey(item.responseExchangeId, item.responseWorkingId);
+    if (branch) batchResponseBranches.add(branch);
+  }
+  const batchResponseBranchAmbiguous = recoverableTurns.size > 0 &&
+    (batchResponseBranches.has(AMBIGUOUS_RESPONSE_BRANCH) || batchResponseBranches.size > 1);
   let recoveredFinal: { turnId: string; time: number; seq: number; origin: number; native: boolean } | undefined;
+  const ambiguousCanonicalTurns = new Set<string>();
+  const unboundAmbiguousTurns = new Set<string>();
+  const canonicalResponseBranches = new Map<string, Set<string>>();
+  if (live?.turnId && recoverableTurns.has(live.turnId)) {
+    canonicalResponseBranches.set(live.turnId, new Set(live.turnResponseBranches));
+  }
+  if (priorUncertainTurnId) {
+    canonicalResponseBranches.set(priorUncertainTurnId, new Set(live?.lastTurnResponseBranches));
+  }
+  const goalCandidateRecoveryOwners: Array<string | null> = [];
+  const goalEligibilityWrites: Array<string | null> = [];
+  const latestAssistantSnapshots = new Map<string, Extract<SessionEvent, { kind: 'assistant_message' }>>();
+  const assistantTerminalTurns = new Map<string | null, string | null>();
 
   for (const item of observations) {
     const base = {
@@ -1927,36 +2065,56 @@ async function recordChatObservationsNow(
       case 'assistant_message': {
         if (!item.messageId) continue;
         const state = item.state ?? (item.final === true ? 'final' : 'streaming');
+        const responseBranch = responseBranchKey(item.responseExchangeId, item.responseWorkingId);
+        const freshBatchOwnsObservation =
+          Boolean(item.turnId && freshBatchTurnIds.has(item.turnId)) ||
+          freshUncertainOwnsUnboundObservation(item);
+        // A reload may replace the public message object and lose or replace the document-local
+        // turn id, but it does not change ChatGPT's native response branch. Bind that branch
+        // while the page still has an exact local owner and persist it on the canonical message
+        // from the first streaming snapshot. A retry or regenerate introduces another branch
+        // and therefore fails closed.
+        const branchOwnedTurn =
+          item.turnId !== preBatchTurnId &&
+          !freshBatchOwnsObservation &&
+          item.activeNow === true &&
+          responseBranch !== null &&
+          preBatchTurnId !== null &&
+          preBatchTurnStartedAt !== null &&
+          preBatchResponseBranches.size === 1 &&
+          preBatchResponseBranches.has(responseBranch) &&
+          !batchResponseBranchAmbiguous &&
+          recoverableTurns.has(preBatchTurnId) &&
+          !freshExplicitEnds.has(preBatchTurnId)
+            ? preBatchTurnId
+            : null;
+        // The native response branch is the durable owner proof. A replacement document may
+        // mint a fresh page-local turn id during the same reload race, so let that exact proof
+        // override only a missing or contradictory page hint. Before native branch metadata is
+        // readable, keep an unknown contradictory page id unowned; a later provider-id alias can
+        // then promote it from unknown to the proven durable owner instead of freezing poison.
+        // Existing canonical historical messages retain their proven owner in the store.
+        const activeRecoveredTurn = state === 'final' ? branchOwnedTurn : null;
+        const weakReplacementTurn =
+          item.activeNow === true &&
+          item.turnId !== undefined &&
+          live !== undefined &&
+          live.turnId !== null &&
+          live.turnStartedAt !== null &&
+          item.turnId !== live.turnId &&
+          !freshBatchTurnIds.has(item.turnId);
+        const effectiveTurnId = branchOwnedTurn ?? (weakReplacementTurn ? undefined : item.turnId);
         // A reload can destroy the document-local generation id after this recorder already
         // made the only honest lifecycle verdict it could: unknown/failed/interrupted/stalled.
         // A new stable final reply is stronger evidence about Goal than that lost id, but an
         // old final seen merely by opening an idle chat is not. The prior uncertain boundary is
         // therefore the exact fence; the stable reply id is the durable exactly-once identity.
-        const batchUncertainStartedAt = batchUncertainEndId
-          ? batchTurnStarts.get(batchUncertainEndId) ??
-            (live?.turnId === batchUncertainEndId ? live.turnStartedAt : null)
-          : null;
-        const priorUncertainStartedAt =
-          live?.turnStartedAt === null &&
-          live.lastTurnOutcome !== null &&
-          live.lastTurnOutcome !== 'completed' &&
-          live.lastTurnOutcome !== 'stopped'
-            ? live.lastTurnStartedAt
-            : null;
-        const uncertainTurnStartedAt = batchUncertainStartedAt ?? priorUncertainStartedAt;
-        const terminalActivity =
-          state === 'final' &&
-          (item.activeNow === true ||
-            (uncertainTurnStartedAt !== null && item.time >= uncertainTurnStartedAt));
-        const recoveredGoalEligible =
-          state === 'final' &&
-          !item.turnId &&
-          live !== undefined &&
-          uncertainTurnStartedAt !== null &&
-          item.time >= uncertainTurnStartedAt;
-        const goalEligible = item.goalEligible === true || recoveredGoalEligible;
-        const written = await upsertMessageEvent(sessionId, {
-          ...base,
+        const uncertainTurnStartedAt = freshBatchUncertainStartedAt ?? priorUncertainStartedAt;
+        const uncertainRecoveryTurnId = freshBatchUncertainEndId ?? priorUncertainTurnId;
+        const assistantEvent = {
+          time: item.time,
+          source: 'extension',
+          ...(agent ? { agent } : {}),
           kind: 'assistant_message',
           // Keep normal 15k–20k-token handoff-style answers inline rather than making the
           // local transcript itself look truncated while the continuation carries more.
@@ -1967,10 +2125,142 @@ async function recordChatObservationsNow(
           messageId: item.messageId,
           state,
           final: state === 'final',
+          ...(effectiveTurnId ? { turnId: effectiveTurnId } : {}),
           ...(item.providerMessageId ? { providerMessageId: item.providerMessageId } : {}),
-          ...(goalEligible && state === 'final' ? { goalEligible: true } : {})
-        }, { preferTime: item.authoredTime === true });
-        const canonicalTurn = written.event.turnId;
+          ...(item.responseExchangeId ? { responseExchangeId: item.responseExchangeId } : {}),
+          ...(item.responseWorkingId ? { responseWorkingId: item.responseWorkingId } : {})
+        } as const;
+        const writeOptions = { preferTime: item.authoredTime === true };
+        let written = await upsertMessageEvent(sessionId, assistantEvent, writeOptions);
+        let canonicalTurn = written.event.turnId;
+        if (written.event.kind === 'assistant_message' && written.event.messageId) {
+          latestAssistantSnapshots.set(written.event.messageId, written.event);
+        }
+        if (written.event.kind === 'assistant_message' && canonicalTurn && recoveryFenceTurns.has(canonicalTurn)) {
+          let canonicalBranches = canonicalResponseBranches.get(canonicalTurn);
+          if (!canonicalBranches) {
+            canonicalBranches = new Set<string>();
+            canonicalResponseBranches.set(canonicalTurn, canonicalBranches);
+          }
+          const canonicalBranch = responseBranchKey(written.event.responseExchangeId, written.event.responseWorkingId);
+          if (canonicalBranch) canonicalBranches.add(canonicalBranch);
+          if (written.event.responseBranchAmbiguous === true) {
+            canonicalBranches.add(AMBIGUOUS_RESPONSE_BRANCH);
+          }
+          if (canonicalBranches.has(AMBIGUOUS_RESPONSE_BRANCH) || canonicalBranches.size > 1) {
+            ambiguousCanonicalTurns.add(canonicalTurn);
+          }
+        }
+        if (written.event.kind === 'assistant_message' && canonicalTurn === undefined && !item.turnId &&
+            uncertainRecoveryTurnId && uncertainTurnStartedAt !== null && item.time >= uncertainTurnStartedAt) {
+          let uncertainBranches = canonicalResponseBranches.get(uncertainRecoveryTurnId);
+          if (!uncertainBranches) {
+            uncertainBranches = new Set<string>();
+            canonicalResponseBranches.set(uncertainRecoveryTurnId, uncertainBranches);
+          }
+          const candidateBranch = responseBranchKey(
+            written.event.responseExchangeId,
+            written.event.responseWorkingId
+          );
+          if (candidateBranch) uncertainBranches.add(candidateBranch);
+          if (written.event.responseBranchAmbiguous === true) {
+            uncertainBranches.add(AMBIGUOUS_RESPONSE_BRANCH);
+          }
+          if (uncertainBranches.has(AMBIGUOUS_RESPONSE_BRANCH) || uncertainBranches.size > 1) {
+            ambiguousCanonicalTurns.add(uncertainRecoveryTurnId);
+            unboundAmbiguousTurns.add(uncertainRecoveryTurnId);
+          }
+        }
+        const uncertainRecoveryBranches = uncertainRecoveryTurnId
+          ? canonicalResponseBranches.get(uncertainRecoveryTurnId)
+          : undefined;
+        const uncertainRecoveryAmbiguous = Boolean(uncertainRecoveryBranches &&
+          (uncertainRecoveryBranches.has(AMBIGUOUS_RESPONSE_BRANCH) || uncertainRecoveryBranches.size > 1));
+        if (live && written.event.kind === 'assistant_message' &&
+            canonicalTurn === live.turnId && live.turnStartedAt !== null) {
+          const canonicalBranch = responseBranchKey(written.event.responseExchangeId, written.event.responseWorkingId);
+          if (canonicalBranch) live.turnResponseBranches.add(canonicalBranch);
+          if (written.event.responseBranchAmbiguous === true) {
+            live.turnResponseBranches.add(AMBIGUOUS_RESPONSE_BRANCH);
+          }
+          if (live.turnResponseBranches.size > 1) ambiguousCanonicalTurns.add(canonicalTurn);
+        } else if (written.event.kind === 'assistant_message' &&
+            canonicalTurn && written.event.responseBranchAmbiguous === true) {
+          ambiguousCanonicalTurns.add(canonicalTurn);
+        }
+        const canonicalBranchAmbiguous =
+          written.event.kind === 'assistant_message' &&
+          ((!freshBatchOwnsObservation && batchResponseBranchAmbiguous) ||
+            written.event.responseBranchAmbiguous === true ||
+            (live !== undefined && canonicalTurn === live.turnId && live.turnResponseBranches.size > 1));
+        const uncertainOwnerConflictsCanonical = uncertainRecoveryTurnId !== null &&
+          canonicalTurn !== undefined && canonicalTurn !== uncertainRecoveryTurnId;
+        const recoveredGoalEligible =
+          state === 'final' &&
+          (!item.turnId || activeRecoveredTurn !== null) &&
+          live !== undefined &&
+          !uncertainOwnerConflictsCanonical &&
+          ((activeRecoveredTurn !== null && !recoveryOwnerSupersededByBatch(activeRecoveredTurn)) ||
+            (!uncertainRecoveryAmbiguous && uncertainRecoveryTurnId !== null &&
+              !recoveryOwnerSupersededByBatch(uncertainRecoveryTurnId) &&
+              uncertainTurnStartedAt !== null && item.time >= uncertainTurnStartedAt));
+        const weakReplacementOwnerProven =
+          !weakReplacementTurn ||
+          (canonicalTurn !== undefined &&
+            canonicalTurn === live?.turnId &&
+            recoverableTurns.has(canonicalTurn) &&
+            (branchOwnedTurn === canonicalTurn ||
+              (!item.responseExchangeId && !item.responseWorkingId)));
+        const canonicalRecoveryOwnerTurn = canonicalTurn && recoveryFenceTurns.has(canonicalTurn)
+          ? canonicalTurn
+          : null;
+        const provisionalRecoveryOwnerTurn = activeRecoveredTurn ?? canonicalRecoveryOwnerTurn ??
+          (!item.turnId && uncertainRecoveryTurnId && !uncertainOwnerConflictsCanonical &&
+              uncertainTurnStartedAt !== null &&
+              item.time >= uncertainTurnStartedAt
+            ? uncertainRecoveryTurnId
+            : !item.turnId && recoverableTurns.size === 1 ? [...recoverableTurns][0]! : null);
+        const recoveredOwnerSuperseded = recoveryOwnerSupersededByBatch(provisionalRecoveryOwnerTurn) ||
+          (provisionalRecoveryOwnerTurn === null && !item.turnId && recoverableTurns.size > 0 &&
+            (batchFreshUserSupersedesRecovery || batchFreshTurnSupersedesRecovery));
+        // Stable canonical ownership outranks a page-local turn hint and a timestamp fallback.
+        // A distinct matching response branch deliberately rewrites effectiveTurnId to its
+        // durable owner above; every other canonical mismatch is an old answer mounted inside
+        // different live work and must not inherit raw or previously persisted eligibility.
+        const canonicalOwnerConsistent = canonicalTurn === undefined ||
+          canonicalTurn === effectiveTurnId ||
+          (effectiveTurnId === undefined && canonicalTurn === provisionalRecoveryOwnerTurn) ||
+          (effectiveTurnId !== undefined && canonicalTurn === live?.turnId && item.turnId !== live.turnId);
+        const uncertainRecoveryUnsafe = uncertainRecoveryAmbiguous &&
+          (canonicalTurn === uncertainRecoveryTurnId || (!item.turnId && activeRecoveredTurn === null));
+        const currentGoalSafe =
+          state === 'final' &&
+          !canonicalBranchAmbiguous &&
+          canonicalOwnerConsistent &&
+          !uncertainRecoveryUnsafe &&
+          !recoveredOwnerSuperseded &&
+          weakReplacementOwnerProven;
+        const goalEligible = currentGoalSafe &&
+          (recoveredGoalEligible || item.goalEligible === true);
+        const recoveryOwnerTurn = provisionalRecoveryOwnerTurn;
+        const goalEligibilityChanged = goalEligible &&
+          written.event.kind === 'assistant_message' && written.event.goalEligible !== true;
+        // Raw activeNow is only a page presentation hint. Retire recovery authority only after
+        // canonical storage accepts this final for the live turn, or the established uncertain
+        // boundary proves an otherwise-unowned same-turn final. Wrong/partial/ambiguous branch
+        // snapshots must leave the recovery watch armed instead of creating a split terminal
+        // activity verdict while the durable turn remains open.
+        const terminalActivity =
+          state === 'final' &&
+          !canonicalBranchAmbiguous &&
+          !uncertainRecoveryUnsafe &&
+          !recoveredOwnerSuperseded &&
+          ((canonicalTurn !== undefined && canonicalTurn === live?.turnId) ||
+            (canonicalTurn === undefined && !weakReplacementTurn &&
+              uncertainTurnStartedAt !== null && item.time >= uncertainTurnStartedAt));
+        const candidateGoalEligible = currentGoalSafe &&
+          written.event.kind === 'assistant_message' &&
+          (goalEligible || written.event.goalEligible === true);
         // A stopped partial answer stays streaming in history. Re-observing its
         // DOM after restart cannot renew work, nor can an old message borrow a
         // newer page turn. Preserve the revision while using its canonical owner
@@ -1978,15 +2268,16 @@ async function recordChatObservationsNow(
         const workingActivity = state !== 'final' && item.activeNow === true &&
           (!canonicalTurn || canonicalTurn === live?.turnId) &&
           !(live?.turnStartedAt === null && (live.lastTurnOutcome === 'stopped' || live.lastTurnOutcome === 'completed'));
-        if (state === 'final' && written.event.kind === 'assistant_message' && canonicalTurn && recoverableTurns.has(canonicalTurn) &&
-            !explicitEnds.has(canonicalTurn) && live?.turnId === canonicalTurn) {
+        if (state === 'final' && written.event.kind === 'assistant_message' && !canonicalBranchAmbiguous &&
+            canonicalTurn && recoverableTurns.has(canonicalTurn) &&
+            !freshExplicitEnds.has(canonicalTurn) && live?.turnId === canonicalTurn) {
           recoveredFinal = { turnId: canonicalTurn, time: item.time,
             seq: written.event.finalContentSeq ?? written.event.origin ?? written.event.seq,
             origin: written.event.origin ?? written.event.seq, native: Boolean(written.event.providerMessageId) };
         }
         if (
           written.event.kind === 'assistant_message' &&
-          written.event.goalEligible === true &&
+          candidateGoalEligible &&
           state === 'final' &&
           written.event.messageId
         ) {
@@ -1995,16 +2286,20 @@ async function recordChatObservationsNow(
             turnId: written.event.turnId ?? `reply:${written.event.messageId}`.slice(0, 200),
             eventSeq: written.event.origin ?? written.event.seq
           });
+          goalCandidateRecoveryOwners.push(recoveryOwnerTurn);
+          goalEligibilityWrites.push(goalEligibilityChanged ? written.event.messageId : null);
         }
-        if (recoveredGoalEligible && live) {
+        if (recoveredGoalEligible && candidateGoalEligible && live) {
           // This is an in-memory verdict for later call/reload decisions, not a fabricated
           // turn_end. The canonical message keeps goalEligible monotonically, so an HTTP 503
           // can still replay the same obligation even after this stronger final evidence wins.
           recoveredGoalSeen = true;
         }
-        if (!written.changed) continue;
+        if (!written.changed && !goalEligibilityChanged) continue;
         if (terminalActivity || workingActivity) { activity.meaningful = true; activity.at = Math.max(activity.at ?? 0, item.time); }
-        if (terminalActivity) activity.terminal = true;
+        if (terminalActivity) {
+          assistantTerminalTurns.set(canonicalTurn ?? recoveryOwnerTurn, recoveryOwnerTurn);
+        }
         if (workingActivity) activity.working = true;
         break;
       }
@@ -2061,6 +2356,7 @@ async function recordChatObservationsNow(
           live.openTurns.add(item.turnId);
           // A page-authored start is a new send; whatever end came before it is settled.
           live.turnRequestIds = new Set<string>();
+          live.turnResponseBranches = new Set<string>();
           live.endedTurn = null;
         }
         activity.meaningful = true; activity.at = Math.max(activity.at ?? 0, item.time);
@@ -2085,16 +2381,27 @@ async function recordChatObservationsNow(
           live.knownTurnEnds.add(item.turnId);
           live.openTurns.delete(item.turnId);
           live.lastTurnOutcome = item.outcome ?? 'unknown';
+          live.lastTurnId = item.turnId;
           live.lastTurnStartedAt = endedStartedAt;
+          live.lastTurnResponseBranches = endedStartedAt === null
+            ? new Set<string>()
+            : new Set(live.turnResponseBranches);
           // Only a completed end can be proven false by a later call: it is the one verdict
           // Goal acts on, and the one a reloaded page fabricates. A stop is the user's own
           // decision and the failure outcomes already belong to recovery.
           live.endedTurn =
             live.turnId === item.turnId && item.outcome === 'completed'
-              ? { turnId: item.turnId, startedAt: endedStartedAt, endedAt: item.time, requestIds: live.turnRequestIds }
+              ? {
+                  turnId: item.turnId,
+                  startedAt: endedStartedAt,
+                  endedAt: item.time,
+                  requestIds: live.turnRequestIds,
+                  responseBranches: live.turnResponseBranches
+                }
               : null;
           live.turnRequestIds = new Set<string>();
           if (live.turnId === item.turnId) {
+            live.turnResponseBranches = new Set<string>();
             live.turnStartedAt = null;
             live.turnId = null;
           }
@@ -2108,6 +2415,64 @@ async function recordChatObservationsNow(
     }
     stored++;
   }
+  // Canonical aliasing can reveal a contradiction only after an earlier item in this same
+  // batch looked safe. Resolve the batch as a whole: ambiguity for a recoverable turn retracts
+  // every provisional completion/Goal/terminal verdict accumulated for that turn, independent
+  // of item order. The durable ambiguity marker keeps later replays fail-closed as well.
+  const unsafeRecoveredTurns = new Set(
+    [...ambiguousCanonicalTurns].filter(turnId => recoveryFenceTurns.has(turnId))
+  );
+  if (unsafeRecoveredTurns.size > 0) {
+    if (recoveredFinal && unsafeRecoveredTurns.has(recoveredFinal.turnId)) recoveredFinal = undefined;
+    for (let index = goalCandidates.length - 1; index >= 0; index--) {
+      const recoveryOwner = goalCandidateRecoveryOwners[index];
+      if (unsafeRecoveredTurns.has(goalCandidates[index]!.turnId) ||
+          (recoveryOwner !== null && recoveryOwner !== undefined && unsafeRecoveredTurns.has(recoveryOwner))) {
+        goalCandidates.splice(index, 1);
+        goalCandidateRecoveryOwners.splice(index, 1);
+        goalEligibilityWrites.splice(index, 1);
+      }
+    }
+    for (const [turnId, recoveryOwner] of assistantTerminalTurns) {
+      if ((turnId !== null && unsafeRecoveredTurns.has(turnId)) ||
+          (recoveryOwner !== null && unsafeRecoveredTurns.has(recoveryOwner))) {
+        assistantTerminalTurns.delete(turnId);
+      }
+    }
+    if (live?.lastTurnId && unsafeRecoveredTurns.has(live.lastTurnId)) {
+      live.lastTurnResponseBranches.add(AMBIGUOUS_RESPONSE_BRANCH);
+    }
+    recoveredGoalSeen = false;
+  }
+  // An unbound contradictory branch must stay unowned, but its contradiction with the turn's
+  // existing owned branch is itself durable evidence. Mark the latest owned canonical anchor so
+  // storedHistory restores the ambiguity after any later app restart. This is a rare fail-closed
+  // path, so a full assistant-only read is preferable to a bounded scan that could miss the anchor.
+  for (const turnId of unboundAmbiguousTurns) {
+    if (!unsafeRecoveredTurns.has(turnId)) continue;
+    const anchors = await readEvents(sessionId, { kinds: ['assistant_message'] });
+    const anchor = [...anchors].reverse().find(event =>
+      event.kind === 'assistant_message' && event.turnId === turnId && event.messageId
+    );
+    if (anchor?.kind === 'assistant_message' && anchor.messageId && anchor.responseBranchAmbiguous !== true) {
+      const durableFence = { ...anchor, responseBranchAmbiguous: true as const };
+      await upsertMessageEvent(sessionId, durableFence, { preferTime: false });
+    }
+  }
+  // Eligibility is durable exactly-once recovery state, so publish it only after the entire
+  // observation batch has proved the candidate safe. A later alias/branch conflict in the same
+  // batch must be able to retract the provisional verdict without leaving a poisonous true bit
+  // that a subsequent replay could revive.
+  for (const replyId of new Set(goalEligibilityWrites.filter((id): id is string => id !== null))) {
+    const latest = latestAssistantSnapshots.get(replyId);
+    if (latest && latest.goalEligible !== true) {
+      // Use the newest canonical body/HTML/final revision. Replaying the earlier observation
+      // that first proved eligibility would overwrite later content merely to set this bit.
+      const promoted = { ...latest, goalEligible: true as const };
+      await upsertMessageEvent(sessionId, promoted, { preferTime: false });
+    }
+  }
+  if (assistantTerminalTurns.size > 0) activity.terminal = true;
   if (pageTitle) await promoteConversationTitle(sessionId, pageTitle.text, conversationId);
   // An old final cannot finish a turn reopened for later tool work. Sequence proves
   // revision order even when ChatGPT keeps its original message creation timestamp.
@@ -2124,7 +2489,8 @@ async function recordChatObservationsNow(
   const nativeReopen = recoveredFinal?.native && lastBoundary?.kind === 'turn_start' && lastBoundary.source === 'app' &&
     lastBoundary.turnId === recoveredFinal.turnId && priorBoundary?.kind === 'turn_end' &&
     priorBoundary.turnId === recoveredFinal.turnId && priorBoundary.outcome === 'completed';
-  if (recoveredFinal && latestWork && (latestWork.seq < recoveredFinal.seq || nativeReopen) &&
+  if (recoveredFinal && !batchFreshUserSupersedesRecovery && !batchFreshTurnSupersedesRecovery && latestWork &&
+      (latestWork.seq < recoveredFinal.seq || nativeReopen) &&
       (!latestUser || (latestUser.kind === 'user_message' && (latestUser.origin ?? latestUser.seq) < recoveredFinal.origin)) &&
       runningToolCalls(conversationId) === 0 && live?.turnId === recoveredFinal.turnId && live.openTurns.has(recoveredFinal.turnId)) {
     const { turnId, time } = recoveredFinal;
@@ -2137,10 +2503,19 @@ async function recordChatObservationsNow(
     live.openTurns.delete(turnId);
     live.knownTurnEnds.add(turnId);
     live.lastTurnOutcome = 'completed';
+    live.lastTurnId = turnId;
     live.lastTurnStartedAt = live.turnStartedAt;
+    live.lastTurnResponseBranches = new Set(live.turnResponseBranches);
     // Native message time may be its creation time, long before this final was observed.
-    live.endedTurn = { turnId, startedAt: live.turnStartedAt, endedAt: Date.now(), requestIds: live.turnRequestIds };
+    live.endedTurn = {
+      turnId,
+      startedAt: live.turnStartedAt,
+      endedAt: Date.now(),
+      requestIds: live.turnRequestIds,
+      responseBranches: live.turnResponseBranches
+    };
     live.turnRequestIds = new Set<string>();
+    live.turnResponseBranches = new Set<string>();
     live.turnStartedAt = null;
     live.turnId = null;
     activity.meaningful = true;
@@ -2348,8 +2723,11 @@ export function rebindConversation(sessionId: string, fromConversationId: string
     knownTurnStarts: new Set<string>(),
     knownTurnEnds: new Set<string>(),
     lastTurnOutcome: null,
+    lastTurnId: null,
     lastTurnStartedAt: null,
+    lastTurnResponseBranches: new Set<string>(),
     turnRequestIds: new Set<string>(),
+    turnResponseBranches: new Set<string>(),
     endedTurn: null,
     pageTools: new Map()
   });

--- a/src/main/session/store.ts
+++ b/src/main/session/store.ts
@@ -1056,6 +1056,40 @@ export function upsertMessageEvent(
       const sameMessage =
         previous?.kind === event.kind && storedTextEqual(previous.message, event.message);
 
+      const previousResponse = previous?.kind === 'assistant_message' && event.kind === 'assistant_message'
+        ? previous : null;
+      const previousResponseComplete = Boolean(previousResponse?.responseExchangeId && previousResponse?.responseWorkingId);
+      const incomingResponseComplete = event.kind === 'assistant_message' &&
+        Boolean(event.responseExchangeId && event.responseWorkingId);
+      const responseBranchAmbiguous = event.kind === 'assistant_message' && (
+        event.responseBranchAmbiguous === true ||
+        (previousResponse !== null && (
+          previousResponse.responseBranchAmbiguous === true ||
+          Boolean(previousResponse.responseExchangeId && event.responseExchangeId &&
+            previousResponse.responseExchangeId !== event.responseExchangeId) ||
+          Boolean(previousResponse.responseWorkingId && event.responseWorkingId &&
+            previousResponse.responseWorkingId !== event.responseWorkingId)
+        ))
+      );
+      // Response identity is an atomic pair. Never manufacture a branch by combining sparse
+      // exchange/working fragments from different observations. Preserve the first complete
+      // pair; a later contradiction is retained separately as a permanent ambiguity fence.
+      const selectedResponse = previousResponseComplete
+        ? {
+            exchangeId: previousResponse!.responseExchangeId,
+            workingId: previousResponse!.responseWorkingId
+          }
+        : incomingResponseComplete && event.kind === 'assistant_message'
+          ? { exchangeId: event.responseExchangeId, workingId: event.responseWorkingId }
+          : previousResponse && (previousResponse.responseExchangeId || previousResponse.responseWorkingId)
+            ? {
+                exchangeId: previousResponse.responseExchangeId,
+                workingId: previousResponse.responseWorkingId
+              }
+            : event.kind === 'assistant_message'
+              ? { exchangeId: event.responseExchangeId, workingId: event.responseWorkingId }
+              : { exchangeId: undefined, workingId: undefined };
+
       const nextEvent: NewMessageEvent =
         previous?.kind === 'assistant_message' && event.kind === 'assistant_message'
           ? {
@@ -1064,6 +1098,9 @@ export function upsertMessageEvent(
               // identity through every revision; a different id is a different logical row.
               messageId: previous.messageId,
               providerMessageId: event.providerMessageId ?? previous.providerMessageId,
+              responseExchangeId: selectedResponse.exchangeId,
+              responseWorkingId: selectedResponse.workingId,
+              responseBranchAmbiguous: responseBranchAmbiguous || undefined,
               // `final` is a compatibility mirror of state, not an independent truth.
               state: event.state === 'final' || event.final === true ? 'final' : 'streaming',
               final: event.state === 'final' || event.final === true,
@@ -1121,7 +1158,10 @@ export function upsertMessageEvent(
             previous.state === nextEvent.state &&
             previous.final === nextEvent.final &&
             previous.goalEligible === nextEvent.goalEligible &&
-            previous.providerMessageId === nextEvent.providerMessageId)) &&
+            previous.providerMessageId === nextEvent.providerMessageId &&
+            previous.responseExchangeId === nextEvent.responseExchangeId &&
+            previous.responseWorkingId === nextEvent.responseWorkingId &&
+            previous.responseBranchAmbiguous === nextEvent.responseBranchAmbiguous)) &&
         (nextEvent.kind !== 'user_message' || previous.kind !== 'user_message' ||
           (nextEvent.inputId === previous.inputId && nextEvent.authoredText === previous.authoredText && nextEvent.inputDelivery === previous.inputDelivery && JSON.stringify(nextEvent.assets) === JSON.stringify(previous.assets) && JSON.stringify(nextEvent.attachments) === JSON.stringify(previous.attachments))) &&
         (previous.turnId ?? undefined) === settledTurnId &&
@@ -1186,6 +1226,16 @@ export function upsertMessageEvent(
     );
     return write;
   });
+}
+
+/** Exact canonical-key lookup used to distinguish a new page-authored user row from journal replay. */
+export async function hasCanonicalMessage(
+  sessionId: string,
+  kind: MessageEvent['kind'],
+  messageId: string
+): Promise<boolean> {
+  const entry = await ensureOpen(sessionId);
+  return entry.messages.has(`${kind}\u0000${messageId}`);
 }
 
 // ------------------------------------------------------------------- read

--- a/src/main/session/usage.ts
+++ b/src/main/session/usage.ts
@@ -17,6 +17,7 @@ export function observeUsage(raw: unknown, capturedAt: unknown = Date.now()): vo
   latestObservedAt = capturedAt;
   limits = parsed.map((entry) => ({ ...entry, observedAt: capturedAt }));
 }
+
 // One persisted derived cache owns both daily and model totals. Formula edits project
 // this baseline; only changed canonical session revisions reread transcripts.
 const CACHE_VERSION = 4;

--- a/src/main/tunnel/locate.ts
+++ b/src/main/tunnel/locate.ts
@@ -118,6 +118,11 @@ export function locateBinary(name: BinaryName, hint?: string): string | null {
       locateCache.set(key, sibling);
       return sibling;
     }
+    // An explicit selection is a fail-closed policy boundary, not merely a search hint.
+    // Falling through to the bundle hid permission damage and ran a different executable
+    // than the user configured.
+    locateCache.set(key, null);
+    return null;
   }
 
   const bundled = bundledDir();

--- a/src/shared/session.ts
+++ b/src/shared/session.ts
@@ -282,6 +282,12 @@ export type SessionEvent =
       renderedHtml?: StoredText;
       /** Public provider object UUID. Evidence for identity drift; not a canonical key or turn owner. */
       providerMessageId?: string;
+      /** Provider-native response branch. Durable ownership evidence across page reloads. */
+      responseExchangeId?: string;
+      /** Provider-native working branch, retained to reject contradictory response ownership. */
+      responseWorkingId?: string;
+      /** More than one native branch was observed for this canonical message; never recover ownership. */
+      responseBranchAmbiguous?: boolean;
       state?: MessageState;
       /** Compatibility mirror for older consumers; equivalent to state === 'final'. */
       final: boolean;

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -89,6 +89,7 @@ const {
   goalDraftBusy,
   goalPendingReplyFor,
   acceptGoalReplyNow,
+  startGoalDraft,
   setGoalReplyActiveNow,
   goalSwitchFor,
   humanReply,
@@ -801,6 +802,18 @@ describe('observations', () => {
     expect(first.body.stored).toBe(1);
     expect(second.body.stored).toBe(0);
     expect(await readEvents(first.body.sessionId, { kinds: ['user_message'] })).toHaveLength(1);
+  });
+
+  it('bounds provider response-branch evidence before storing it', async () => {
+    await pair();
+    const conversationId = '12121212-3434-5656-7878-909090909090';
+    const reply = await request('POST', '/events', { body: { conversationId, events: [{
+      kind: 'assistant_message', time: Date.now(), text: 'working', messageId: 'branch-message', state: 'streaming',
+      responseExchangeId: 'exchange_valid-1', responseWorkingId: '../invalid working id'
+    }] } });
+    const [message] = await readEvents(reply.body.sessionId, { kinds: ['assistant_message'] });
+    expect(message).toMatchObject({ responseExchangeId: 'exchange_valid-1' });
+    expect(message).not.toHaveProperty('responseWorkingId');
   });
 
   it('refuses an over-sized body with an answer, not a reset connection', async () => {
@@ -8127,6 +8140,61 @@ describe('the goal loop over the bridge', () => {
     const keyless = await request('POST', '/goal/draft', { body: { conversationId: 'cafe0002-0000-4000-8000-000000000002', turnId: 'g-1' } });
     expect(keyless.status).toBe(409);
     expect(keyless.body.error).toBe('no_api_key');
+  });
+
+  it('withholds a quota-paused draft from activity and refuses an early draft request', async () => {
+    await pair();
+    const chat = 'cafe0201-0000-4000-8000-000000000201';
+    const turnId = 'g-quota-fenced';
+    const session = await createSession({ conversationId: chat, title: 'Quota fenced' });
+    await request('POST', '/events', { body: { conversationId: chat, events: [
+      { kind: 'user_message', time: Date.now(), text: 'continue safely', messageId: 'quota-user' }
+    ] } });
+    await acceptGoalReplyNow({
+      conversationId: chat, sessionId: session.id, replyId: 'assistant-quota-fenced', turnId, eventSeq: 1, blocked: false
+    });
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => Response.json({
+      choices: [{ message: { content: JSON.stringify({ action: 'continue', reply: 'Run the bounded check.' }) } }]
+    })) as never;
+    try {
+      const prepared = startGoalDraft({ conversationId: chat, sessionId: session.id, turnId, clientId: '201' });
+      let activity: any = null;
+      for (let attempt = 0; attempt < 200; attempt++) {
+        activity = await request('GET', `/activity?conversationId=${chat}&goalClient=201`);
+        if (activity.body.goal.draft?.stage === 'ready') break;
+        await new Promise(resolve => setTimeout(resolve, 5));
+      }
+      expect(activity.body.goal.draft).toMatchObject({ token: prepared.token, stage: 'ready' });
+
+      // Neither an old token nor another tab may postpone the current owner's draft.
+      for (const body of [
+        { conversationId: chat, turnId, token: 'old-token', clientId: '201' },
+        { conversationId: chat, turnId, token: prepared.token, clientId: '202' }
+      ]) {
+        const stale = await request('POST', '/goal/defer', { body });
+        expect(stale.status).toBe(409);
+        expect(stale.body.error).toBe('goal_not_pending');
+      }
+      expect((await request('GET', `/activity?conversationId=${chat}&goalClient=201`)).body.goal.draft).not.toBeNull();
+
+      const paused = await request('POST', '/goal/defer', {
+        body: { conversationId: chat, turnId, token: prepared.token, clientId: '201' }
+      });
+      const resumeAt = paused.body.resumeAt;
+      expect(paused.status).toBe(200);
+      expect(resumeAt).toEqual(expect.any(Number));
+
+      activity = await request('GET', `/activity?conversationId=${chat}&goalClient=201`);
+      expect(activity.body.goal.pending).toBeNull();
+      expect(activity.body.goal.draft).toBeNull();
+
+      const early = await request('POST', '/goal/draft', { body: { conversationId: chat, turnId, clientId: '201' } });
+      expect(early.status).toBe(409);
+      expect(early.body).toMatchObject({ error: 'goal_quota_paused', retryable: true, resumeAt });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
   });
 
   /** A generation is the draft's identity, so it has to be given one. */

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -1679,7 +1679,7 @@ async function replyFiber(
     );
     window.dispatchEvent(
       new window.MessageEvent('message', {
-        data: { source: 'clf-fiber-reply', nonce: event.data.nonce, scanToken, v: 10, scanOk: true, rows, turns: indexedTurns },
+        data: { source: 'clf-fiber-reply', nonce: event.data.nonce, scanToken, v: 11, scanOk: true, rows, turns: indexedTurns },
         source: window
       })
     );
@@ -2146,7 +2146,7 @@ describe('naming the agent behind a row', () => {
     }));
     await replyFiber([
       {
-        v: 10,
+        v: 11,
         index: 0,
         tool: 'run_command',
         path: null,
@@ -2185,7 +2185,7 @@ describe('naming the agent behind a row', () => {
  */
 describe('the calls a row folded away', () => {
   const FOLDED = {
-    v: 10,
+    v: 11,
     index: 0,
     tool: 'run_command',
     path: '/TobisComputer/mcp/run_command',
@@ -6157,7 +6157,7 @@ describe('a stop button that goes missing while the turn is still running', () =
           source: 'clf-fiber-reply',
           nonce: event.data.nonce,
           scanToken: event.data.nonce,
-          v: 10,
+          v: 11,
           scanOk: true,
           rows: [],
           turns: [{
@@ -7830,7 +7830,7 @@ describe('a page leaving the screen', () => {
  */
 describe('evidence from the page context', () => {
   const GOOD = {
-    v: 10,
+    v: 11,
     index: 0,
     tool: 'agent_status',
     path: '/TobisComputer/mcp/agent_status',
@@ -8875,7 +8875,7 @@ describe('evidence from the page context', () => {
             source: 'clf-fiber-reply',
             nonce: event.data.nonce,
             scanToken: event.data.nonce,
-            v: 10,
+            v: 11,
             scanOk: true,
             rows: [],
             turns: [
@@ -8982,7 +8982,7 @@ describe('evidence from the page context', () => {
             source: 'clf-fiber-reply',
             nonce: event.data.nonce,
             scanToken: event.data.nonce,
-            v: 10,
+            v: 11,
             scanOk: true,
             rows: [{ ...GOOD, tool: 'read' }],
             turns: []
@@ -13890,6 +13890,281 @@ describe('the goal loop', () => {
     expect(acked).toBe(1);
   });
 
+  it('defers a provider-blocked ready draft without sending or acknowledging it', async () => {
+    let draft: ReturnType<typeof readyDraft> | null = null;
+    let deferred = 0;
+    live = await harness(`https://chatgpt.com/c/${CHAT}`, {
+      ...goalReplies(),
+      activity: () => feed(draft)(),
+      goal_defer: () => {
+        deferred += 1;
+        return { ok: true, data: { deferred: true, resumeAt: Date.now() + 5 * 60_000 } };
+      }
+    });
+    const sends = watchSend(live.document);
+    const providerNode = live.document.createElement('div');
+    (live.window as any).CLF_DOM.errors = () => [{
+      blocking: true, recoverable: false, text: 'Pro access limit reached', node: providerNode, turnId: null
+    }];
+    draft = readyDraft('Continue after the quota reset.');
+    await live.hook.pullActivity();
+    await settle();
+
+    expect(deferred).toBe(1);
+    expect(sends()).toBe(0);
+    expect(acks(live)).toHaveLength(0);
+    expect(composerText(live.document)).toBe('');
+
+    // The app hides the payload while its durable wake deadline is active. Even if React has
+    // already removed the dialog, the next poll cannot fall through to Send from local state.
+    draft = null;
+    (live.window as any).CLF_DOM.errors = () => [];
+    await live.hook.pullActivity();
+    await settle();
+    expect(sends()).toBe(0);
+    expect(acks(live)).toHaveLength(0);
+  });
+
+  it('defers from cached provider-limit evidence after the observer dismisses the dialog', async () => {
+    let draft: ReturnType<typeof readyDraft> | null = null;
+    let deferred = 0;
+    let firstRead = true;
+    live = await harness(`https://chatgpt.com/c/${CHAT}`, {
+      ...goalReplies(),
+      activity: () => feed(draft)(),
+      goal_defer: () => {
+        deferred += 1;
+        return { ok: true, data: { deferred: true, resumeAt: Date.now() + 5 * 60_000 } };
+      }
+    });
+    const providerNode = live.document.createElement('div');
+    (live.window as any).CLF_DOM.errors = () => {
+      if (!firstRead) return [];
+      firstRead = false;
+      return [{
+        blocking: true, recoverable: false, text: 'ChatGPT access is limited', node: providerNode, turnId: null
+      }];
+    };
+    const sends = watchSend(live.document);
+
+    // The ordinary transcript pass sees and acknowledges the dialog before /activity
+    // publishes the ready draft. React removes it, so every later DOM read is empty.
+    live.hook.observe();
+    draft = readyDraft('Do not lose the continuation after dismissal.');
+    await live.hook.pullActivity();
+    await settle();
+
+    expect(firstRead).toBe(false);
+    expect(deferred).toBe(1);
+    expect(sends()).toBe(0);
+    expect(acks(live)).toHaveLength(0);
+    expect(composerText(live.document)).toBe('');
+  });
+
+  it('renews a dismissed provider limit revealed only by the retry click', async () => {
+    let draft: ReturnType<typeof readyDraft> | null = null;
+    let deferred = 0;
+    let firstRead = true;
+    let refusedAfterClick = false;
+    live = await harness(`https://chatgpt.com/c/${CHAT}`, {
+      ...goalReplies(),
+      activity: () => feed(draft)(),
+      goal_defer: () => {
+        deferred += 1;
+        return { ok: true, data: { deferred: true, resumeAt: live!.window.Date.now() + 5 * 60_000 } };
+      }
+    }, document => {
+      document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+        refusedAfterClick = true;
+      });
+    });
+    const providerNode = live.document.createElement('div');
+    (live.window as any).CLF_DOM.errors = () => {
+      if (firstRead) {
+        firstRead = false;
+        return [{
+          blocking: true, recoverable: false, text: 'ChatGPT access is limited', node: providerNode, turnId: null
+        }];
+      }
+      return refusedAfterClick ? [{
+        blocking: true, recoverable: false, text: 'ChatGPT access is still limited', node: providerNode, turnId: null
+      }] : [];
+    };
+    const sends = watchSend(live.document);
+
+    live.hook.observe();
+    draft = readyDraft('Retry this exact continuation only when access returns.');
+    await live.hook.pullActivity();
+    await settle();
+    expect(deferred).toBe(1);
+    expect(sends()).toBe(0);
+
+    // The app hides the draft until this deadline, then republishes that same token. The
+    // original dialog is gone, and the provider reveals the continuing limit only on click.
+    draft = null;
+    live.advance(5 * 60_000);
+    draft = readyDraft('Retry this exact continuation only when access returns.');
+    await live.hook.pullActivity();
+    await settle();
+
+    expect(sends()).toBe(1);
+    expect(deferred).toBe(2);
+    expect(acks(live)).toHaveLength(0);
+    expect(composerText(live.document)).toBe('');
+  });
+
+  it('renews the same ready draft pause when the provider is still blocked at its deadline', async () => {
+    let draft: ReturnType<typeof readyDraft> | null = null;
+    let deferred = 0;
+    let now = Date.now();
+    live = await harness(`https://chatgpt.com/c/${CHAT}`, {
+      ...goalReplies(),
+      activity: () => feed(draft)(),
+      goal_defer: () => {
+        deferred += 1;
+        return { ok: true, data: { deferred: true, resumeAt: now + 5 * 60_000 } };
+      }
+    });
+    (live.window as any).Date.now = () => now;
+    const providerNode = live.document.createElement('div');
+    (live.window as any).CLF_DOM.errors = () => [{
+      blocking: true, recoverable: false, text: 'ChatGPT access is limited', node: providerNode, turnId: null
+    }];
+    const sends = watchSend(live.document);
+    draft = readyDraft('Continue when access returns.');
+    await live.hook.pullActivity();
+    await settle();
+    expect(deferred).toBe(1);
+
+    now += 5 * 60_000 - 1;
+    await live.hook.pullActivity();
+    await settle();
+    expect(deferred).toBe(1);
+
+    now += 1;
+    await live.hook.pullActivity();
+    await settle();
+    expect(deferred).toBe(2);
+    expect(sends()).toBe(0);
+    expect(acks(live)).toHaveLength(0);
+  });
+
+  it('defers when the provider limit appears during composer preparation', async () => {
+    let draft: ReturnType<typeof readyDraft> | null = null;
+    let deferred = 0;
+    let blocked = false;
+    live = await harness(`https://chatgpt.com/c/${CHAT}`, {
+      ...goalReplies(),
+      activity: () => feed(draft)(),
+      goal_defer: () => {
+        deferred += 1;
+        return { ok: true, data: { deferred: true, resumeAt: Date.now() + 5 * 60_000 } };
+      }
+    });
+    const providerNode = live.document.createElement('div');
+    (live.window as any).CLF_DOM.errors = () => blocked ? [{
+      blocking: true, recoverable: false, text: 'ChatGPT access is limited', node: providerNode, turnId: null
+    }] : [];
+    const sends = watchSend(live.document);
+    let resume: (() => void) | undefined;
+    const timer = live.window.setTimeout;
+    live.window.setTimeout = ((fn: () => void, ms?: number) => {
+      if (ms === 200) { resume = fn; return 0; }
+      return timer(fn, ms);
+    }) as typeof live.window.setTimeout;
+
+    draft = readyDraft('Keep this exact continuation.');
+    const pulling = live.hook.pullActivity();
+    await settle();
+    expect(composerText(live.document)).toBe('Keep this exact continuation.');
+    blocked = true;
+    resume!();
+    await pulling; await settle();
+
+    expect(deferred).toBe(1);
+    expect(sends()).toBe(0);
+    expect(acks(live)).toHaveLength(0);
+    expect(composerText(live.document)).toBe('');
+  });
+
+  it('defers when the provider limit appears while native Send is unavailable', async () => {
+    let draft: ReturnType<typeof readyDraft> | null = null;
+    let deferred = 0;
+    let blocked = false;
+    live = await harness(`https://chatgpt.com/c/${CHAT}`, {
+      ...goalReplies(),
+      activity: () => feed(draft)(),
+      goal_defer: () => {
+        deferred += 1;
+        return { ok: true, data: { deferred: true, resumeAt: Date.now() + 5 * 60_000 } };
+      }
+    }, () => undefined, false, true);
+    const providerNode = live.document.createElement('div');
+    (live.window as any).CLF_DOM.errors = () => blocked ? [{
+      blocking: true, recoverable: false, text: 'ChatGPT access is limited', node: providerNode, turnId: null
+    }] : [];
+    const button = live.document.querySelector<HTMLButtonElement>('[data-testid="send-button"]')!;
+    button.disabled = true;
+    const sends = watchSend(live.document);
+
+    draft = readyDraft('Wait for provider access.');
+    const pulling = live.hook.pullActivity();
+    await settle();
+    expect(composerText(live.document)).toBe('Wait for provider access.');
+    blocked = true;
+    button.disabled = false;
+    await pulling; await settle();
+
+    expect(deferred).toBe(1);
+    expect(sends()).toBe(0);
+    expect(acks(live)).toHaveLength(0);
+    expect(composerText(live.document)).toBe('');
+  });
+
+  it('defers when the provider limit appears during final app authorization', async () => {
+    let draft: ReturnType<typeof readyDraft> | null = null;
+    let deferred = 0;
+    let blocked = false;
+    let publishedReady = false;
+    let authorizationStarted = () => undefined as void;
+    let releaseAuthorization = () => undefined as void;
+    const started = new Promise<void>(resolve => { authorizationStarted = resolve; });
+    const held = new Promise<void>(resolve => { releaseAuthorization = resolve; });
+    live = await harness(`https://chatgpt.com/c/${CHAT}`, {
+      ...goalReplies(),
+      activity: async () => {
+        if (draft && publishedReady) {
+          authorizationStarted();
+          await held;
+        }
+        if (draft) publishedReady = true;
+        return feed(draft)();
+      },
+      goal_defer: () => {
+        deferred += 1;
+        return { ok: true, data: { deferred: true, resumeAt: Date.now() + 5 * 60_000 } };
+      }
+    });
+    const providerNode = live.document.createElement('div');
+    (live.window as any).CLF_DOM.errors = () => blocked ? [{
+      blocking: true, recoverable: false, text: 'ChatGPT access is limited', node: providerNode, turnId: null
+    }] : [];
+    const sends = watchSend(live.document);
+
+    draft = readyDraft('Authorize this exact continuation.');
+    const pulling = live.hook.pullActivity();
+    await started;
+    expect(composerText(live.document)).toBe('Authorize this exact continuation.');
+    blocked = true;
+    releaseAuthorization();
+    await pulling; await settle();
+
+    expect(deferred).toBe(1);
+    expect(sends()).toBe(0);
+    expect(acks(live)).toHaveLength(0);
+    expect(composerText(live.document)).toBe('');
+  });
+
   /**
    * The composer belongs to the user, and this is the moment the loop borrows it. It types
    * the message, sends it, and acknowledges the draft — the acknowledgement being what stops
@@ -13924,7 +14199,7 @@ describe('the goal loop', () => {
     expect(acks(live)).toHaveLength(0);
   });
 
-  it.each(['off', 'new-token', 'editor'])('rechecks the exact Goal authority when delayed Send becomes ready (%s)', async change => {
+  it.each(['off', 'quota-pause', 'new-token', 'editor'])('rechecks the exact Goal authority when delayed Send becomes ready (%s)', async change => {
     let draft: ReturnType<typeof readyDraft> | null = null, enabled = true;
     live = await harness(`https://chatgpt.com/c/${CHAT}`, {
       ...goalReplies(),
@@ -13946,6 +14221,7 @@ describe('the goal loop', () => {
     await settle();
     expect(composerText(live.document)).toBe('Old Goal reply');
     if (change === 'off') { enabled = false; draft = null; }
+    else if (change === 'quota-pause') draft = null;
     else if (change === 'new-token') draft = { ...readyDraft('New Goal reply'), token: 'new-token' };
     else {
       const editor = live.document.querySelector('#prompt-textarea')!;
@@ -14881,7 +15157,7 @@ describe('the goal loop', () => {
             source: 'clf-fiber-reply',
             nonce: event.data.nonce,
             scanToken,
-            v: 10,
+            v: 11,
             scanOk: true,
             rows: [],
             turns: [{
@@ -14964,7 +15240,7 @@ describe('the goal loop', () => {
             source: 'clf-fiber-reply',
             nonce: event.data.nonce,
             scanToken,
-            v: 10,
+            v: 11,
             scanOk: true,
             rows: [],
             turns: [{
@@ -16114,7 +16390,7 @@ describe('app Stop command uses current native turn proof', () => {
       if (event.data?.source !== 'clf-fiber-ask') return;
       section.setAttribute('data-clf-fiber-turn', `${event.data.nonce}:0`);
       window.dispatchEvent(new window.MessageEvent('message', { source: window, data: {
-        source: 'clf-fiber-reply', nonce: event.data.nonce, scanToken: event.data.nonce, v: 10, scanOk: true, rows: [],
+        source: 'clf-fiber-reply', nonce: event.data.nonce, scanToken: event.data.nonce, v: 11, scanOk: true, rows: [],
         turns: [{ ...terminal, index: 0, conversationId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', messages: [{
           messageId: 'late-final-message', stable: true, rawText: 'First words and the complete final answer.', renderedHtml: '<p>First words and the complete final answer.</p>'
         }] }]
@@ -16153,7 +16429,7 @@ describe('app Stop command uses current native turn proof', () => {
       }
       section.setAttribute('data-clf-fiber-turn', `${event.data.nonce}:0`);
       window.dispatchEvent(new window.MessageEvent('message', { source: window, data: {
-        source: 'clf-fiber-reply', nonce: event.data.nonce, scanToken: event.data.nonce, v: 10, scanOk: true, rows: [],
+        source: 'clf-fiber-reply', nonce: event.data.nonce, scanToken: event.data.nonce, v: 11, scanOk: true, rows: [],
         turns: [{ ...terminal, index: 0, conversationId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', endMessageId: next === 'retry' ? null : terminal.endMessageId }]
       } }));
     };

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -2546,11 +2546,11 @@ describe('extension observation journal', () => {
     expect(journalOf(session)).toEqual([]);
   });
 
-  it('carries the browser tab identity through Goal activity, draft and acknowledgement', async () => {
+  it('carries the exact browser tab and token through Goal activity, draft, defer and acknowledgement', async () => {
     const conversationId = '22222222-3333-4444-5555-666666666666';
     const local = new FakeStorageArea({ port: 8765, token: 'paired-token' });
     const session = new FakeStorageArea();
-    const seen: Array<{ route: string; client: string | null }> = [];
+    const seen: Array<{ route: string; client: string | null; token?: string }> = [];
     const fetch = vi.fn(async (input: string, init: Record<string, unknown> = {}) => {
       const url = new URL(input);
       if (url.pathname === '/hello') return response(200, { app: 'chat-on-steroids', paired: true });
@@ -2558,10 +2558,16 @@ describe('extension observation journal', () => {
         seen.push({ route: url.pathname, client: url.searchParams.get('goalClient') });
         return response(200, { sessionId: 'session', entries: [], stream: [], nextSince: 0 });
       }
-      if (url.pathname === '/goal/draft' || url.pathname === '/goal/ack') {
+      if (url.pathname === '/goal/draft' || url.pathname === '/goal/ack' || url.pathname === '/goal/defer') {
         const body = JSON.parse(String(init.body || '{}'));
-        seen.push({ route: url.pathname, client: typeof body.clientId === 'string' ? body.clientId : null });
-        return response(200, url.pathname.endsWith('/draft') ? { goal: { stage: 'drafting' } } : { acknowledged: true });
+        seen.push({
+          route: url.pathname,
+          client: typeof body.clientId === 'string' ? body.clientId : null,
+          ...(typeof body.token === 'string' ? { token: body.token } : {})
+        });
+        return response(200, url.pathname.endsWith('/draft') ? { goal: { stage: 'drafting' } }
+          : url.pathname.endsWith('/defer') ? { deferred: true, resumeAt: Date.now() + 300_000 }
+          : { acknowledged: true });
       }
       return response(404, {});
     });
@@ -2569,12 +2575,14 @@ describe('extension observation journal', () => {
 
     await worker.send({ type: 'activity', conversationId, since: 0 }, 73);
     await worker.send({ type: 'goal_draft', conversationId, turnId: 'generation-owned' }, 73);
+    await worker.send({ type: 'goal_defer', conversationId, turnId: 'generation-owned', token: 'goal-token' }, 73);
     await worker.send({ type: 'goal_ack', conversationId, token: 'goal-token' }, 73);
 
     expect(seen).toEqual([
       { route: '/activity', client: '73' },
       { route: '/goal/draft', client: '73' },
-      { route: '/goal/ack', client: '73' }
+      { route: '/goal/defer', client: '73', token: 'goal-token' },
+      { route: '/goal/ack', client: '73', token: 'goal-token' }
     ]);
   });
 

--- a/test/fiber.test.ts
+++ b/test/fiber.test.ts
@@ -54,6 +54,7 @@ const THREAD = 'f0f00004-1111-4111-8111-111111111111';
  */
 const APP = 'Chat On Steroids Core';
 const DESKTOP_APP = 'Chat On Steroids Desktop';
+const PLUGINS_APP = 'Chat On Steroids Plugins';
 /** What the connector was called before 1.7.1 split it. Older chats still hold it. */
 const LEGACY_APP = 'TobisComputer';
 /** The connector's link id, as it appears in a request path. */
@@ -254,6 +255,8 @@ interface TurnEvidence {
     rawMessageId: string;
     role?: 'user' | 'assistant';
     stable: boolean;
+    workingTurnId?: string | null;
+    turnExchangeId?: string | null;
     order: number;
     createTime?: number | null;
     rawText: string;
@@ -392,8 +395,8 @@ describe('reading a row out of the page', () => {
 
   it('keeps the version it was built for on the reply', async () => {
     const { version, rows } = await scan([row([request('req-1', 'read_file')])]);
-    expect(version).toBe(10);
-    expect(rows[0]!.v).toBe(10);
+    expect(version).toBe(11);
+    expect(rows[0]!.v).toBe(11);
   });
   it('counts only TobisComputer requests in the complete turn, not api_tool metadata calls', async () => {
     const mine1 = request('req-1', 'read_file');
@@ -440,12 +443,14 @@ describe('the calls a turn says it made', () => {
    * ours, so no turn produced evidence and one chat's whole run of calls was filed under
    * `Unattributed activity`. Both current connectors and the old name must read.
    */
-  it('recognises both 1.7.1 connectors and the pre-1.7.1 name', async () => {
+  it('recognises every current connector and the pre-1.7.1 name', async () => {
     const messages = [
       request('req-core', 'read'),
       answer('res-core', 'req-core', 'read'),
       request('req-desk', 'computer', { app: DESKTOP_APP }),
       answer('res-desk', 'req-desk', 'computer', DESKTOP_APP),
+      request('req-plugins', 'search', { app: PLUGINS_APP }),
+      answer('res-plugins', 'req-plugins', 'search', PLUGINS_APP),
       request('req-old', 'read_file', { app: LEGACY_APP }),
       answer('res-old', 'req-old', 'read_file', LEGACY_APP)
     ];
@@ -454,7 +459,8 @@ describe('the calls a turn says it made', () => {
     expect(turns[0]!.calls).toEqual([
       { messageId: 'req-core', tool: 'read', order: 0, answered: true, requestId: 'wfr_01a009', createTime: 1786873658.125 },
       { messageId: 'req-desk', tool: 'computer', order: 1, answered: true, requestId: 'wfr_01a009', createTime: 1786873658.125 },
-      { messageId: 'req-old', tool: 'read_file', order: 2, answered: true, requestId: 'wfr_01a009', createTime: 1786873658.125 }
+      { messageId: 'req-plugins', tool: 'search', order: 2, answered: true, requestId: 'wfr_01a009', createTime: 1786873658.125 },
+      { messageId: 'req-old', tool: 'read_file', order: 3, answered: true, requestId: 'wfr_01a009', createTime: 1786873658.125 }
     ]);
   });
 
@@ -755,6 +761,14 @@ describe('the calls a turn says it made', () => {
     expect(reloaded.turns[0]!.messages[0]!.messageId).toBe(live.turns[0]!.messages[0]!.messageId);
     expect(live.turns[0]!.messages[0]!.stable).toBe(true);
     expect(reloaded.turns[0]!.messages[0]!.stable).toBe(true);
+    expect(live.turns[0]!.messages[0]).toMatchObject({
+      workingTurnId: branch.workingTurnId,
+      turnExchangeId: branch.turnExchangeId
+    });
+    expect(reloaded.turns[0]!.messages[0]).toMatchObject({
+      workingTurnId: branch.workingTurnId,
+      turnExchangeId: branch.turnExchangeId
+    });
   });
 
   it('falls back to the parent tuple when two messages of one branch share a creation stamp', async () => {

--- a/test/goal.test.ts
+++ b/test/goal.test.ts
@@ -1729,6 +1729,278 @@ describe('a chat driven towards a specific goal', () => {
     });
   });
 
+  it('keeps a quota-paused reply durable and wakes it once after the recheck time', async () => {
+    const conversationId = 'c-reply-quota-paused';
+    const turnId = 'g-reply-quota-paused';
+    const session = await createSession({ conversationId, title: 'Quota pause' });
+    await appendEvent(session.id, {
+      time: Date.now(), source: 'extension', kind: 'user_message',
+      message: { text: 'continue', truncated: false, chars: 8 }
+    });
+    globalThis.fetch = (async () => decision('continue', 'Continue safely.')) as never;
+    await goal.acceptGoalReplyNow({
+      conversationId,
+      sessionId: session.id,
+      replyId: 'assistant-message-quota-paused',
+      turnId,
+      eventSeq: 8,
+      blocked: false
+    });
+    const draft = goal.startGoalDraft({ conversationId, sessionId: session.id, turnId, clientId: 'tab-quota' });
+    expect((await settled(conversationId)).stage).toBe('ready');
+    let now = Date.now();
+    const clock = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    try {
+      const resumeAt = await goal.deferGoalReplyForQuotaNow(conversationId, turnId, draft.token, 'tab-quota');
+      expect(resumeAt).toBe(Date.now() + 5 * 60_000);
+      now += 30_000;
+      expect(await goal.deferGoalReplyForQuotaNow(conversationId, turnId, draft.token, 'tab-quota')).toBe(resumeAt);
+      expect(goal.goalPendingReplyFor(conversationId)).toBeNull();
+      expect(goal.pendingGoalReplies()).toEqual([]);
+
+      const saved = goal.snapshotGoalReplies();
+      goal.resetGoalStateForTests();
+      goal.restoreGoalReplies(saved);
+      now += 5 * 60_000 - 30_000 - 1;
+      expect(goal.goalPendingReplyFor(conversationId)).toBeNull();
+      now += 1;
+      expect(goal.goalPendingReplyFor(conversationId)).toMatchObject({
+        replyId: 'assistant-message-quota-paused', turnId, acceptedAt: resumeAt
+      });
+      expect(goal.pendingGoalReplies()).toHaveLength(1);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it('preserves a quota pause when a provisional reply is promoted to its stable identity', async () => {
+    const conversationId = 'c-provisional-quota-promotion';
+    const turnId = 'g-provisional-quota-promotion';
+    const session = await createSession({ conversationId, title: 'Provisional quota promotion' });
+    await appendEvent(session.id, {
+      time: Date.now(), source: 'extension', kind: 'user_message',
+      message: { text: 'continue after quota', truncated: false, chars: 20 }
+    });
+    await goal.acceptGoalReplyNow({
+      conversationId, sessionId: session.id, replyId: `turn:${turnId}`, turnId, eventSeq: 0, blocked: false
+    });
+    globalThis.fetch = (async () => decision('continue', 'Continue once access returns.')) as never;
+    const draft = goal.startGoalDraft({ conversationId, sessionId: session.id, turnId, clientId: 'tab-provisional' });
+    expect((await settled(conversationId)).stage).toBe('ready');
+
+    const base = Date.now();
+    let now = base;
+    const clock = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    try {
+      const resumeAt = await goal.deferGoalReplyForQuotaNow(
+        conversationId, turnId, draft.token, 'tab-provisional'
+      );
+      expect(resumeAt).toBe(base + 5 * 60_000);
+      await goal.acceptGoalReplyNow({
+        conversationId, sessionId: session.id, replyId: 'assistant-stable-after-quota',
+        turnId, eventSeq: 12, blocked: false
+      });
+      expect(goal.goalReplyResumeAtFor(conversationId, turnId)).toBe(resumeAt);
+      expect(goal.goalViewFor(conversationId, 'tab-provisional')).toBeNull();
+      expect(goal.snapshotGoalReplies().replies).toContainEqual(expect.objectContaining({
+        replyId: 'assistant-stable-after-quota', turnId, eventSeq: 12,
+        state: 'pending', resumeAt
+      }));
+      now = resumeAt!;
+      expect(goal.goalViewFor(conversationId, 'tab-provisional')).toMatchObject({
+        token: draft.token, stage: 'ready'
+      });
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it('withholds a paused ready payload and safely redrafts it after a long offline wake', async () => {
+    const conversationId = 'c-ready-quota-paused';
+    const turnId = 'g-ready-quota-paused';
+    const session = await createSession({ conversationId, title: 'Ready quota pause' });
+    await appendEvent(session.id, {
+      time: Date.now(), source: 'extension', kind: 'user_message',
+      message: { text: 'continue the proof', truncated: false, chars: 18 }
+    });
+    await goal.acceptGoalReplyNow({
+      conversationId, sessionId: session.id, replyId: 'assistant-ready-quota', turnId, eventSeq: 9, blocked: false
+    });
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return decision('continue', 'Run the next bounded check.');
+    }) as never;
+    const first = goal.startGoalDraft({ conversationId, sessionId: session.id, turnId });
+    expect((await settled(conversationId)).stage).toBe('ready');
+
+    const base = Date.now();
+    let now = base;
+    const clock = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    try {
+      const firstWake = await goal.deferGoalReplyForQuotaNow(conversationId, turnId, first.token, '');
+      expect(firstWake).toBe(base + 5 * 60_000);
+      expect(goal.goalViewFor(conversationId)).toBeNull();
+      expect(goal.goalReplyResumeAtFor(conversationId, turnId)).toBe(firstWake);
+
+      // React removing the dialog cannot expose the payload before the app-owned deadline.
+      now = firstWake! - 1;
+      expect(goal.goalViewFor(conversationId)).toBeNull();
+      now = firstWake!;
+      expect(goal.goalViewFor(conversationId)).toMatchObject({ token: first.token, stage: 'ready' });
+
+      // If the machine stays down beyond the payload TTL after that wake, the exact durable
+      // obligation remains. It may buy another helper decision, but never lose the loop or
+      // reuse a payload whose browser-send state is no longer knowable.
+      now = firstWake! + 11 * 60_000;
+      expect(goal.goalViewFor(conversationId)).toBeNull();
+      expect(goal.goalPendingReplyFor(conversationId)).toMatchObject({ turnId });
+      const replacement = goal.startGoalDraft({ conversationId, sessionId: session.id, turnId });
+      expect(replacement.token).not.toBe(first.token);
+      expect((await settled(conversationId)).stage).toBe('ready');
+      expect(calls).toBe(2);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it('does not roll a failed defer write back over a newer acknowledgement', async () => {
+    const conversationId = 'c-quota-defer-race';
+    const turnId = 'g-quota-defer-race';
+    const session = await createSession({ conversationId, title: 'Quota defer race' });
+    await appendEvent(session.id, {
+      time: Date.now(), source: 'extension', kind: 'user_message',
+      message: { text: 'continue once', truncated: false, chars: 13 }
+    });
+    await goal.acceptGoalReplyNow({
+      conversationId, sessionId: session.id, replyId: 'assistant-quota-defer-race', turnId, eventSeq: 10, blocked: false
+    });
+    globalThis.fetch = (async () => decision('continue', 'One exact continuation.')) as never;
+    const draft = goal.startGoalDraft({ conversationId, sessionId: session.id, turnId, clientId: 'tab-race' });
+    expect((await settled(conversationId)).stage).toBe('ready');
+
+    const durable = await import('../src/main/durable.js');
+    const realWrite = durable.writeDurableNow;
+    let entered!: () => void;
+    let fail!: (error: Error) => void;
+    const writeEntered = new Promise<void>(resolve => { entered = resolve; });
+    const heldWrite = new Promise<void>((_resolve, reject) => { fail = reject; });
+    const spy = vi.spyOn(durable, 'writeDurableNow')
+      .mockImplementationOnce(async () => { entered(); await heldWrite; })
+      .mockImplementation(realWrite);
+    try {
+      const pausing = goal.deferGoalReplyForQuotaNow(conversationId, turnId, draft.token, 'tab-race');
+      await writeEntered;
+      expect(goal.goalReplyResumeAtFor(conversationId, turnId)).toEqual(expect.any(Number));
+
+      expect(await goal.ackGoalDraftNow(conversationId, draft.token, 'tab-race')).toBe(true);
+      expect(goal.goalPendingReplyFor(conversationId)).toBeNull();
+      fail(new Error('older defer fsync failed'));
+      await expect(pausing).rejects.toThrow('older defer fsync failed');
+
+      expect(goal.goalPendingReplyFor(conversationId)).toBeNull();
+      expect(goal.snapshotGoalReplies()).toMatchObject({
+        replies: expect.arrayContaining([
+          expect.objectContaining({ conversationId, replyId: 'assistant-quota-defer-race', state: 'handled' })
+        ])
+      });
+      expect(await durable.readDurable<{ replies: Array<{ conversationId: string; state: string }> }>(goal.GOAL_REPLIES_STATE))
+        .toMatchObject({ replies: expect.arrayContaining([expect.objectContaining({ conversationId, state: 'handled' })]) });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('retires a quota-paused draft when a newer final replaces its obligation', async () => {
+    const conversationId = 'c-quota-draft-superseded';
+    const session = await createSession({ conversationId, title: 'Superseded paused draft' });
+    await appendEvent(session.id, {
+      time: Date.now(), source: 'extension', kind: 'user_message',
+      message: { text: 'continue A', truncated: false, chars: 10 }
+    });
+    await goal.acceptGoalReplyNow({
+      conversationId, sessionId: session.id, replyId: 'assistant-a',
+      turnId: 'turn-a', eventSeq: 10, blocked: false
+    });
+    globalThis.fetch = (async () => decision('continue', 'Continuation for A.')) as never;
+    const oldDraft = goal.startGoalDraft({
+      conversationId, sessionId: session.id, turnId: 'turn-a', clientId: 'tab-a'
+    });
+    expect((await settled(conversationId)).stage).toBe('ready');
+    expect(await goal.deferGoalReplyForQuotaNow(
+      conversationId, 'turn-a', oldDraft.token, 'tab-a'
+    )).toEqual(expect.any(Number));
+
+    // Another tab records a genuinely newer completed answer before A's pause expires.
+    await goal.acceptGoalReplyNow({
+      conversationId, sessionId: session.id, replyId: 'assistant-b',
+      turnId: 'turn-b', eventSeq: 20, blocked: false
+    });
+
+    expect(goal.goalViewFor(conversationId, 'tab-a')).toBeNull();
+    expect(goal.goalPendingReplyFor(conversationId)).toMatchObject({
+      replyId: 'assistant-b', turnId: 'turn-b', eventSeq: 20
+    });
+    const replacement = goal.startGoalDraft({
+      conversationId, sessionId: session.id, turnId: 'turn-b', clientId: 'tab-b', deferStart: true
+    });
+    expect(replacement.token).not.toBe(oldDraft.token);
+    expect(replacement.turnId).toBe('turn-b');
+  });
+
+  it('does not roll a failed promotion write back over a durable quota renewal', async () => {
+    const conversationId = 'c-promotion-renewal-race';
+    const turnId = 'g-promotion-renewal-race';
+    const session = await createSession({ conversationId, title: 'Promotion renewal race' });
+    await appendEvent(session.id, {
+      time: Date.now(), source: 'extension', kind: 'user_message',
+      message: { text: 'continue after quota', truncated: false, chars: 20 }
+    });
+    await goal.acceptGoalReplyNow({
+      conversationId, sessionId: session.id, replyId: `turn:${turnId}`,
+      turnId, eventSeq: 0, blocked: false
+    });
+    globalThis.fetch = (async () => decision('continue', 'Continue after access returns.')) as never;
+    const draft = goal.startGoalDraft({ conversationId, sessionId: session.id, turnId, clientId: 'tab-race' });
+    expect((await settled(conversationId)).stage).toBe('ready');
+
+    const durable = await import('../src/main/durable.js');
+    const realWrite = durable.writeDurableNow;
+    let entered!: () => void;
+    let fail!: (error: Error) => void;
+    const writeEntered = new Promise<void>(resolve => { entered = resolve; });
+    const heldWrite = new Promise<void>((_resolve, reject) => { fail = reject; });
+    const spy = vi.spyOn(durable, 'writeDurableNow')
+      .mockImplementationOnce(async () => { entered(); await heldWrite; })
+      .mockImplementation(realWrite);
+    try {
+      const promotion = goal.acceptGoalReplyNow({
+        conversationId, sessionId: session.id, replyId: 'assistant-stable-race',
+        turnId, eventSeq: 30, blocked: false
+      });
+      await writeEntered;
+      const resumeAt = await goal.deferGoalReplyForQuotaNow(
+        conversationId, turnId, draft.token, 'tab-race'
+      );
+      expect(resumeAt).toEqual(expect.any(Number));
+      fail(new Error('older promotion fsync failed'));
+      await expect(promotion).rejects.toThrow('older promotion fsync failed');
+
+      expect(goal.goalReplyResumeAtFor(conversationId, turnId)).toBe(resumeAt);
+      expect(goal.goalViewFor(conversationId, 'tab-race')).toBeNull();
+      expect(goal.snapshotGoalReplies().replies).toContainEqual(expect.objectContaining({
+        conversationId, replyId: 'assistant-stable-race', turnId, eventSeq: 30,
+        state: 'pending', resumeAt
+      }));
+      expect(await durable.readDurable<{ replies: Array<Record<string, unknown>> }>(goal.GOAL_REPLIES_STATE))
+        .toMatchObject({ replies: expect.arrayContaining([expect.objectContaining({
+          conversationId, replyId: 'assistant-stable-race', state: 'pending', resumeAt
+        })]) });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it('stores a handled tombstone when Goal was off at terminal acceptance', async () => {
     await saveConfig({
       ...defaultConfig(),

--- a/test/recorder-final-identity.test.ts
+++ b/test/recorder-final-identity.test.ts
@@ -63,7 +63,7 @@ it.each(['missing', 'replaced', 'matching', 'restart'])('closes the canonical re
     await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests();
   }
   const final = { kind: 'assistant_message' as const, time: 20, messageId: 'stable-answer',
-    text: 'The full canonical answer.', state: 'final' as const, final: true,
+    text: 'The full canonical answer.', state: 'final' as const, final: true, goalEligible: true,
     ...(mode === 'matching' ? { turnId } : mode === 'replaced' ? { turnId: 'replacement-page-id' } : {}) };
   const recovered = await recordChatObservations(conversationId, [final]);
   const sessionId = opened.sessionId!;
@@ -73,8 +73,943 @@ it.each(['missing', 'replaced', 'matching', 'restart'])('closes the canonical re
   expect((await getSession(sessionId))?.activeTurnId).toBeNull();
   expect(liveConversations().find(row => row.conversationId === conversationId)?.activeTurnId).toBeNull();
   expect(recovered.activity).toMatchObject({ terminal: true, endedTurnId: turnId });
+  expect(recovered.goalCandidates).toEqual([expect.objectContaining({ replyId: 'stable-answer', turnId })]);
   await recordChatObservations(conversationId, [final]);
   expect(await readEvents(sessionId, { kinds: ['turn_end'] })).toHaveLength(1);
+});
+
+it.each(['missing', 'replacement'] as const)(
+  'recovers a distinct final from the exact response branch after recorder restart with a %s page turn id',
+  async pageTurn => {
+  const conversationId = `distinct-response-branch-final-${pageTurn}`;
+  const turnId = `response-branch-turn-${pageTurn}`;
+  const branch = { responseExchangeId: 'exchange_exact', responseWorkingId: 'working_exact' };
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId },
+    { kind: 'assistant_message', time: 11, turnId, messageId: 'partial-before-reload',
+      providerMessageId: 'provider-partial', text: 'Working.', state: 'streaming', ...branch }
+  ]);
+  await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests();
+
+  const recovered = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, messageId: 'distinct-final-after-reload',
+    providerMessageId: 'provider-final', text: 'Completed.', state: 'final', final: true,
+    activeNow: true, ...(pageTurn === 'replacement' ? { turnId: 'replacement-page-turn' } : {}), ...branch
+  }]);
+
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBeNull();
+  expect(recovered.activity).toMatchObject({ terminal: true, endedTurnId: turnId });
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] })).at(-1)).toMatchObject({
+    turnId, responseExchangeId: branch.responseExchangeId, responseWorkingId: branch.responseWorkingId
+  });
+});
+
+it('binds replacement-page streaming before its matching native-branch final', async () => {
+  const conversationId = 'replacement-streaming-then-final';
+  const turnId = 'durable-response-turn';
+  const branch = { responseExchangeId: 'exchange_exact', responseWorkingId: 'working_exact' };
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId },
+    { kind: 'assistant_message', time: 11, turnId, messageId: 'old-page-partial',
+      providerMessageId: 'provider-partial', text: 'Working.', state: 'streaming', ...branch }
+  ]);
+  await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests();
+
+  await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, turnId: 'replacement-page-turn', messageId: 'new-page-answer',
+    providerMessageId: 'provider-answer', text: 'Still working.', state: 'streaming', activeNow: true, ...branch
+  }]);
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] })).at(-1)).toMatchObject({ turnId });
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe(turnId);
+
+  const completed = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 30, turnId: 'replacement-page-turn', messageId: 'new-page-answer',
+    providerMessageId: 'provider-answer', text: 'Completed.', state: 'final', final: true, activeNow: true, ...branch
+  }]);
+  expect(completed.activity).toMatchObject({ terminal: true, endedTurnId: turnId });
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBeNull();
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(1);
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] })).at(-1)).toMatchObject({
+    turnId, state: 'final', message: { text: 'Completed.' }
+  });
+});
+
+it('keeps a branchless replacement snapshot promotable by later exact provider-branch proof', async () => {
+  const conversationId = 'branchless-replacement-promoted-later';
+  const turnId = 'durable-response-turn';
+  const branch = { responseExchangeId: 'exchange_exact', responseWorkingId: 'working_exact' };
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId },
+    { kind: 'assistant_message', time: 11, turnId, messageId: 'old-page-partial',
+      providerMessageId: 'provider-partial', text: 'Working.', state: 'streaming', ...branch }
+  ]);
+  await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests();
+
+  await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, turnId: 'replacement-page-turn', messageId: 'replacement-snapshot',
+    providerMessageId: 'provider-new-answer', text: 'Still working.', state: 'streaming', activeNow: true
+  }]);
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] })).at(-1)).not.toHaveProperty('turnId');
+
+  const completed = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 30, turnId: 'replacement-page-turn', messageId: 'replacement-remount',
+    providerMessageId: 'provider-new-answer', text: 'Completed.', state: 'final', final: true, activeNow: true, ...branch
+  }]);
+  expect(completed.activity).toMatchObject({ terminal: true, endedTurnId: turnId });
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBeNull();
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(1);
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] })).at(-1)).toMatchObject({
+    turnId, state: 'final', providerMessageId: 'provider-new-answer'
+  });
+});
+
+it('does not let an older matching branch close a newer durable turn', async () => {
+  const conversationId = 'older-branch-after-newer-turn';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'older-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'older-turn', messageId: 'older-partial',
+      text: 'Older work.', state: 'streaming', responseExchangeId: 'exchange_old', responseWorkingId: 'working_old' },
+    { kind: 'turn_start', time: 20, turnId: 'newer-turn' },
+    { kind: 'user_message', time: 21, turnId: 'newer-turn', messageId: 'newer-user', text: 'New request', authoredNow: true }
+  ]);
+  const observed = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 30, turnId: 'replacement-page-turn', messageId: 'older-final',
+    providerMessageId: 'provider-old-final', text: 'Older completed.', state: 'final', final: true, activeNow: true,
+    responseExchangeId: 'exchange_old', responseWorkingId: 'working_old'
+  }]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('newer-turn');
+  expect(observed.activity.endedTurnId).toBeUndefined();
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(0);
+});
+
+it.each(['user-before-final', 'final-before-user'] as const)(
+  'does not close or enqueue a matching-branch final when a fresh user appears %s',
+  async order => {
+    const conversationId = `matching-branch-with-fresh-user-${order}`;
+    const turnId = 'durable-turn';
+    const branch = { responseExchangeId: 'exchange_exact', responseWorkingId: 'working_exact' };
+    const opened = await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 10, turnId },
+      { kind: 'assistant_message', time: 11, turnId, messageId: 'partial', text: 'Working.', state: 'streaming', ...branch }
+    ]);
+    const final = { kind: 'assistant_message' as const, time: 20, turnId: 'replacement-page-turn',
+      messageId: 'distinct-final', providerMessageId: 'provider-final', text: 'Completed.', state: 'final' as const,
+      final: true, activeNow: true, goalEligible: true, ...branch };
+    const user = { kind: 'user_message' as const, time: 21, messageId: 'fresh-user', text: 'New work', authoredNow: true };
+    const observed = await recordChatObservations(conversationId, order === 'user-before-final' ? [user, final] : [final, user]);
+    expect((await getSession(opened.sessionId!))?.activeTurnId).toBe(turnId);
+    expect(observed.activity.endedTurnId).toBeUndefined();
+    expect(observed.goalCandidates).toEqual([]);
+    expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(0);
+  }
+);
+
+it.each([
+  ['user-before-final', 'missing'],
+  ['final-before-user', 'missing'],
+  ['user-before-final', 'durable'],
+  ['final-before-user', 'durable']
+] as const)(
+  'does not trust explicit Goal eligibility for a superseded pre-batch final (%s, %s id)',
+  async (order, identity) => {
+    const conversationId = `superseded-explicit-goal-${order}-${identity}`;
+    const opened = await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 10, turnId: 'durable-turn' },
+      { kind: 'assistant_message', time: 11, turnId: 'durable-turn', messageId: 'partial', text: 'Working.', state: 'streaming' }
+    ]);
+    const final = { kind: 'assistant_message' as const, time: 20, messageId: 'stable-final',
+      text: 'Old completion.', state: 'final' as const, final: true, goalEligible: true,
+      ...(identity === 'durable' ? { turnId: 'durable-turn' } : {}) };
+    const user = { kind: 'user_message' as const, time: 21, messageId: 'fresh-user', text: 'New work', authoredNow: true };
+    const observed = await recordChatObservations(conversationId, order === 'user-before-final' ? [user, final] : [final, user]);
+    expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('durable-turn');
+    expect(observed.goalCandidates).toEqual([]);
+    expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(0);
+  }
+);
+
+it.each(['turn-before-final', 'final-before-turn'] as const)(
+  'does not close or enqueue a matching-branch final when a fresh turn appears %s',
+  async order => {
+    const conversationId = `matching-branch-with-fresh-turn-${order}`;
+    const branch = { responseExchangeId: 'exchange_exact', responseWorkingId: 'working_exact' };
+    const opened = await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 10, turnId: 'durable-turn' },
+      { kind: 'assistant_message', time: 11, turnId: 'durable-turn', messageId: 'partial', text: 'Working.', state: 'streaming', ...branch }
+    ]);
+    const final = { kind: 'assistant_message' as const, time: 20, turnId: 'replacement-page-turn',
+      messageId: 'distinct-final', providerMessageId: 'provider-final', text: 'Completed.', state: 'final' as const,
+      final: true, activeNow: true, goalEligible: true, ...branch };
+    const start = { kind: 'turn_start' as const, time: 21, turnId: 'fresh-turn' };
+    const observed = await recordChatObservations(conversationId, order === 'turn-before-final' ? [start, final] : [final, start]);
+    expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('fresh-turn');
+    expect(observed.activity.endedTurnId).toBeUndefined();
+    expect(observed.goalCandidates).toEqual([]);
+    expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(0);
+  }
+);
+
+it('keeps an explicit Goal candidate for a legitimate fast new turn in one batch', async () => {
+  const conversationId = 'fresh-user-turn-final-one-batch';
+  const observed = await recordChatObservations(conversationId, [
+    { kind: 'user_message', time: 10, turnId: 'fresh-turn', messageId: 'fresh-user', text: 'New work', authoredNow: true },
+    { kind: 'turn_start', time: 11, turnId: 'fresh-turn' },
+    { kind: 'assistant_message', time: 12, turnId: 'fresh-turn', messageId: 'fresh-final',
+      providerMessageId: 'fresh-provider', text: 'Completed.', state: 'final', final: true, goalEligible: true },
+    { kind: 'turn_end', time: 13, turnId: 'fresh-turn', outcome: 'completed' }
+  ]);
+  expect(observed.goalCandidates).toHaveLength(1);
+  expect(observed.goalCandidates[0]).toMatchObject({ replyId: 'fresh-final', turnId: 'fresh-turn' });
+});
+
+it('rejects a replacement page turn whose response branch contradicts the durable owner', async () => {
+  const conversationId = 'replacement-wrong-response-branch';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'durable-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'durable-turn', messageId: 'durable-partial',
+      text: 'Working.', state: 'streaming', responseExchangeId: 'exchange_current', responseWorkingId: 'working_current' }
+  ]);
+  await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests();
+  const observed = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, turnId: 'replacement-page-turn', messageId: 'wrong-branch-final',
+    providerMessageId: 'provider-final', text: 'Different branch.', state: 'final', final: true, activeNow: true,
+    goalEligible: true, responseExchangeId: 'exchange_other', responseWorkingId: 'working_other'
+  }]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('durable-turn');
+  expect(observed.activity.endedTurnId).toBeUndefined();
+  expect(observed.activity.terminal).toBe(false);
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(0);
+  const stored = (await readEvents(opened.sessionId!, { kinds: ['assistant_message'] })).at(-1);
+  expect(stored).not.toHaveProperty('turnId');
+  expect(stored).not.toHaveProperty('goalEligible');
+  expect(observed.goalCandidates).toEqual([]);
+});
+
+it('does not bind a live response branch through a provider alias owned by an ended turn', async () => {
+  const conversationId = 'historical-provider-alias-cannot-bind-live-branch';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'ended-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'ended-turn', messageId: 'historical-answer',
+      providerMessageId: 'shared-provider-id', text: 'Historical.', state: 'final', final: true },
+    { kind: 'turn_end', time: 12, turnId: 'ended-turn', outcome: 'completed' },
+    { kind: 'turn_start', time: 20, turnId: 'live-turn' }
+  ]);
+  await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 21, turnId: 'live-turn', messageId: 'provider-alias-remount',
+    providerMessageId: 'shared-provider-id', text: 'Historical remount.', state: 'streaming', activeNow: true,
+    responseExchangeId: 'exchange_live', responseWorkingId: 'working_live'
+  }]);
+  const attempted = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 30, turnId: 'replacement-page-turn', messageId: 'distinct-final',
+    providerMessageId: 'distinct-provider-id', text: 'Unproven completion.', state: 'final', final: true, activeNow: true,
+    responseExchangeId: 'exchange_live', responseWorkingId: 'working_live'
+  }]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('live-turn');
+  expect(attempted.activity.endedTurnId).toBeUndefined();
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(1);
+});
+
+it('does not trust a differing known historical turn id for active replacement content', async () => {
+  const conversationId = 'known-historical-replacement-id';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'historical-turn' },
+    { kind: 'turn_end', time: 12, turnId: 'historical-turn', outcome: 'completed' },
+    { kind: 'turn_start', time: 20, turnId: 'live-turn' }
+  ]);
+  const observed = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 30, turnId: 'historical-turn', messageId: 'new-active-answer',
+    providerMessageId: 'new-provider', text: 'Unproven.', state: 'final', final: true, activeNow: true, goalEligible: true
+  }]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('live-turn');
+  expect(observed.goalCandidates).toEqual([]);
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] })).at(-1)).not.toHaveProperty('turnId');
+});
+
+it.each([
+  ['inactive exact branch', false, 'exchange_current', 'working_current'],
+  ['missing exchange id', true, undefined, 'working_current'],
+  ['missing working id', true, 'exchange_current', undefined]
+] as const)('does not recover a replacement page turn from %s', async (_case, activeNow, exchangeId, workingId) => {
+  const conversationId = `insufficient-branch-proof-${_case}`;
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'durable-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'durable-turn', messageId: 'durable-partial',
+      text: 'Working.', state: 'streaming', responseExchangeId: 'exchange_current', responseWorkingId: 'working_current' }
+  ]);
+  const observed = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, turnId: 'replacement-page-turn', messageId: `insufficient-${_case}`,
+    providerMessageId: `provider-${_case}`, text: 'Unproven final.', state: 'final', final: true, activeNow,
+    ...(exchangeId ? { responseExchangeId: exchangeId } : {}),
+    ...(workingId ? { responseWorkingId: workingId } : {})
+  }]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('durable-turn');
+  expect(observed.activity.endedTurnId).toBeUndefined();
+  expect(observed.activity.terminal).toBe(false);
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(0);
+});
+
+it('rejects a distinct final from a different response branch', async () => {
+  const conversationId = 'wrong-response-branch-final';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'current-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'current-turn', messageId: 'current-partial',
+      text: 'Working.', state: 'streaming', responseExchangeId: 'exchange_current', responseWorkingId: 'working_current' }
+  ]);
+  const observed = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, messageId: 'old-final', text: 'Old answer.', state: 'final', final: true,
+    activeNow: true, responseExchangeId: 'exchange_old', responseWorkingId: 'working_old'
+  }]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('current-turn');
+  expect(observed.activity.terminal).toBe(false);
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(0);
+});
+
+it('fails closed when one local turn has contradictory response branches', async () => {
+  const conversationId = 'ambiguous-response-branches';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'current-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'current-turn', messageId: 'first-branch',
+      text: 'First.', state: 'streaming', responseExchangeId: 'exchange_one', responseWorkingId: 'working_one' },
+    { kind: 'assistant_message', time: 12, turnId: 'current-turn', messageId: 'second-branch',
+      text: 'Second.', state: 'streaming', responseExchangeId: 'exchange_two', responseWorkingId: 'working_two' }
+  ]);
+  await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests();
+  await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, turnId: 'replacement-page-turn', messageId: 'ambiguous-final', text: 'Answer.', state: 'final', final: true,
+    activeNow: true, responseExchangeId: 'exchange_one', responseWorkingId: 'working_one'
+  }]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('current-turn');
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(0);
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] })).at(-1)).not.toHaveProperty('turnId');
+});
+
+it('persists canonical response-branch ambiguity across restart', async () => {
+  const conversationId = 'canonical-response-branch-ambiguity';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'current-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'current-turn', messageId: 'canonical-answer',
+      providerMessageId: 'canonical-provider', text: 'First.', state: 'streaming',
+      responseExchangeId: 'exchange_a', responseWorkingId: 'working_a' },
+    { kind: 'assistant_message', time: 12, turnId: 'current-turn', messageId: 'provider-alias-remount',
+      providerMessageId: 'canonical-provider', text: 'Second.', state: 'streaming',
+      responseExchangeId: 'exchange_b', responseWorkingId: 'working_b' }
+  ]);
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] }))[0]).toMatchObject({
+    responseExchangeId: 'exchange_a', responseWorkingId: 'working_a', responseBranchAmbiguous: true
+  });
+  await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests();
+  await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, turnId: 'replacement-page-turn', messageId: 'distinct-final',
+    providerMessageId: 'distinct-provider', text: 'Completed.', state: 'final', final: true, activeNow: true,
+    responseExchangeId: 'exchange_b', responseWorkingId: 'working_b'
+  }]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('current-turn');
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(0);
+});
+
+it('does not close or enqueue the contradictory canonical revision that creates ambiguity', async () => {
+  const conversationId = 'canonical-final-creates-ambiguity';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'current-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'current-turn', messageId: 'canonical-answer',
+      providerMessageId: 'canonical-provider', text: 'Working.', state: 'streaming',
+      responseExchangeId: 'exchange_a', responseWorkingId: 'working_a' }
+  ]);
+  const observed = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, turnId: 'replacement-page-turn', messageId: 'provider-alias-remount',
+    providerMessageId: 'canonical-provider', text: 'Contradictory final.', state: 'final', final: true,
+    activeNow: true, goalEligible: true, responseExchangeId: 'exchange_b', responseWorkingId: 'working_b'
+  }]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('current-turn');
+  expect(observed.goalCandidates).toEqual([]);
+  expect(observed.activity.terminal).toBe(false);
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(0);
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] }))[0]).toMatchObject({
+    turnId: 'current-turn', responseBranchAmbiguous: true
+  });
+});
+
+it.each([
+  ['final-before-conflict', 'provider-alias'],
+  ['conflict-before-final', 'provider-alias'],
+  ['final-before-conflict', 'distinct-message'],
+  ['conflict-before-final', 'distinct-message']
+] as const)(
+  'fails closed for whole-batch response ambiguity (%s, %s)',
+  async (order, conflictKind) => {
+    const conversationId = `whole-batch-ambiguity-${order}-${conflictKind}`;
+    const branchA = { responseExchangeId: 'exchange_a', responseWorkingId: 'working_a' };
+    const branchB = { responseExchangeId: 'exchange_b', responseWorkingId: 'working_b' };
+    const opened = await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 10, turnId: 'current-turn' },
+      { kind: 'assistant_message', time: 11, turnId: 'current-turn', messageId: 'canonical-partial',
+        providerMessageId: 'canonical-provider', text: 'Working.', state: 'streaming', ...branchA }
+    ]);
+    const final = { kind: 'assistant_message' as const, time: 20, turnId: 'replacement-page-turn',
+      messageId: 'safe-final-remount', providerMessageId: 'canonical-provider', text: 'Completed.',
+      state: 'final' as const, final: true, activeNow: true, goalEligible: true, ...branchA };
+    const conflict = { kind: 'assistant_message' as const, time: 21, turnId: 'replacement-page-turn',
+      messageId: 'conflicting-snapshot',
+      providerMessageId: conflictKind === 'provider-alias' ? 'canonical-provider' : 'distinct-provider',
+      text: 'Contradictory branch.', state: 'streaming' as const, activeNow: true, ...branchB };
+    const observed = await recordChatObservations(conversationId,
+      order === 'final-before-conflict' ? [final, conflict] : [conflict, final]);
+    expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('current-turn');
+    expect(observed.goalCandidates).toEqual([]);
+    expect(observed.activity.terminal).toBe(false);
+    expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(0);
+  }
+);
+
+it.each(['active-final-before-inactive-conflict', 'inactive-conflict-before-active-final'] as const)(
+  'retracts provisional recovery when canonical ambiguity appears later in batch order: %s',
+  async order => {
+    const conversationId = `post-upsert-batch-ambiguity-${order}`;
+    const branchA = { responseExchangeId: 'exchange_a', responseWorkingId: 'working_a' };
+    const branchB = { responseExchangeId: 'exchange_b', responseWorkingId: 'working_b' };
+    const opened = await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 10, turnId: 'current-turn' },
+      { kind: 'assistant_message', time: 11, turnId: 'current-turn', messageId: 'canonical-answer',
+        providerMessageId: 'canonical-provider', text: 'Working.', state: 'streaming', ...branchA }
+    ]);
+    const final = { kind: 'assistant_message' as const, time: 20, turnId: 'replacement-page-turn',
+      messageId: 'active-final-remount', providerMessageId: 'canonical-provider', text: 'Completed.',
+      state: 'final' as const, final: true, activeNow: true, goalEligible: true, ...branchA };
+    const conflict = { kind: 'assistant_message' as const, time: 21, turnId: 'historical-page-turn',
+      messageId: 'inactive-provider-alias', providerMessageId: 'canonical-provider', text: 'Contradictory final.',
+      state: 'final' as const, final: true, activeNow: false, ...branchB };
+    const observed = await recordChatObservations(conversationId,
+      order === 'active-final-before-inactive-conflict' ? [final, conflict] : [conflict, final]);
+    expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('current-turn');
+    expect(observed.goalCandidates).toEqual([]);
+    expect(observed.activity.terminal).toBe(false);
+    expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(0);
+  }
+);
+
+it('retracts an unowned uncertain-end final when a later alias makes its durable turn ambiguous', async () => {
+  const conversationId = 'unowned-uncertain-final-before-alias-conflict';
+  const branchA = { responseExchangeId: 'exchange_a', responseWorkingId: 'working_a' };
+  const branchB = { responseExchangeId: 'exchange_b', responseWorkingId: 'working_b' };
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'current-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'current-turn', messageId: 'canonical-answer',
+      providerMessageId: 'canonical-provider', text: 'Working.', state: 'streaming', ...branchA }
+  ]);
+  const unownedFinal = { kind: 'assistant_message' as const, time: 20, messageId: 'unowned-final',
+    providerMessageId: 'unowned-provider', text: 'Apparently complete.', state: 'final' as const, final: true };
+  const observed = await recordChatObservations(conversationId, [
+    unownedFinal,
+    { kind: 'assistant_message', time: 21, turnId: 'current-turn', messageId: 'provider-alias-conflict',
+      providerMessageId: 'canonical-provider', text: 'Conflicting branch.', state: 'final', final: true,
+      activeNow: false, ...branchB },
+    { kind: 'turn_end', time: 22, turnId: 'current-turn', outcome: 'unknown' }
+  ]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBeNull();
+  expect(observed.goalCandidates).toEqual([]);
+  expect(observed.activity.terminal).toBe(false);
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] }))
+    .find(event => event.kind === 'assistant_message' && event.messageId === 'unowned-final'))
+    .not.toHaveProperty('goalEligible');
+
+  await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests();
+  const replay = await recordChatObservations(conversationId, [unownedFinal]);
+  expect(replay.goalCandidates).toEqual([]);
+  expect(replay.activity.terminal).toBe(false);
+});
+
+it('finds a distinct canonical branch conflict even after an uncertain end clears live ownership', async () => {
+  const conversationId = 'distinct-branch-after-uncertain-end';
+  const branchA = { responseExchangeId: 'exchange_a', responseWorkingId: 'working_a' };
+  const branchB = { responseExchangeId: 'exchange_b', responseWorkingId: 'working_b' };
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'current-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'current-turn', messageId: 'canonical-answer',
+      providerMessageId: 'canonical-provider', text: 'Working.', state: 'streaming', ...branchA }
+  ]);
+  const activeFinal = { kind: 'assistant_message' as const, time: 20, turnId: 'current-turn',
+    messageId: 'canonical-answer', providerMessageId: 'canonical-provider', text: 'Apparently complete.',
+    state: 'final' as const, final: true, activeNow: true, goalEligible: true, ...branchA };
+  const observed = await recordChatObservations(conversationId, [
+    activeFinal,
+    { kind: 'turn_end', time: 21, turnId: 'current-turn', outcome: 'unknown' },
+    { kind: 'assistant_message', time: 22, turnId: 'current-turn', messageId: 'distinct-conflict',
+      providerMessageId: 'distinct-provider', text: 'Another branch.', state: 'final', final: true,
+      activeNow: false, ...branchB }
+  ]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBeNull();
+  expect(observed.goalCandidates).toEqual([]);
+  expect(observed.activity.terminal).toBe(false);
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] }))
+    .find(event => event.kind === 'assistant_message' && event.messageId === 'canonical-answer'))
+    .not.toHaveProperty('goalEligible');
+
+  await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests();
+  const replay = await recordChatObservations(conversationId, [activeFinal]);
+  expect(replay.goalCandidates).toEqual([]);
+  expect(replay.activity.terminal).toBe(false);
+});
+
+it('promotes Goal eligibility on the latest canonical final without restoring older text', async () => {
+  const conversationId = 'latest-final-survives-deferred-eligibility';
+  const branch = { responseExchangeId: 'exchange_a', responseWorkingId: 'working_a' };
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'current-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'current-turn', messageId: 'canonical-answer',
+      providerMessageId: 'canonical-provider', text: 'Working.', state: 'streaming', ...branch }
+  ]);
+  const observed = await recordChatObservations(conversationId, [
+    { kind: 'assistant_message', time: 20, turnId: 'current-turn', messageId: 'canonical-answer',
+      providerMessageId: 'canonical-provider', text: 'Earlier final.', state: 'final', final: true,
+      activeNow: true, goalEligible: true, ...branch },
+    { kind: 'assistant_message', time: 21, turnId: 'current-turn', messageId: 'canonical-answer',
+      providerMessageId: 'canonical-provider', text: 'Later complete final.', state: 'final', final: true,
+      activeNow: false, ...branch }
+  ]);
+  expect(observed.goalCandidates).toHaveLength(1);
+  expect(observed.activity.terminal).toBe(true);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBeNull();
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] }))[0]).toMatchObject({
+    message: { text: 'Later complete final.' }, goalEligible: true
+  });
+});
+
+it('fences ambiguity for an uncertain turn that starts and ends in one observation batch', async () => {
+  const conversationId = 'same-batch-fresh-uncertain-ambiguity';
+  const unownedFinal = { kind: 'assistant_message' as const, time: 20, messageId: 'unowned-final',
+    providerMessageId: 'unowned-provider', text: 'Apparently complete.', state: 'final' as const, final: true };
+  const observed = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'fresh-turn' },
+    unownedFinal,
+    { kind: 'assistant_message', time: 21, turnId: 'fresh-turn', messageId: 'branch-a',
+      providerMessageId: 'provider-a', text: 'Branch A.', state: 'final', final: true,
+      responseExchangeId: 'exchange_a', responseWorkingId: 'working_a' },
+    { kind: 'assistant_message', time: 22, turnId: 'fresh-turn', messageId: 'branch-b',
+      providerMessageId: 'provider-b', text: 'Branch B.', state: 'final', final: true,
+      responseExchangeId: 'exchange_b', responseWorkingId: 'working_b' },
+    { kind: 'turn_end', time: 23, turnId: 'fresh-turn', outcome: 'unknown' }
+  ]);
+  expect(observed.goalCandidates).toEqual([]);
+  expect(observed.activity.terminal).toBe(false);
+  expect((await readEvents(observed.sessionId!, { kinds: ['assistant_message'] }))
+    .find(event => event.kind === 'assistant_message' && event.messageId === 'unowned-final'))
+    .not.toHaveProperty('goalEligible');
+});
+
+it.each([
+  ['user-first', false], ['final-first', false], ['user-first', true], ['final-first', true]
+] as const)(
+  'a fresh user supersedes prior uncertain recovery (%s, restart=%s)',
+  async (order, restart) => {
+    const conversationId = `fresh-user-supersedes-prior-uncertain-${order}-${restart}`;
+    await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 10, turnId: 'old-turn' },
+      { kind: 'turn_end', time: 20, turnId: 'old-turn', outcome: 'unknown' }
+    ]);
+    if (restart) { await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests(); }
+    const user = { kind: 'user_message' as const, time: 30, messageId: 'new-user',
+      text: 'This is new work.', authoredNow: true };
+    const final = { kind: 'assistant_message' as const, time: 31, messageId: 'late-old-final',
+      providerMessageId: 'late-old-provider', text: 'Late old answer.', state: 'final' as const, final: true };
+    const observed = await recordChatObservations(conversationId,
+      order === 'user-first' ? [user, final] : [final, user]);
+    expect(observed.goalCandidates).toEqual([]);
+    expect(observed.activity.terminal).toBe(false);
+  }
+);
+
+it('does not mistake the opening user of a same-batch uncertain turn for superseding work', async () => {
+  const conversationId = 'same-batch-opening-user-is-not-supersession';
+  const observed = await recordChatObservations(conversationId, [
+    { kind: 'user_message', time: 5, turnId: 'fresh-turn', messageId: 'opening-user',
+      text: 'Do this work.', authoredNow: true },
+    { kind: 'turn_start', time: 10, turnId: 'fresh-turn' },
+    { kind: 'assistant_message', time: 20, messageId: 'fresh-final', providerMessageId: 'fresh-provider',
+      text: 'Completed.', state: 'final', final: true },
+    { kind: 'turn_end', time: 21, turnId: 'fresh-turn', outcome: 'unknown' }
+  ]);
+  expect(observed.goalCandidates).toEqual([expect.objectContaining({
+    replyId: 'fresh-final', turnId: 'reply:fresh-final'
+  })]);
+});
+
+it.each([
+  ['without-user', 'start-before-final', false], ['with-user', 'start-before-final', false],
+  ['without-user', 'final-before-start', false], ['with-user', 'final-before-start', false],
+  ['without-user', 'start-before-final', true], ['with-user', 'start-before-final', true],
+  ['without-user', 'final-before-start', true], ['with-user', 'final-before-start', true]
+] as const)(
+  'recovers a fresh unbound branch without reviving a stale open turn (%s, %s, restart=%s)',
+  async (userMode, order, restart) => {
+    const conversationId = `fresh-turn-after-stale-open-${userMode}-${order}-${restart}`;
+    const opened = await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 1, turnId: 'stale-open-turn' },
+      { kind: 'assistant_message', time: 2, turnId: 'stale-open-turn', messageId: 'stale-partial',
+        providerMessageId: 'stale-provider', text: 'Old work.', state: 'streaming',
+        responseExchangeId: 'exchange_old', responseWorkingId: 'working_old' }
+    ]);
+    if (restart) { await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests(); }
+    const openingUser = userMode === 'with-user' ? [{ kind: 'user_message' as const, time: 5,
+      turnId: 'fresh-turn', messageId: 'opening-user', text: 'New work.', authoredNow: true }] : [];
+    const start = { kind: 'turn_start' as const, time: 10, turnId: 'fresh-turn' };
+    const final = { kind: 'assistant_message' as const, time: 20, messageId: 'fresh-final',
+      providerMessageId: 'fresh-provider', text: 'Completed.', state: 'final' as const, final: true,
+      activeNow: true, responseExchangeId: 'exchange_new', responseWorkingId: 'working_new' };
+    const end = { kind: 'turn_end' as const, time: 21, turnId: 'fresh-turn', outcome: 'unknown' as const };
+    const observations = order === 'start-before-final'
+      ? [...openingUser, start, final, end]
+      : [...openingUser, final, start, end];
+    const observed = await recordChatObservations(conversationId, observations);
+    expect(observed.goalCandidates).toEqual([expect.objectContaining({
+      replyId: 'fresh-final', turnId: 'reply:fresh-final'
+    })]);
+    expect(observed.activity.terminal).toBe(true);
+    expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toEqual([
+      expect.objectContaining({ turnId: 'fresh-turn', outcome: 'unknown' })
+    ]);
+  }
+);
+
+it.each(['start-before-final', 'final-before-start'] as const)(
+  'does not mix a stale open branch with a fresh explicit turn branch (%s)',
+  async order => {
+    const conversationId = `fresh-explicit-branch-after-stale-open-${order}`;
+    const opened = await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 1, turnId: 'stale-open-turn' },
+      { kind: 'assistant_message', time: 2, turnId: 'stale-open-turn', messageId: 'stale-partial',
+        providerMessageId: 'stale-provider', text: 'Old work.', state: 'streaming',
+        responseExchangeId: 'exchange_old', responseWorkingId: 'working_old' }
+    ]);
+    const start = { kind: 'turn_start' as const, time: 10, turnId: 'fresh-turn' };
+    const final = { kind: 'assistant_message' as const, time: 20, turnId: 'fresh-turn',
+      messageId: 'fresh-final', providerMessageId: 'fresh-provider', text: 'New completion.',
+      state: 'final' as const, final: true, activeNow: true, goalEligible: true,
+      responseExchangeId: 'exchange_new', responseWorkingId: 'working_new' };
+    const end = { kind: 'turn_end' as const, time: 21, turnId: 'fresh-turn', outcome: 'completed' as const };
+    const observed = await recordChatObservations(conversationId,
+      order === 'start-before-final' ? [start, final, end] : [final, start, end]);
+    expect(observed.goalCandidates).toEqual([expect.objectContaining({
+      replyId: 'fresh-final', turnId: 'fresh-turn'
+    })]);
+    expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toEqual([
+      expect.objectContaining({ turnId: 'fresh-turn', outcome: 'completed' })
+    ]);
+  }
+);
+
+it.each([
+  ['provider-alias', 'start-before-final', false], ['matching-branch', 'start-before-final', false],
+  ['provider-alias', 'final-before-start', false], ['matching-branch', 'final-before-start', false],
+  ['provider-alias', 'start-before-final', true], ['matching-branch', 'start-before-final', true],
+  ['provider-alias', 'final-before-start', true], ['matching-branch', 'final-before-start', true]
+] as const)(
+  'does not assign an old canonical answer to a fresh uncertain turn (%s, %s, restart=%s)',
+  async (identity, order, restart) => {
+    const conversationId = `old-canonical-inside-fresh-turn-${identity}-${order}-${restart}`;
+    const branch = { responseExchangeId: 'exchange_old', responseWorkingId: 'working_old' };
+    const opened = await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 1, turnId: 'stale-open-turn' },
+      { kind: 'assistant_message', time: 2, turnId: 'stale-open-turn', messageId: 'old-answer',
+        providerMessageId: 'old-provider', text: 'Old work.', state: 'streaming', ...branch }
+    ]);
+    if (restart) { await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests(); }
+    const start = { kind: 'turn_start' as const, time: 10, turnId: 'fresh-turn' };
+    const oldFinal = { kind: 'assistant_message' as const, time: 20,
+      messageId: identity === 'provider-alias' ? 'old-answer-remount' : 'old-answer-distinct',
+      providerMessageId: identity === 'provider-alias' ? 'old-provider' : 'old-provider-distinct',
+      text: 'Old completion remounted.', state: 'final' as const, final: true,
+      activeNow: true, goalEligible: true,
+      ...(identity === 'matching-branch' ? branch : {}) };
+    const end = { kind: 'turn_end' as const, time: 21, turnId: 'fresh-turn', outcome: 'unknown' as const };
+    const observed = await recordChatObservations(conversationId,
+      order === 'start-before-final' ? [start, oldFinal, end] : [oldFinal, start, end]);
+    expect(observed.goalCandidates).toEqual([]);
+    expect(observed.activity.terminal).toBe(false);
+    expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toEqual([
+      expect.objectContaining({ turnId: 'fresh-turn', outcome: 'unknown' })
+    ]);
+  }
+);
+
+it.each([
+  ['direct-id', false], ['provider-alias', false], ['direct-id', true], ['provider-alias', true]
+] as const)(
+  'does not enqueue an old canonical final under a newer live turn (%s, restart=%s)',
+  async (identity, restart) => {
+    const conversationId = `old-canonical-under-new-live-${identity}-${restart}`;
+    const opened = await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 1, turnId: 'old-turn' },
+      { kind: 'assistant_message', time: 2, turnId: 'old-turn', messageId: 'old-answer',
+        providerMessageId: 'old-provider', text: 'Old completion.', state: 'final', final: true },
+      { kind: 'turn_end', time: 3, turnId: 'old-turn', outcome: 'completed' }
+    ]);
+    await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 10, turnId: 'new-turn' }
+    ]);
+    if (restart) { await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests(); }
+    const observed = await recordChatObservations(conversationId, [{
+      kind: 'assistant_message', time: 20, turnId: 'new-turn',
+      messageId: identity === 'direct-id' ? 'old-answer' : 'old-answer-remount',
+      providerMessageId: 'old-provider', text: 'Old completion remounted.', state: 'final', final: true,
+      activeNow: true, goalEligible: true
+    }]);
+    expect(observed.goalCandidates).toEqual([]);
+    expect(observed.activity.terminal).toBe(false);
+    expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('new-turn');
+  }
+);
+
+it.each([false, true])(
+  'does not re-emit persisted eligibility from an unbound old answer while a newer turn is live (restart=%s)',
+  async restart => {
+    const conversationId = `persisted-old-eligibility-under-new-live-${restart}`;
+    const oldFinal = { kind: 'assistant_message' as const, time: 2, turnId: 'old-turn',
+      messageId: 'old-answer', providerMessageId: 'old-provider', text: 'Old completion.',
+      state: 'final' as const, final: true, goalEligible: true };
+    const opened = await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 1, turnId: 'old-turn' },
+      oldFinal,
+      { kind: 'turn_end', time: 3, turnId: 'old-turn', outcome: 'completed' }
+    ]);
+    expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] }))[0])
+      .toMatchObject({ goalEligible: true });
+    await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 10, turnId: 'new-turn' }
+    ]);
+    if (restart) { await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests(); }
+    const observed = await recordChatObservations(conversationId, [{
+      ...oldFinal, time: 20, turnId: undefined, activeNow: true, goalEligible: undefined
+    }]);
+    expect(observed.goalCandidates).toEqual([]);
+    expect(observed.activity.terminal).toBe(false);
+    expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('new-turn');
+  }
+);
+
+it.each([
+  ['same-branch', false], ['different-branch', false],
+  ['same-branch', true], ['different-branch', true]
+] as const)(
+  'checks an unbound final against the prior uncertain turn branch (%s, restart=%s)',
+  async (branchMode, restart) => {
+    const conversationId = `prior-uncertain-unbound-branch-${branchMode}-${restart}`;
+    const branchA = { responseExchangeId: 'exchange_a', responseWorkingId: 'working_a' };
+    const branchB = { responseExchangeId: 'exchange_b', responseWorkingId: 'working_b' };
+    const opened = await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 10, turnId: 'uncertain-turn' },
+      { kind: 'assistant_message', time: 11, turnId: 'uncertain-turn', messageId: 'partial',
+        providerMessageId: 'partial-provider', text: 'Working.', state: 'streaming', ...branchA },
+      { kind: 'turn_end', time: 12, turnId: 'uncertain-turn', outcome: 'unknown' }
+    ]);
+    if (restart) { await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests(); }
+    const observed = await recordChatObservations(conversationId, [{
+      kind: 'assistant_message', time: 20, messageId: 'distinct-final',
+      providerMessageId: 'distinct-provider', text: 'Completed.', state: 'final', final: true,
+      activeNow: true, ...(branchMode === 'same-branch' ? branchA : branchB)
+    }]);
+    if (branchMode === 'same-branch') {
+      expect(observed.goalCandidates).toEqual([expect.objectContaining({
+        replyId: 'distinct-final', turnId: 'reply:distinct-final'
+      })]);
+      expect(observed.activity.terminal).toBe(true);
+    } else {
+      expect(observed.goalCandidates).toEqual([]);
+      expect(observed.activity.terminal).toBe(false);
+      expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] }))
+        .find(event => event.kind === 'assistant_message' && event.messageId === 'distinct-final'))
+        .not.toHaveProperty('goalEligible');
+    }
+  }
+);
+
+it('keeps an unbound branch-conflict fence durable across a second restart', async () => {
+  const conversationId = 'prior-uncertain-unbound-conflict-second-restart';
+  const branchA = { responseExchangeId: 'exchange_a', responseWorkingId: 'working_a' };
+  const branchB = { responseExchangeId: 'exchange_b', responseWorkingId: 'working_b' };
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'uncertain-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'uncertain-turn', messageId: 'owned-anchor',
+      providerMessageId: 'owned-provider', text: 'Working.', state: 'streaming', ...branchA },
+    { kind: 'turn_end', time: 12, turnId: 'uncertain-turn', outcome: 'unknown' }
+  ]);
+  const rejected = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, messageId: 'unbound-conflict',
+    providerMessageId: 'unbound-provider', text: 'Contradictory final.', state: 'final', final: true,
+    activeNow: true, ...branchB
+  }]);
+  expect(rejected.goalCandidates).toEqual([]);
+  expect(rejected.activity.terminal).toBe(false);
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] }))
+    .find(event => event.kind === 'assistant_message' && event.messageId === 'owned-anchor'))
+    .toMatchObject({ responseBranchAmbiguous: true });
+
+  await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests();
+  const replay = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 30, messageId: 'unbound-same-branch-after-restart',
+    providerMessageId: 'unbound-same-provider', text: 'Looks consistent in isolation.',
+    state: 'final', final: true, activeNow: true, ...branchA
+  }]);
+  expect(replay.goalCandidates).toEqual([]);
+  expect(replay.activity.terminal).toBe(false);
+});
+
+it('restores the latest published uncertain turn when end timestamps arrive out of order', async () => {
+  const conversationId = 'latest-published-uncertain-end';
+  const olderBranch = { responseExchangeId: 'exchange_old', responseWorkingId: 'working_old' };
+  const latestBranch = { responseExchangeId: 'exchange_latest', responseWorkingId: 'working_latest' };
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'older-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'older-turn', messageId: 'older-partial',
+      providerMessageId: 'older-provider', text: 'Older work.', state: 'streaming', ...olderBranch },
+    { kind: 'turn_end', time: 100, turnId: 'older-turn', outcome: 'unknown' },
+    { kind: 'turn_start', time: 20, turnId: 'latest-turn' },
+    { kind: 'assistant_message', time: 21, turnId: 'latest-turn', messageId: 'latest-partial',
+      providerMessageId: 'latest-provider', text: 'Latest work.', state: 'streaming', ...latestBranch },
+    // Delayed publication: this is the latest journal event despite its earlier timestamp.
+    { kind: 'turn_end', time: 30, turnId: 'latest-turn', outcome: 'unknown' }
+  ]);
+  await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests();
+
+  const observed = await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 110, messageId: 'latest-final',
+    providerMessageId: 'latest-final-provider', text: 'Latest work completed.',
+    state: 'final', final: true, activeNow: true, ...latestBranch
+  }]);
+
+  expect(observed.activity.terminal).toBe(true);
+  expect(observed.goalCandidates).toEqual([expect.objectContaining({
+    replyId: 'latest-final', turnId: 'reply:latest-final'
+  })]);
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] }))
+    .find(event => event.kind === 'assistant_message' && event.messageId === 'latest-final'))
+    .toMatchObject({ responseExchangeId: latestBranch.responseExchangeId });
+});
+
+it.each(['branch ambiguity', 'fresh user'] as const)(
+  'does not re-emit persisted Goal eligibility through later %s',
+  async hazard => {
+    const conversationId = `persisted-goal-eligibility-${hazard}`;
+    const turnId = 'reopened-turn';
+    const branch = { responseExchangeId: 'exchange_a', responseWorkingId: 'working_a' };
+    const opened = await recordChatObservations(conversationId, [
+      { kind: 'turn_start', time: 10, turnId },
+      { kind: 'assistant_message', time: 11, turnId, messageId: 'canonical-answer',
+        providerMessageId: 'canonical-provider', text: 'Working.', state: 'streaming', ...branch }
+    ]);
+    const first = await recordChatObservations(conversationId, [{
+      kind: 'assistant_message', time: 20, turnId, messageId: 'canonical-answer',
+      providerMessageId: 'canonical-provider', text: 'First final.', state: 'final', final: true,
+      goalEligible: true, ...branch
+    }]);
+    expect(first.goalCandidates).toHaveLength(1);
+    await appendEvent(opened.sessionId!, {
+      kind: 'turn_start', source: 'app', time: 30, turnId, detail: 'late work reopened this turn'
+    });
+    await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests();
+
+    const final = hazard === 'branch ambiguity'
+      ? { kind: 'assistant_message' as const, time: 40, turnId: 'replacement-page-turn',
+          messageId: 'provider-alias-remount', providerMessageId: 'canonical-provider',
+          text: 'Contradictory final.', state: 'final' as const, final: true, activeNow: true,
+          responseExchangeId: 'exchange_b', responseWorkingId: 'working_b' }
+      : { kind: 'assistant_message' as const, time: 40, turnId,
+          messageId: 'canonical-answer', providerMessageId: 'canonical-provider',
+          text: 'First final.', state: 'final' as const, final: true, ...branch };
+    const observations = hazard === 'fresh user'
+      ? [{ kind: 'user_message' as const, time: 41, messageId: 'new-user', text: 'New work', authoredNow: true }, final]
+      : [final];
+    const observed = await recordChatObservations(conversationId, observations);
+    expect((await getSession(opened.sessionId!))?.activeTurnId).toBe(turnId);
+    expect(observed.goalCandidates).toEqual([]);
+    expect(observed.activity.terminal).toBe(false);
+  }
+);
+
+it('ignores a replayed known turn start while recovering the current exact branch', async () => {
+  const conversationId = 'stale-start-with-current-final';
+  const branch = { responseExchangeId: 'exchange_current', responseWorkingId: 'working_current' };
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 1, turnId: 'old-turn' },
+    { kind: 'turn_end', time: 2, turnId: 'old-turn', outcome: 'completed' },
+    { kind: 'turn_start', time: 10, turnId: 'current-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'current-turn', messageId: 'current-partial',
+      providerMessageId: 'current-provider', text: 'Working.', state: 'streaming', ...branch }
+  ]);
+  const observed = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 1, turnId: 'old-turn' },
+    { kind: 'assistant_message', time: 20, turnId: 'replacement-page-turn', messageId: 'current-final',
+      providerMessageId: 'current-final-provider', text: 'Completed.', state: 'final', final: true,
+      activeNow: true, goalEligible: true, ...branch }
+  ]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBeNull();
+  expect(observed.activity.endedTurnId).toBe('current-turn');
+  expect(observed.goalCandidates).toHaveLength(1);
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(2);
+});
+
+it('ignores a replayed authored user row while recovering the current exact branch', async () => {
+  const conversationId = 'replayed-user-with-current-final';
+  const branch = { responseExchangeId: 'exchange_current', responseWorkingId: 'working_current' };
+  const user = { kind: 'user_message' as const, time: 5, turnId: 'current-turn',
+    messageId: 'current-user', text: 'Original request', authoredNow: true };
+  const opened = await recordChatObservations(conversationId, [
+    user,
+    { kind: 'turn_start', time: 10, turnId: 'current-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'current-turn', messageId: 'current-partial',
+      providerMessageId: 'current-provider', text: 'Working.', state: 'streaming', ...branch }
+  ]);
+  const observed = await recordChatObservations(conversationId, [
+    user,
+    { kind: 'assistant_message', time: 20, turnId: 'replacement-page-turn', messageId: 'current-final',
+      providerMessageId: 'current-final-provider', text: 'Completed.', state: 'final', final: true,
+      activeNow: true, goalEligible: true, ...branch }
+  ]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBeNull();
+  expect(observed.activity.endedTurnId).toBe('current-turn');
+  expect(observed.goalCandidates).toHaveLength(1);
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(1);
+});
+
+it('uses the last fresh uncertain end when a later uncertain end is only a replay', async () => {
+  const conversationId = 'fresh-uncertain-before-replayed-uncertain';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 1, turnId: 'known-ended-turn' },
+    { kind: 'turn_end', time: 2, turnId: 'known-ended-turn', outcome: 'unknown' },
+    { kind: 'turn_start', time: 10, turnId: 'current-turn' }
+  ]);
+  const observed = await recordChatObservations(conversationId, [
+    { kind: 'turn_end', time: 15, turnId: 'current-turn', outcome: 'unknown' },
+    { kind: 'turn_end', time: 2, turnId: 'known-ended-turn', outcome: 'unknown' },
+    { kind: 'assistant_message', time: 20, messageId: 'current-final', providerMessageId: 'current-provider',
+      text: 'Completed after the uncertain edge.', state: 'final', final: true }
+  ]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBeNull();
+  expect(observed.goalCandidates).toEqual([expect.objectContaining({
+    replyId: 'current-final', turnId: 'reply:current-final'
+  })]);
+});
+
+it('never synthesizes a recoverable response branch from contradictory partial identity', async () => {
+  const conversationId = 'partial-response-identity-ambiguity';
+  const opened = await recordChatObservations(conversationId, [
+    { kind: 'turn_start', time: 10, turnId: 'current-turn' },
+    { kind: 'assistant_message', time: 11, turnId: 'current-turn', messageId: 'canonical-answer',
+      providerMessageId: 'canonical-provider', text: 'First.', state: 'streaming', responseExchangeId: 'exchange_a' },
+    { kind: 'assistant_message', time: 12, turnId: 'current-turn', messageId: 'canonical-answer',
+      providerMessageId: 'canonical-provider', text: 'Second.', state: 'streaming',
+      responseExchangeId: 'exchange_b', responseWorkingId: 'working_b' }
+  ]);
+  expect((await readEvents(opened.sessionId!, { kinds: ['assistant_message'] }))[0]).toMatchObject({
+    responseExchangeId: 'exchange_b', responseWorkingId: 'working_b', responseBranchAmbiguous: true
+  });
+  await flushSessions(); resetRecorderForTests(); resetSessionStoreForTests();
+  await recordChatObservations(conversationId, [{
+    kind: 'assistant_message', time: 20, turnId: 'replacement-page-turn', messageId: 'distinct-final',
+    providerMessageId: 'distinct-provider', text: 'Completed.', state: 'final', final: true, activeNow: true,
+    responseExchangeId: 'exchange_b', responseWorkingId: 'working_b'
+  }]);
+  expect((await getSession(opened.sessionId!))?.activeTurnId).toBe('current-turn');
+  expect(await readEvents(opened.sessionId!, { kinds: ['turn_end'] })).toHaveLength(0);
 });
 
 it.each(['missing', 'current-page-id'])('never closes newer work from an old canonical answer with %s identity', async mode => {


### PR DESCRIPTION
## Summary
- persist ChatGPT native working/exchange response identity and use it to recover a distinct final after reload without trusting reused request IDs
- recognize the Plugins connector in both Fiber and content-script allowlists
- durably pause an unsent Goal/Loop continuation while ChatGPT blocks Pro traffic, using the observed Pro reset when available and a no-send recheck otherwise

## Safety
- exact Pro synthetic-silence continuation remains disabled
- retry/regenerate ambiguity fails closed when more than one provider response branch is bound
- quota handling never clicks Send while the provider blocking dialog remains visible

## Verification
- `npm run verify` (3,956 tests passed; 131 skipped)
- focused recovery/Goal/Fiber/bridge/content tests: 1,045 passed
- `npm run dist:linux:x64`

Fixes the reload-final class discussed in #109, #140, #147, #151, and #172 without reviving the request-set ownership approach from #175.