### PR TITLE
Clarify ChatGPT Work and Codex usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="docs/images/readme-hero.svg?v=2" width="960" alt="Turn ChatGPT into Codex without touching Codex limits. Chat On Steroids: Your files. Your terminal. Your ChatGPT plan." /></p>
+<p align="center"><img src="docs/images/readme-hero.svg?v=2" width="960" alt="Turn ChatGPT into Codex-style local coding. Chat On Steroids: Your files. Your terminal. Your ChatGPT plan." /></p>
 
 <p align="center">
   <a href="https://github.com/totec448-spec/chat-on-steroids/releases/latest/download/Chat-On-Steroids-Setup-x64.exe"><img src="docs/images/download-windows.svg" width="208" height="56" alt="Download for Windows x64" /></a>&nbsp;
@@ -24,7 +24,7 @@
 
 **Stay in control of long tasks.** Send a correction while work runs. Goal follows unfinished work; Loop keeps working within your brief. Compact & Resume carries the session and worker history into a fresh chat.
 
-<p align="center"><strong>Uses your ChatGPT conversation. Does not consume Codex quota.</strong><br /><sub>Your account’s model availability, usage and context limits still apply.</sub></p>
+<p align="center"><strong>Uses your ChatGPT conversation rather than invoking Codex directly.</strong><br /><sub>Regular Chat is separate from the shared Work/Codex allowance; ChatGPT Work uses that allowance. <a href="https://help.openai.com/en/articles/11369540">OpenAI usage details →</a></sub></p>
 
 <br />
 

--- a/docs/images/readme-hero.svg
+++ b/docs/images/readme-hero.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="330" viewBox="0 0 960 330" role="img" aria-labelledby="title desc">
-  <title id="title">Turn ChatGPT into Codex without touching Codex limits.</title>
-  <desc id="desc">Chat On Steroids. Only ChatGPT, no Codex quota. Your files. Your terminal. Your ChatGPT plan.</desc>
+  <title id="title">Turn ChatGPT into Codex-style local coding.</title>
+  <desc id="desc">Chat On Steroids. Your files. Your terminal. Your ChatGPT plan.</desc>
   <defs>
     <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
       <stop stop-color="#b0f4d8"/><stop offset="1" stop-color="#80caff"/>
@@ -15,7 +15,7 @@
     <text x="480" y="48" font-size="13" font-weight="700" letter-spacing="3.4" fill="#b3c1cc">CHAT ON STEROIDS</text>
     <text x="480" y="122" font-size="64" font-weight="900" letter-spacing="-2" fill="#f4f7fb">Turn ChatGPT</text>
     <text x="480" y="192" font-size="72" font-weight="900" letter-spacing="-2.5" fill="url(#accent)">into Codex.</text>
-    <text x="480" y="248" font-size="28" font-weight="700" fill="#f4f7fb">Without touching Codex limits.</text>
+    <text x="480" y="248" font-size="28" font-weight="700" fill="#f4f7fb">Powered by your ChatGPT conversation.</text>
     <text x="480" y="288" font-size="18" fill="#c5ced7">Your files. Your terminal. Your ChatGPT plan.</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

Clarify the README's Codex-usage wording so it distinguishes regular Chat from ChatGPT Work.

The previous copy said CoS "does not consume Codex quota" without qualification. CoS itself still uses the user's ChatGPT conversation rather than invoking Codex directly, but OpenAI documents that ChatGPT Work and Codex share the same usage allowance, while regular Chat is separate from those Work/Codex usage views.

This PR:
- replaces the absolute quota claim in the README with the Chat vs Work/Codex distinction;
- updates the matching hero copy/accessible text so the same absolute claim is not repeated there;
- links to OpenAI's usage documentation for the current policy.

Refs #190.

## Scope

Documentation only. No runtime, connector, permission, model-selection, or billing behavior changes.

## Validation

- Compared against current upstream `main` (`99ec069cfbe7aae01e2ba9ab234c237ffbf609ff`).
- Diff is limited to `README.md` and `docs/images/readme-hero.svg`.
- OpenAI usage documentation: https://help.openai.com/en/articles/20001516-managing-usage-with-gpt-6-astra-in-work-and-codex and https://help.openai.com/en/articles/20001275
