### PR TITLE
Fix reviewed turn recovery and plan usability for 2.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -748,6 +748,9 @@ editor/route identity and attachment changes still do.
 The witnessed Send receipt captures the pre-send assistant baseline. If app identity or native
 message source arrives after a fast reply has rendered, that question still owns its reply and
 exact final marker. A later observation must not classify its own answer as old history.
+An exact accepted fresh-chat receipt remains valid when native submit promotes its null
+conversation to the delivered conversation. The same receipt, message, epoch and send lifetime
+must still agree; a second navigation or replaced receipt cannot inherit that acceptance.
 While an exact send receipt still has a bounded evidence reader, the existing observation also
 requests canonical MAIN-world text even after native generation stops. Rendered Markdown can
 remove submitted bytes; recognizing the generation must not be a prerequisite for reading the
@@ -1026,6 +1029,8 @@ a different lifetime from MV3 suspension (§2).
 
 An idle composer or missing Stop button alone does not prove a completed answer. Turn state
 combines native message/terminal evidence with exact user/assistant identities and live tools.
+Adopted generation recovery excludes historical assistant nodes above the latest user question,
+even when hydration remounts them after its baseline. DOM novelty cannot reassign that answer.
 Interim prose, tool progress, refusal/error presentation, interrupted generation and final
 completion remain distinct. Navigation first retires the old epoch; no late callback may record
 or send for it. A settings overlay must not count as a usable hidden composer.
@@ -1471,6 +1476,8 @@ The sidebar groups local projects/sessions, exposes worker state and retains del
 and expansion preferences. The chat keeps the current input queue/plan visible alongside a
 paged transcript. Main owns durable mutation acknowledgements; renderer optimism is not a
 receipt. Native edit context menus respect the focused editable control and selection.
+The plan heading is a native disclosure with a visible open/closed chevron. Collapsing it
+returns height to the conversation; status updates preserve its current disclosure state.
 
 Session metadata owns `titleSource` (authored fallback, provider, manual). The preview uses only
 the first authored user message, at one 80-character bound; injected instructions/AGENTS frames

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,11 +33,34 @@ disabled-permission guidance from [#146](https://github.com/totec448-spec/chat-o
 The claim release was strengthened with durable command/document ownership; this does not
 incorporate the rest of the native Desktop proposal.
 
+The September 13 review confirms the incorporated bounded tab-reuse work from
+[@ventianima-lab](https://github.com/ventianima-lab) ([#144](https://github.com/totec448-spec/chat-on-steroids/pull/144),
+[#159](https://github.com/totec448-spec/chat-on-steroids/pull/159)), the stream-attribution design
+from [#170](https://github.com/totec448-spec/chat-on-steroids/pull/170), and
+[@nofihq](https://github.com/nofihq)'s fetch-reattachment follow-up. The implementation retains
+bounded server-metadata parsing and exact page ownership; this does not claim every attribution
+failure is resolved. Pinned-tab protection incorporates the proposals from
+[@Maximapple](https://github.com/Maximapple) ([#161](https://github.com/totec448-spec/chat-on-steroids/pull/161))
+and [@L4XB](https://github.com/L4XB) ([#158](https://github.com/totec448-spec/chat-on-steroids/pull/158)),
+with fresh pin checks at the existing close sites.
+[@pop15106](https://github.com/pop15106)'s [#192](https://github.com/totec448-spec/chat-on-steroids/pull/192)
+corrected the README and hero's absolute quota claim. The adapted wording describes CoS's Chat
+surface and links to OpenAI's current Work/Codex usage policy.
+
+Additional receipt-promotion and adopted-answer ownership fixes adapt
+[@ventianima-lab](https://github.com/ventianima-lab)'s minimal reproductions and proposed repairs
+in [#185](https://github.com/totec448-spec/chat-on-steroids/issues/185#issuecomment-5650663451)
+and its [remounted-answer follow-up](https://github.com/totec448-spec/chat-on-steroids/issues/185#issuecomment-5651819276).
+
 ## Reports, review and proposed work
 
 [@ventianima-lab](https://github.com/ventianima-lab)'s reproductions also led to the focused
 resume-selection ([#155](https://github.com/totec448-spec/chat-on-steroids/issues/155)) and Windows
 plugin-path ([#178](https://github.com/totec448-spec/chat-on-steroids/issues/178)) repairs.
+[@rcnir](https://github.com/rcnir) identified the unknown-model silence-recovery gap in
+[#172](https://github.com/totec448-spec/chat-on-steroids/issues/172), and
+[@Gauthammaster2012Code](https://github.com/Gauthammaster2012Code) reported the missing visible
+plan-collapse affordance in [#191](https://github.com/totec448-spec/chat-on-steroids/issues/191).
 
 Contributions also include reproductions, independent testing, designs and patches that are still under review or were superseded. Thank you to:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="docs/images/readme-hero.svg?v=2" width="960" alt="Turn ChatGPT into Codex without touching Codex limits. Chat On Steroids: Your files. Your terminal. Your ChatGPT plan." /></p>
+<p align="center"><img src="docs/images/readme-hero.svg?v=3" width="960" alt="Turn ChatGPT into Codex-style local coding. Chat On Steroids: Your files. Your terminal. Your ChatGPT plan." /></p>
 
 <p align="center">
   <a href="https://github.com/totec448-spec/chat-on-steroids/releases/latest/download/Chat-On-Steroids-Setup-x64.exe"><img src="docs/images/download-windows.svg" width="208" height="56" alt="Download for Windows x64" /></a>&nbsp;
@@ -24,7 +24,7 @@
 
 **Stay in control of long tasks.** Send a correction while work runs. Goal follows unfinished work; Loop keeps working within your brief. Compact & Resume carries the session and worker history into a fresh chat.
 
-<p align="center"><strong>Uses your ChatGPT conversation. Does not consume Codex quota.</strong><br /><sub>Your account’s model availability, usage and context limits still apply.</sub></p>
+<p align="center"><strong>Uses the Chat surface in ChatGPT without invoking Codex directly.</strong><br /><sub>Your account’s model availability, usage and context limits still apply. ChatGPT Work and Codex share usage — <a href="https://learn.chatgpt.com/docs/pricing">OpenAI usage details →</a></sub></p>
 
 <br />
 

--- a/docs/images/readme-hero.svg
+++ b/docs/images/readme-hero.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="330" viewBox="0 0 960 330" role="img" aria-labelledby="title desc">
-  <title id="title">Turn ChatGPT into Codex without touching Codex limits.</title>
-  <desc id="desc">Chat On Steroids. Only ChatGPT, no Codex quota. Your files. Your terminal. Your ChatGPT plan.</desc>
+  <title id="title">Turn ChatGPT into Codex-style local coding.</title>
+  <desc id="desc">Chat On Steroids. Your files. Your terminal. Your ChatGPT plan.</desc>
   <defs>
     <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
       <stop stop-color="#b0f4d8"/><stop offset="1" stop-color="#80caff"/>
@@ -15,7 +15,7 @@
     <text x="480" y="48" font-size="13" font-weight="700" letter-spacing="3.4" fill="#b3c1cc">CHAT ON STEROIDS</text>
     <text x="480" y="122" font-size="64" font-weight="900" letter-spacing="-2" fill="#f4f7fb">Turn ChatGPT</text>
     <text x="480" y="192" font-size="72" font-weight="900" letter-spacing="-2.5" fill="url(#accent)">into Codex.</text>
-    <text x="480" y="248" font-size="28" font-weight="700" fill="#f4f7fb">Without touching Codex limits.</text>
+    <text x="480" y="248" font-size="28" font-weight="700" fill="#f4f7fb">Powered by your ChatGPT conversation.</text>
     <text x="480" y="288" font-size="18" fill="#c5ced7">Your files. Your terminal. Your ChatGPT plan.</text>
   </g>
 </svg>

--- a/extension/content.js
+++ b/extension/content.js
@@ -1735,6 +1735,13 @@
    * whole point of this batch is that the local session log stops containing those.
    */
   function generationTurn(turns = CLF_DOM.turns()) {
+    // Hydration may remount an old answer with a new node after our baseline.
+    // An adopted generation still belongs after the latest question; DOM novelty
+    // above that boundary cannot establish or retain its assistant owner.
+    if (unwitnessedGeneration) {
+      const question = turns.findLastIndex(turn => turn.role === 'user');
+      if (question >= 0) turns = turns.slice(question + 1);
+    }
     if (genNode) {
       const held = turnForNode(genNode, turns);
       if (held) return held;
@@ -10378,7 +10385,8 @@
       const accepted = acknowledged?.data?.ok === true;
       if (accepted && deliveredConversation && receipt.user?.id && sendingTarget() &&
           userSendReceipt === witnessedSendReceipt && witnessedSendReceipt?.text === submittedText &&
-          witnessedSendReceipt.conversationId === target &&
+          (witnessedSendReceipt.conversationId === target ||
+            (!target && witnessedSendReceipt.conversationId === deliveredConversation)) &&
           (witnessedSendReceipt.previousMessageId ?? null) === (previousUserId ?? null) &&
           Date.now() - witnessedSendReceipt.at <= USER_SEND_RECEIPT_MS) {
         witnessedSendReceipt.accepted = { messageId: receipt.user.id, conversationId: deliveredConversation, epoch };

--- a/scripts/verify-plan-collapse.cjs
+++ b/scripts/verify-plan-collapse.cjs
@@ -1,0 +1,55 @@
+// Real Electron layout with the production renderer and CSS. No user session is loaded.
+const { app, BrowserWindow } = require('electron');
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert/strict');
+
+app.whenReady().then(async () => {
+  const { build } = await import('vite');
+  const bundle = await build({ configFile: false, logLevel: 'error', build: {
+    write: false, minify: false,
+    lib: { entry: path.join(__dirname, '../src/renderer/agent-plan.ts'), name: 'PlanProbe', formats: ['iife'] }
+  } });
+  const code = bundle[0].output.find(item => item.type === 'chunk').code;
+  const css = fs.readFileSync(path.join(__dirname, '../src/renderer/styles.css'), 'utf8');
+  const win = new BrowserWindow({ show: false, width: 1000, height: 760,
+    webPreferences: { sandbox: true, backgroundThrottling: false } });
+  await win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(`<style>${css}</style>
+    <div data-panel="chat" style="height:100vh"><section class="card is-session" style="height:100%">
+    <div class="subhead">Plan layout check</div><div id="chatBody" class="scroll"><div style="height:2000px">Conversation</div></div>
+    <div class="composer-dock"><section class="agent-plan" id="agentPlan"></section></div>
+    <form id="composer" class="composer"><textarea rows="1">A draft stays here</textarea></form><div id="chatFoot"></div>
+    </section></div><script>${code}</script>`));
+  const results = [];
+  for (const zoom of [1, 1.5]) {
+    win.webContents.setZoomFactor(zoom);
+    results.push(await win.webContents.executeJavaScript(`(async () => {
+      const host = document.getElementById('agentPlan');
+      const plan = { updatedAt: 1, plan: Array.from({length: 12}, (_, i) => ({step: 'Step ' + i, status: 'pending'})) };
+      PlanProbe.renderAgentPlan(host, 'layout', plan);
+      const shell = host.querySelector('details'); shell.open = true;
+      const heading = shell.querySelector('summary');
+      const body = document.getElementById('chatBody');
+      const expanded = body.clientHeight;
+      const openArrow = getComputedStyle(heading, '::after').transform;
+      heading.click();
+      await new Promise(requestAnimationFrame);
+      const collapsed = body.clientHeight;
+      const closedArrow = getComputedStyle(heading, '::after').transform;
+      PlanProbe.renderAgentPlan(host, 'layout', {...plan, explanation: 'Progress update'});
+      const stayedClosed = !host.querySelector('details').open;
+      body.scrollTop = body.scrollHeight;
+      return { zoom: ${zoom}, expanded, collapsed, stayedClosed, scrollTop: body.scrollTop,
+        arrowVisible: getComputedStyle(host.querySelector('summary'), '::after').content !== 'none',
+        arrowChanges: openArrow !== closedArrow, draft: document.querySelector('textarea').value };
+    })()`));
+  }
+  console.log(JSON.stringify(results, null, 2));
+  for (const row of results) {
+    assert.ok(row.collapsed > row.expanded + 80, 'Collapsing returns space to the conversation');
+    assert.ok(row.stayedClosed && row.arrowVisible && row.arrowChanges);
+    assert.ok(row.scrollTop > 0, 'Conversation still scrolls');
+    assert.equal(row.draft, 'A draft stays here');
+  }
+  win.destroy(); app.quit();
+}).catch(error => { console.error(error); app.exit(1); });

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -6046,9 +6046,10 @@ async function inspectSilentChats(now: number): Promise<{ queued: boolean; spent
       spent.push(conversationId);
       continue;
     }
-    // Queue and Goal share the model's work clock. Unknown models retain the
-    // conservative ten-minute input floor; known normal models use two minutes.
-    if (afterTurn && grant.model !== 'other' && !grant.thinkingFailed && now < grant.evidenceAt + PRO_SILENCE_MS) {
+    // Recovery and queued delivery share the same model clock. Missing selection
+    // is not evidence of a normal model, even when no follow-up input is queued.
+    // Thinking failed keeps its separately proven immediate refresh authority.
+    if ((afterTurn || tabRecoveryWanted(conversationId)) && grant.model !== 'other' && !grant.thinkingFailed && now < grant.evidenceAt + PRO_SILENCE_MS) {
       grant.until = grant.evidenceAt + PRO_SILENCE_MS;
       deferred = true;
       continue;
@@ -6095,7 +6096,7 @@ async function inspectSilentChats(now: number): Promise<{ queued: boolean; spent
     if (queueBrowserRecovery(conversationId, grant.sessionId, `silence:${grant.until}`, 'silence', 0, now)) {
       queued = true;
       logInfo(
-        `bridge: active chat silent for ${grant.model === 'pro' ? 'ten' : 'two'} minutes — asking the browser to reload ${conversationId} once`
+        `bridge: active chat silent for ${grant.model === 'other' ? 'two' : 'ten'} minutes — asking the browser to reload ${conversationId} once`
       );
     }
   }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2867,6 +2867,9 @@ select option::checkmark { order: 1; margin-inline-start: auto; color: var(--ink
 .agent-plan summary::-webkit-details-marker { display: none; }
 .agent-plan summary:focus-visible { outline: 2px solid var(--ink); outline-offset: -3px; border-radius: 7px; }
 .agent-plan-heading { min-height: 38px; padding: 8px 12px; }
+.agent-plan-heading::after { content: ''; width: 7px; height: 7px; flex: none; margin: 0 4px; border-right: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor; transform: rotate(45deg); }
+.agent-plan-shell[open] > .agent-plan-heading::after { transform: rotate(225deg); }
+.agent-plan-heading:hover { background: var(--hover); color: var(--ink); }
 .agent-plan-heading .ico { width: 15px; height: 15px; }
 .agent-plan-title { flex: 1; font-weight: 550; }
 .agent-plan-count { color: var(--faint); font-size: 12px; font-variant-numeric: tabular-nums; }

--- a/test/bridge-done-repair-silence.test.ts
+++ b/test/bridge-done-repair-silence.test.ts
@@ -172,7 +172,10 @@ describe('silence after a confirmed assistant-error repair', () => {
     vi.useFakeTimers();
     try {
       await pair();
-      await events([{ kind: 'turn_start', time: Date.now(), turnId: TURN }]);
+      await events([
+        { kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() },
+        { kind: 'turn_start', time: Date.now(), turnId: TURN }
+      ]);
 
       // Keep the turn alive up to the transport failure, as the live Prime did with connector work.
       await vi.advanceTimersByTimeAsync(60_000);

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -6121,7 +6121,7 @@ describe('unattributed activity recovery', () => {
     vi.useFakeTimers();
     try {
       await pair();
-      await events(OTHER, [openTurn('turn-dead')]);
+      await events(OTHER, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-dead')]);
       await events(OTHER, [endTurn('turn-dead', 'failed')]);
       await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS);
       await sweepStaleSwarm(Date.now());
@@ -6263,7 +6263,7 @@ describe('unattributed activity recovery', () => {
     vi.useFakeTimers();
     try {
       await pair();
-      await events(OTHER, [openTurn('turn-heavy')]);
+      await events(OTHER, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-heavy')]);
       await events(OTHER, [
         {
           kind: 'chat_error',
@@ -6300,7 +6300,7 @@ describe('unattributed activity recovery', () => {
       await pair();
       // An earlier transport failure, repaired and then retired by a turn the chat got through.
       // That spends this chat's browser action and starts its three-minute floor.
-      await events(OTHER, [openTurn('turn-first')]);
+      await events(OTHER, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-first')]);
       await events(OTHER, [
         {
           kind: 'chat_error',
@@ -6317,7 +6317,7 @@ describe('unattributed activity recovery', () => {
       await events(OTHER, [openTurn('turn-through'), endTurn('turn-through', 'completed')]);
       expect(await maintenance()).toBeNull();
 
-      await events(OTHER, [openTurn('turn-broken')]);
+      await events(OTHER, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-broken')]);
       await events(OTHER, [
         {
           kind: 'chat_error',
@@ -6402,7 +6402,7 @@ describe('unattributed activity recovery', () => {
     vi.useFakeTimers();
     try {
       await pair();
-      await events(OTHER, [openTurn('turn-silent-from-the-start')]);
+      await events(OTHER, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-silent-from-the-start')]);
 
       await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS - 1);
       await sweepStaleSwarm(Date.now());
@@ -6432,7 +6432,7 @@ describe('unattributed activity recovery', () => {
       // that spent handout, and this is about arming a fresh episode on time.
       const PUNCTUAL = 'a1a1a1a1-1111-2222-3333-444444444444';
       await pair();
-      await events(PUNCTUAL, [openTurn('turn-silent-punctual')]);
+      await events(PUNCTUAL, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-silent-punctual')]);
 
       await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS - 1);
       expect(await maintenance()).toBeNull();
@@ -6445,7 +6445,7 @@ describe('unattributed activity recovery', () => {
     }
   });
 
-  it('makes a newly started session recoverable for the full two-minute opening window', async () => {
+  it('makes a newly started session recoverable for the full unknown-model opening window', async () => {
     vi.useFakeTimers();
     try {
       await pair();
@@ -6457,7 +6457,7 @@ describe('unattributed activity recovery', () => {
         text: 'start working'
       }]);
 
-      await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS - 1);
+      await vi.advanceTimersByTimeAsync(PRO_SILENCE_MS - 1);
       await sweepStaleSwarm(Date.now());
       expect(await maintenance()).toBeNull();
 
@@ -6520,6 +6520,7 @@ describe('unattributed activity recovery', () => {
     try {
       await pair();
       await events(OTHER, [
+        { kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() },
         {
           kind: 'user_message',
           time: Date.now(),
@@ -6585,7 +6586,7 @@ describe('unattributed activity recovery', () => {
     vi.useFakeTimers();
     try {
       await pair();
-      await events(OTHER, [openTurn('turn-ends-uncertain')]);
+      await events(OTHER, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-ends-uncertain')]);
       await events(OTHER, [
         { kind: 'turn_end', time: Date.now(), turnId: 'turn-ends-uncertain', outcome: 'unknown' }
       ]);
@@ -6618,7 +6619,7 @@ describe('unattributed activity recovery', () => {
     try {
       await pair();
       spawn({ workers: [{ task: 'hold the run open' }], caller: { conversationId: PRIME } });
-      await events(PRIME, [openTurn('turn-prime-silent')]);
+      await events(PRIME, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-prime-silent')]);
       await attributed(PRIME);
 
       await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS - 1);
@@ -6648,7 +6649,7 @@ describe('unattributed activity recovery', () => {
     vi.useFakeTimers();
     try {
       await pair();
-      await events(OTHER, [openTurn('turn-loop-silent')]);
+      await events(OTHER, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-loop-silent')]);
       await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS);
       await sweepStaleSwarm(Date.now());
       expect(await maintenance()).toMatchObject({ conversationId: OTHER, reason: 'silence' });
@@ -6986,6 +6987,51 @@ describe('unattributed activity recovery', () => {
     } finally { await saveConfig(previous); vi.useRealTimers(); }
   });
 
+  it.each(['unknown', 'normal'] as const)('uses the %s model recovery clock without queued input', async model => {
+    const chat = model === 'unknown' ? 'a7777777-1111-4111-8111-000000000001' : 'a7777777-1111-4111-8111-000000000002';
+    vi.useFakeTimers();
+    try {
+      await pair();
+      expect(getConfig().multiAgent.recoverAgentTabs).toBe(true);
+      await events(chat, [
+        ...(model === 'normal' ? [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }] : []),
+        openTurn(`no-queue-${model}`)
+      ]);
+      const deadline = model === 'unknown' ? PRO_SILENCE_MS : CHAT_SILENCE_MS;
+      await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS - 1);
+      expect(await maintenance()).toBeNull();
+      if (model === 'unknown') {
+        await vi.advanceTimersByTimeAsync(deadline - CHAT_SILENCE_MS);
+        expect(await maintenance()).toBeNull();
+      }
+      await vi.advanceTimersByTimeAsync(1);
+      await sweepStaleSwarm(Date.now());
+      expect(await maintenance()).toMatchObject({ conversationId: chat, reason: 'silence' });
+      expect(goalPendingReplyFor(chat)).toBeNull();
+    } finally { vi.useRealTimers(); }
+  });
+
+  it('retires unknown activity after five minutes when recovery is off and no input is queued', async () => {
+    const previous = getConfig();
+    const chat = 'a7777777-1111-4111-8111-000000000003';
+    await saveConfig({ ...previous, goal: { ...previous.goal, enabled: false },
+      multiAgent: { ...previous.multiAgent, recoverAgentTabs: false } });
+    vi.useFakeTimers();
+    try {
+      await pair();
+      await events(chat, [openTurn('unknown-recovery-off')]);
+      await vi.advanceTimersByTimeAsync(PRO_SILENCE_RETIRE_MS);
+      await sweepStaleSwarm(Date.now());
+      expect((await request('GET', `/activity?conversationId=${chat}`)).body.activeTurnId).toBeNull();
+      expect(await maintenance()).toBeNull();
+      // Enabling recovery later must not resurrect the already-retired grant.
+      await saveConfig({ ...getConfig(), multiAgent: { ...getConfig().multiAgent, recoverAgentTabs: true } });
+      await vi.advanceTimersByTimeAsync(PRO_SILENCE_MS - PRO_SILENCE_RETIRE_MS);
+      await sweepStaleSwarm(Date.now());
+      expect(await maintenance()).toBeNull();
+    } finally { await saveConfig(previous); vi.useRealTimers(); }
+  });
+
   for (const selection of ['missing', 'stale', 'after-start']) it(`does not synthesize a silence Goal from ${selection} model evidence`, async () => {
     // Persisted model observations survive the bridge reset: use a fresh conversation.
     const uncertainChat = `a4444444-1111-4111-8111-00000000000${["missing", "stale", "after-start"].indexOf(selection)}`;
@@ -6999,7 +7045,7 @@ describe('unattributed activity recovery', () => {
       await vi.advanceTimersByTimeAsync(1_000);
       await events(uncertainChat, [openTurn('uncertain-' + selection)]);
       if (selection === 'after-start') await events(uncertainChat, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() + 1 }]);
-      await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS);
+      await vi.advanceTimersByTimeAsync(PRO_SILENCE_MS);
       await sweepStaleSwarm(Date.now());
       const reload = await maintenance();
       expect(reload).toMatchObject({ reason: 'silence' });
@@ -7041,7 +7087,7 @@ describe('unattributed activity recovery', () => {
     vi.useFakeTimers();
     try {
       await pair();
-      await events('a6666666-1111-4111-8111-000000000006', [openTurn('turn-loop-slow')]);
+      await events('a6666666-1111-4111-8111-000000000006', [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-loop-slow')]);
       await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS);
       await sweepStaleSwarm(Date.now());
       const handout = await maintenance();
@@ -7468,7 +7514,7 @@ describe('unattributed activity recovery', () => {
     vi.useFakeTimers();
     try {
       await pair();
-      await events(OTHER, [openTurn('turn-solo-silent')]);
+      await events(OTHER, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-solo-silent')]);
       await attributed(OTHER);
 
       await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS);
@@ -7494,7 +7540,7 @@ describe('unattributed activity recovery', () => {
     vi.useFakeTimers();
     try {
       await pair();
-      await events(OTHER, [openTurn('turn-closed-while-tools-run')]);
+      await events(OTHER, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-closed-while-tools-run')]);
       await request('POST', '/closed', { body: { conversationId: OTHER } });
 
       // The model keeps running server-side after Chrome has gone. Exact attribution is the
@@ -7528,7 +7574,7 @@ describe('unattributed activity recovery', () => {
     vi.useFakeTimers();
     try {
       await pair();
-      await events(OTHER, [openTurn('turn-reload-episode-one')]);
+      await events(OTHER, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-reload-episode-one')]);
       await attributed(OTHER);
 
       await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS);
@@ -7539,8 +7585,9 @@ describe('unattributed activity recovery', () => {
       await sweepStaleSwarm(Date.now());
 
       // A confirmed reload alone is spent. A new exact call is the sole fact that starts episode 2.
+      // Its replacement page has supplied no new model proof, so recovery is conservative.
       await attributed(OTHER);
-      await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS - 1);
+      await vi.advanceTimersByTimeAsync(PRO_SILENCE_MS - 1);
       await sweepStaleSwarm(Date.now());
       expect(await maintenance()).toBeNull();
 
@@ -7556,7 +7603,7 @@ describe('unattributed activity recovery', () => {
     vi.useFakeTimers();
     try {
       await pair();
-      await events(OTHER, [openTurn('turn-reload-interim-one')]);
+      await events(OTHER, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-reload-interim-one')]);
       await attributed(OTHER);
       await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS);
       await sweepStaleSwarm(Date.now());
@@ -7574,7 +7621,8 @@ describe('unattributed activity recovery', () => {
         final: false,
         activeNow: true
       }]);
-      await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS);
+      // The old grant was spent; this unowned interim carries no fresh model selection.
+      await vi.advanceTimersByTimeAsync(PRO_SILENCE_MS);
       await sweepStaleSwarm(Date.now());
       expect(chatOf(await maintenance())).toBe(OTHER);
     } finally {
@@ -7664,7 +7712,7 @@ describe('unattributed activity recovery', () => {
     vi.useFakeTimers();
     try {
       await pair();
-      await events(OTHER, [openTurn('turn-lost-on-reload')]);
+      await events(OTHER, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-lost-on-reload')]);
       await events(OTHER, [endTurn('turn-lost-on-reload', 'unknown')]);
       await attributed(OTHER);
 
@@ -7722,7 +7770,7 @@ describe('unattributed activity recovery', () => {
       await request('POST', '/commands/ack', {
         body: { id: bootstrap.id, status: 'sent', conversationId: WORKER, agent: 'worker-1' }
       });
-      await events(WORKER, [openTurn('turn-worker-pruned')]);
+      await events(WORKER, [{ kind: 'model_selection', model: 'GPT-5.6 Sol', reasoningEffort: 'high', time: Date.now() }, openTurn('turn-worker-pruned')]);
       await attributed(WORKER);
 
       await vi.advanceTimersByTimeAsync(CHAT_SILENCE_MS);

--- a/test/content-script.test.ts
+++ b/test/content-script.test.ts
@@ -621,7 +621,7 @@ describe('desktop input delivery and helper ownership', () => {
     expect(live.sent.filter(message => message.ack)).toHaveLength(change === 'accepted' ? 1 : 0);
     if (change === 'draft') expect(composerText(live.document)).toBe('My own draft');
   });
-  it('retains a reused-document send boundary when canonical Fiber text arrives before activity identity', async () => {
+  it.each([false, true])('retains a reused-document send boundary when canonical Fiber text arrives before activity identity (promoted submit: %s)', async promotedSubmit => {
     const submitted = 'Keep [literal] #tags in the receipt.';
     const escaped = String.raw`Keep \[literal\] \#tags in the receipt\.`;
     const run = async (canonical: string, acknowledge = true, invalidate?: 'epoch' | 'receipt'): Promise<number> => {
@@ -639,6 +639,11 @@ describe('desktop input delivery and helper ownership', () => {
       live.hook.observe();
       let user!: HTMLElement;
       live.document.querySelector('[data-testid="send-button"]')!.addEventListener('click', () => {
+        if (promotedSubmit) {
+          live!.dom.reconfigure({ url: `https://chatgpt.com/c/${chatB}` });
+          live!.hook.observe();
+          live!.document.dispatchEvent(new live!.window.Event('submit', { bubbles: true }));
+        }
         user = userTurn(live!.document, 'gated-spa-user', submitted, { sent: false });
         startGenerating(live!.document, { send: false });
         live!.dom.reconfigure({ url: `https://chatgpt.com/c/${chatB}` });
@@ -7318,7 +7323,7 @@ describe('a content script reloaded into a turn already in flight', () => {
    * reload while the same request went on calling tools. A section above the question is not
    * this turn's; with none after it, the turn stays open until one appears and ends.
    */
-  it('never binds an adopted turn to an answer that sits above the question it is answering', async () => {
+  it.each(['static', 'remounted-final', 'remounted-interim'])('never binds an adopted turn to an answer above its question (%s)', async variant => {
     live = await harness(
       'https://chatgpt.com/c/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
       { activity: () => activity({ activeTurnId: 'g-old-run-0-4' }) },
@@ -7338,12 +7343,17 @@ describe('a content script reloaded into a turn already in flight', () => {
     await settle();
 
     // The page model names the previous answer terminal. It is the previous answer.
-    const settled = live.document.querySelector('[data-turn-id="turn-old"]') as HTMLElement;
+    let settled = live.document.querySelector('[data-turn-id="turn-old"]') as HTMLElement;
+    if (variant !== 'static') {
+      const replacement = settled.cloneNode(true) as HTMLElement;
+      settled.replaceWith(replacement); settled = replacement;
+      live.hook.observe(); await settle();
+    }
     await bindFiberTurns([{
       section: settled,
       turn: {
         turnId: 'turn-old',
-        endMessageId: 'reload-prev-final',
+        endMessageId: variant === 'remounted-interim' ? undefined : 'reload-prev-final',
         messages: [{
           messageId: 'reload-prev-final', rawMessageId: 'reload-prev-final', stable: true, order: 1,
           rawText: 'The recorder is fixed.', renderedHtml: '<p>The recorder is fixed.</p>'
@@ -7374,7 +7384,7 @@ describe('a content script reloaded into a turn already in flight', () => {
     live.hook.observe();
     await settle();
     await bindFiberTurns([
-      { section: settled, turn: { turnId: 'turn-old', endMessageId: 'reload-prev-final', messages: [{
+      { section: settled, turn: { turnId: 'turn-old', endMessageId: variant === 'remounted-interim' ? undefined : 'reload-prev-final', messages: [{
         messageId: 'reload-prev-final', rawMessageId: 'reload-prev-final', stable: true, order: 1,
         rawText: 'The recorder is fixed.', renderedHtml: '<p>The recorder is fixed.</p>'
       }] } },


### PR DESCRIPTION
Reload hydration could attach an active turn to a remounted historical answer, while native submission during a fresh-chat navigation could lose the exact accepted turn-start boundary. This keeps the accepted receipt and current question authoritative, adapting the focused reproductions and fixes from @ventianima-lab in #185.

The integration also fixes unknown-model silence recovery when no input is queued (#172): recovery waits ten minutes, with known normal models retaining two minutes, Thinking-failed retaining immediate refresh, and recovery-disabled retirement preserved. The existing native plan disclosure gains a visible chevron (#191). The README/hero adapt @pop15106's #192 correction and link to current OpenAI usage documentation.

Contributor credit is retained in CONTRIBUTORS.md and GitHub-linked coauthor trailers, including previously incorporated stream/reuse/pin work. Broad controller, browser-tool, renderer and native-platform proposals remain separate where production wiring, exact ownership or runtime proof is incomplete.

Validation: full verify passed 4,164 tests plus 2 isolated shutdown tests (40 skipped), TypeScript, notices/native-source inventory and public-history privacy. Production build passed. Real Electron plan layout passed at 100% and 150% zoom, including retained collapse state, conversation scroll and draft preservation; the updated SVG was rendered and visually checked. The new #185 cases failed before repair; all 564 content-script and 338 bridge tests passed afterward. No installed-runtime or live-provider verification is claimed for these fixes. No release, version bump or updater change is included.

Refs #172, #185, #191, #192.
